### PR TITLE
[#86] feat: 텍스트 반응 애니메이션 구현

### DIFF
--- a/lib/common/routers/route_provider.dart
+++ b/lib/common/routers/route_provider.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:wehavit/common/common.dart';
-import 'package:wehavit/features/effects/balloon_sample_page.dart';
+import 'package:wehavit/features/effects/animation_sample_page.dart';
 import 'package:wehavit/features/features.dart';
 import 'package:wehavit/features/live_writing/presentation/screens/live_writing_page.dart';
 import 'package:wehavit/features/my_page/presentation/screens/add_resolution_screen.dart';

--- a/lib/features/effects/animation_sample_page.dart
+++ b/lib/features/effects/animation_sample_page.dart
@@ -94,7 +94,12 @@ class _BalloonPageState extends ConsumerState<AnimationSampleView> {
                 child: Stack(
                   alignment: Alignment.bottomLeft,
                   children: [
-                    TextBubbleFrameWidget(),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        TextBubbleFrameWidget(),
+                      ],
+                    ),
                   ],
                 ),
               ),

--- a/lib/features/effects/animation_sample_page.dart
+++ b/lib/features/effects/animation_sample_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/features/effects/balloon_animation/balloon_manager.dart';
 import 'package:wehavit/features/effects/emoji_firework_animation/emoji_firework_manager.dart';
+import 'package:wehavit/features/effects/text_animation/text_bubble_manager.dart';
 import 'package:wehavit/features/effects/text_animation/text_bubble_widget.dart';
 
 class AnimationSampleView extends ConsumerStatefulWidget {
@@ -13,6 +14,8 @@ class AnimationSampleView extends ConsumerStatefulWidget {
 class _BalloonPageState extends ConsumerState<AnimationSampleView> {
   late Map<Key, BalloonWidget> _balloonWidgets;
   late BalloonManager _balloonManager;
+  late Map<Key, TextBubbleFrameWidget> _textBubbleWidgets;
+  late TextBubbleAnimationManager _textBubbleAnimationManager;
 
   EmojiFireWorkManager emojiFireWork = EmojiFireWorkManager(
     emojiAsset: const AssetImage('assets/images/emoji_3d/heart_suit_3d.png'),
@@ -29,7 +32,12 @@ class _BalloonPageState extends ConsumerState<AnimationSampleView> {
 
     _balloonWidgets = ref.watch(balloonManagerProvider);
     _balloonManager = ref.read(balloonManagerProvider.notifier);
+
     _balloonManager.onTapCallbackWithTappedPositionOffset = callBackFunction;
+
+    _textBubbleWidgets = ref.watch(textBubbleAnimationManagerProvider);
+    _textBubbleAnimationManager =
+        ref.read(textBubbleAnimationManagerProvider.notifier);
   }
 
   @override
@@ -37,6 +45,7 @@ class _BalloonPageState extends ConsumerState<AnimationSampleView> {
     _balloonWidgets = ref.watch(balloonManagerProvider);
 
     return Scaffold(
+      // extendBodyBehindAppBar: true,
       appBar: AppBar(title: const Text('Balloon and Emoji Firework')),
       body: Container(
         constraints: const BoxConstraints.expand(),
@@ -83,26 +92,19 @@ class _BalloonPageState extends ConsumerState<AnimationSampleView> {
               bottom: 0,
               child: ElevatedButton(
                 onPressed: () {
-                  setState(() {});
+                  setState(() {
+                    _textBubbleAnimationManager.addTextBubble(
+                      message: 'hello world!',
+                      imageUrl:
+                          'https://avatars.githubusercontent.com/u/39216546?v=4',
+                    );
+                  });
                 },
-                child: Text(_balloonWidgets.length.toString()),
+                child: const Text("showTextBubble"),
               ),
             ),
-            SafeArea(
-              child: Container(
-                constraints: BoxConstraints.expand(),
-                child: Stack(
-                  alignment: Alignment.bottomLeft,
-                  children: [
-                    Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        TextBubbleFrameWidget(),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
+            Stack(
+              children: _textBubbleWidgets.values.toList(),
             ),
           ],
         ),

--- a/lib/features/effects/animation_sample_page.dart
+++ b/lib/features/effects/animation_sample_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/features/effects/balloon_animation/balloon_manager.dart';
 import 'package:wehavit/features/effects/emoji_firework_animation/emoji_firework_manager.dart';
+import 'package:wehavit/features/effects/text_animation/text_bubble_widget.dart';
 
 class AnimationSampleView extends ConsumerStatefulWidget {
   const AnimationSampleView({super.key});
@@ -85,6 +86,17 @@ class _BalloonPageState extends ConsumerState<AnimationSampleView> {
                   setState(() {});
                 },
                 child: Text(_balloonWidgets.length.toString()),
+              ),
+            ),
+            SafeArea(
+              child: Container(
+                constraints: BoxConstraints.expand(),
+                child: Stack(
+                  alignment: Alignment.bottomLeft,
+                  children: [
+                    TextBubbleFrameWidget(),
+                  ],
+                ),
               ),
             ),
           ],

--- a/lib/features/effects/text_animation/text_bubble_manager.dart
+++ b/lib/features/effects/text_animation/text_bubble_manager.dart
@@ -1,1 +1,48 @@
-class TextBubbleAnimationManager {}
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/features/effects/text_animation/text_bubble_widget.dart';
+
+final textBubbleAnimationManagerProvider = StateNotifierProvider<
+    TextBubbleAnimationManager, Map<Key, TextBubbleFrameWidget>>(
+  (ref) {
+    return TextBubbleAnimationManager();
+  },
+);
+
+/// 간단한 텍스트 메시지를 보여주는 위젯을 화면에 그려줍니다.
+/// - message 에 받은 메시지를 담기
+/// - imageUrl에 친구의 프로필사진 URL을 담기
+///
+/// ## 사용 방법
+/// 1. `_textBubbleWidgets = ref.watch(textBubbleAnimationManagerProvider);`
+/// 을 통해 풍선 정보들을 받아와서
+/// 2. `Stack(children: _textBubbleWidgets.values.toList())` list로 변환 후 Stack
+/// 에 담아서 위젯을 그려주기
+/// 3. `_textBubbleAnimationManager = ref.read(textBubbleAnimationManagerProvider.notifier)`를
+/// 통해 가져온 textBubbleAnimationManager 대해
+///  `_textBubbleAnimationManager.addTextBubble(...)` 함수를 호출해 위젯을 추가해주기
+class TextBubbleAnimationManager
+    extends StateNotifier<Map<Key, TextBubbleFrameWidget>> {
+  TextBubbleAnimationManager() : super({});
+
+  List<TextBubbleWidget> queue = [];
+
+  void addTextBubble({
+    required String message,
+    required String imageUrl,
+  }) {
+    final widgetKey = UniqueKey();
+    state.addEntries(
+      {
+        widgetKey: TextBubbleFrameWidget(
+          key: widgetKey,
+          killWidgetCallback: (Key key) {
+            state.remove(key);
+          },
+          message: message,
+          userImageUrl: imageUrl,
+        ),
+      }.entries,
+    );
+  }
+}

--- a/lib/features/effects/text_animation/text_bubble_manager.dart
+++ b/lib/features/effects/text_animation/text_bubble_manager.dart
@@ -1,0 +1,1 @@
+class TextBubbleAnimationManager {}

--- a/lib/features/effects/text_animation/text_bubble_widget.dart
+++ b/lib/features/effects/text_animation/text_bubble_widget.dart
@@ -23,7 +23,7 @@ class TextBubbleFrameWidget extends StatelessWidget {
   }
 }
 
-class TextBubbleWidget extends StatelessWidget {
+class TextBubbleWidget extends StatefulWidget {
   const TextBubbleWidget({
     super.key,
     required this.message,
@@ -34,6 +34,58 @@ class TextBubbleWidget extends StatelessWidget {
   final String userImageUrl;
 
   @override
+  State<TextBubbleWidget> createState() => _TextBubbleWidgetState();
+}
+
+class _TextBubbleWidgetState extends State<TextBubbleWidget>
+    with TickerProviderStateMixin {
+  late final AnimationController _lifetimeAnimationController;
+  late final AnimationController _avatarAnimationController;
+  late final AnimationController _textBubbleController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _lifetimeAnimationController = AnimationController(
+      vsync: this,
+      duration: Duration(seconds: 5),
+    );
+    _lifetimeAnimationController.addListener(() {
+      setState(() {});
+    });
+    _avatarAnimationController = AnimationController(
+      vsync: this,
+      duration: Duration(seconds: 1),
+    );
+    _avatarAnimationController.addListener(() {
+      setState(() {});
+    });
+    _textBubbleController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 500),
+    );
+    _textBubbleController.addListener(() {
+      setState(() {});
+    });
+
+    _avatarAnimationController.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        _textBubbleController.forward();
+      }
+    });
+
+    _lifetimeAnimationController.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        dispose();
+      }
+    });
+
+    _lifetimeAnimationController.forward();
+    _avatarAnimationController.forward();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       children: [
@@ -42,19 +94,22 @@ class TextBubbleWidget extends StatelessWidget {
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.only(bottom: 16.0),
-                child: Container(
-                  decoration: const BoxDecoration(
-                      color: Colors.amber,
-                      borderRadius: BorderRadius.only(
-                        topLeft: Radius.circular(16.0),
-                        topRight: Radius.circular(16.0),
-                        bottomLeft: Radius.circular(16.0),
-                      )),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Text(
-                      message,
-                      style: TextStyle(fontSize: 16.0),
+                child: Opacity(
+                  opacity: _textBubbleController.value,
+                  child: Container(
+                    decoration: const BoxDecoration(
+                        color: Colors.amber,
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(16.0),
+                          topRight: Radius.circular(16.0),
+                          bottomLeft: Radius.circular(16.0),
+                        )),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: Text(
+                        widget.message,
+                        style: TextStyle(fontSize: 16.0),
+                      ),
                     ),
                   ),
                 ),
@@ -70,12 +125,15 @@ class TextBubbleWidget extends StatelessWidget {
             Expanded(
               child: Container(),
             ),
-            Padding(
-              padding: const EdgeInsets.only(left: 8.0),
-              child: CircleAvatar(
-                radius: 30,
-                backgroundColor: Colors.grey,
-                foregroundImage: NetworkImage(userImageUrl),
+            Opacity(
+              opacity: _avatarAnimationController.value,
+              child: Padding(
+                padding: const EdgeInsets.only(left: 8.0),
+                child: CircleAvatar(
+                  radius: 30,
+                  backgroundColor: Colors.grey,
+                  foregroundImage: NetworkImage(widget.userImageUrl),
+                ),
               ),
             ),
           ],

--- a/lib/features/effects/text_animation/text_bubble_widget.dart
+++ b/lib/features/effects/text_animation/text_bubble_widget.dart
@@ -18,7 +18,7 @@ class TextBubbleFrameWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      constraints: BoxConstraints.expand(),
+      constraints: const BoxConstraints.expand(),
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
@@ -77,28 +77,28 @@ class _TextBubbleWidgetState extends State<TextBubbleWidget>
 
     _lifetimeAnimationController = AnimationController(
       vsync: this,
-      duration: Duration(seconds: 8),
+      duration: const Duration(seconds: 8),
     );
     _lifetimeAnimationController.addListener(() {
       setState(() {});
     });
     _avatarAnimationController = AnimationController(
       vsync: this,
-      duration: Duration(seconds: 1),
+      duration: const Duration(seconds: 1),
     );
     _avatarAnimationController.addListener(() {
       setState(() {});
     });
     _textBubbleAnimationController = AnimationController(
       vsync: this,
-      duration: Duration(milliseconds: 500),
+      duration: const Duration(milliseconds: 500),
     );
     _textBubbleAnimationController.addListener(() {
       setState(() {});
     });
     _disappearAnimationController = AnimationController(
       vsync: this,
-      duration: Duration(seconds: 1),
+      duration: const Duration(seconds: 1),
     );
     _disappearAnimationController.addListener(() {
       setState(() {});
@@ -153,7 +153,7 @@ class _TextBubbleWidgetState extends State<TextBubbleWidget>
   @override
   Widget build(BuildContext context) {
     return Container(
-      constraints: BoxConstraints.expand(height: 500),
+      constraints: const BoxConstraints.expand(height: 500),
       height: 500,
       child: Stack(
         alignment: Alignment.bottomCenter,
@@ -191,14 +191,14 @@ class _TextBubbleWidgetState extends State<TextBubbleWidget>
                               padding: const EdgeInsets.all(16.0),
                               child: Text(
                                 widget.message,
-                                style: TextStyle(fontSize: 16.0),
+                                style: const TextStyle(fontSize: 16.0),
                               ),
                             ),
                           ),
                         ),
                       ),
                     ),
-                    SizedBox(
+                    const SizedBox(
                       width: 40,
                     ),
                   ],

--- a/lib/features/effects/text_animation/text_bubble_widget.dart
+++ b/lib/features/effects/text_animation/text_bubble_widget.dart
@@ -1,20 +1,33 @@
 import 'package:flutter/material.dart';
 
 class TextBubbleFrameWidget extends StatelessWidget {
-  const TextBubbleFrameWidget({super.key});
+  const TextBubbleFrameWidget({
+    super.key,
+    required this.killWidgetCallback,
+    required this.message,
+    required this.userImageUrl,
+  });
+  final Function killWidgetCallback;
+  final String message;
+  final String userImageUrl;
+
+  void killWidget() {
+    killWidgetCallback(super.key);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Container(
+      constraints: BoxConstraints.expand(),
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             TextBubbleWidget(
-              message: '오늘도 화이팅 화이팅!!',
-              userImageUrl:
-                  'https://i.namu.wiki/i/TrdI_AZmxU2LZKqbM03iBQ42-hh9iSA3Hre27jXgLXwbQxKFV6OJ0hB2qksroJwTUvBU6yogPa3QbfCRKtWHqA.webp',
+              message: message,
+              userImageUrl: userImageUrl,
+              killWidgetCallback: killWidget,
             ),
           ],
         ),
@@ -28,10 +41,12 @@ class TextBubbleWidget extends StatefulWidget {
     super.key,
     required this.message,
     required this.userImageUrl,
+    required this.killWidgetCallback,
   });
 
   final String message;
   final String userImageUrl;
+  final Function killWidgetCallback;
 
   @override
   State<TextBubbleWidget> createState() => _TextBubbleWidgetState();
@@ -41,15 +56,28 @@ class _TextBubbleWidgetState extends State<TextBubbleWidget>
     with TickerProviderStateMixin {
   late final AnimationController _lifetimeAnimationController;
   late final AnimationController _avatarAnimationController;
-  late final AnimationController _textBubbleController;
+  late final AnimationController _textBubbleAnimationController;
+  late final AnimationController _disappearAnimationController;
+
+  late final Animation _textBubbleAnimation;
+  late final Animation _disappearAnimation;
+  late final double _width;
+
+  late final Function killWidgetCallback;
+
+  void killWidget() {
+    killWidgetCallback();
+  }
 
   @override
   void initState() {
     super.initState();
 
+    killWidgetCallback = widget.killWidgetCallback;
+
     _lifetimeAnimationController = AnimationController(
       vsync: this,
-      duration: Duration(seconds: 5),
+      duration: Duration(seconds: 8),
     );
     _lifetimeAnimationController.addListener(() {
       setState(() {});
@@ -61,84 +89,157 @@ class _TextBubbleWidgetState extends State<TextBubbleWidget>
     _avatarAnimationController.addListener(() {
       setState(() {});
     });
-    _textBubbleController = AnimationController(
+    _textBubbleAnimationController = AnimationController(
       vsync: this,
       duration: Duration(milliseconds: 500),
     );
-    _textBubbleController.addListener(() {
+    _textBubbleAnimationController.addListener(() {
+      setState(() {});
+    });
+    _disappearAnimationController = AnimationController(
+      vsync: this,
+      duration: Duration(seconds: 1),
+    );
+    _disappearAnimationController.addListener(() {
       setState(() {});
     });
 
+    _textBubbleAnimation = Tween<double>(begin: 0, end: 400).animate(
+      CurvedAnimation(
+        parent: _textBubbleAnimationController,
+        curve: Curves.easeOutCirc,
+      ),
+    );
+    _disappearAnimation = Tween<double>(begin: 0, end: 400).animate(
+      CurvedAnimation(
+        parent: _disappearAnimationController,
+        curve: Curves.easeInCirc,
+      ),
+    );
+
     _avatarAnimationController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
-        _textBubbleController.forward();
+        _textBubbleAnimationController.forward();
       }
     });
 
     _lifetimeAnimationController.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
-        dispose();
+        _disappearAnimationController.forward();
       }
     });
 
-    _lifetimeAnimationController.forward();
+    _disappearAnimationController.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        _avatarAnimationController.dispose();
+        _disappearAnimationController.dispose();
+        _lifetimeAnimationController.dispose();
+        _textBubbleAnimationController.dispose();
+
+        killWidget();
+      }
+    });
+
     _avatarAnimationController.forward();
+    _lifetimeAnimationController.forward();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _width = MediaQuery.of(context).size.width;
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 16.0),
-                child: Opacity(
-                  opacity: _textBubbleController.value,
-                  child: Container(
-                    decoration: const BoxDecoration(
-                        color: Colors.amber,
-                        borderRadius: BorderRadius.only(
-                          topLeft: Radius.circular(16.0),
-                          topRight: Radius.circular(16.0),
-                          bottomLeft: Radius.circular(16.0),
-                        )),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Text(
-                        widget.message,
-                        style: TextStyle(fontSize: 16.0),
+    return Container(
+      constraints: BoxConstraints.expand(height: 500),
+      height: 500,
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          Positioned(
+            bottom:
+                _textBubbleAnimation.value - 300 + _disappearAnimation.value,
+            child: GestureDetector(
+              onTapUp: (details) {
+                _lifetimeAnimationController.stop();
+                _disappearAnimationController.forward();
+              },
+              child: Container(
+                alignment: Alignment.bottomCenter,
+                height: 500,
+                width: _width - 16,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: 16.0),
+                        child: Opacity(
+                          opacity: _textBubbleAnimationController.value -
+                              _disappearAnimationController.value,
+                          child: Container(
+                            decoration: const BoxDecoration(
+                              color: Colors.amber,
+                              borderRadius: BorderRadius.only(
+                                topLeft: Radius.circular(16.0),
+                                topRight: Radius.circular(16.0),
+                                bottomLeft: Radius.circular(16.0),
+                              ),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.all(16.0),
+                              child: Text(
+                                widget.message,
+                                style: TextStyle(fontSize: 16.0),
+                              ),
+                            ),
+                          ),
+                        ),
                       ),
                     ),
+                    SizedBox(
+                      width: 40,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: _avatarAnimationController.value * 150 + (-100),
+            child: Container(
+              alignment: Alignment.bottomCenter,
+              height: 500,
+              width: _width - 16,
+              child: Column(
+                children: [
+                  Expanded(child: Container()),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Container(),
+                      ),
+                      Opacity(
+                        opacity: _avatarAnimationController.value -
+                            _disappearAnimationController.value,
+                        child: Padding(
+                          padding: const EdgeInsets.only(left: 8.0),
+                          child: CircleAvatar(
+                            radius: 30,
+                            backgroundColor: Colors.grey,
+                            foregroundImage: NetworkImage(widget.userImageUrl),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                ),
+                ],
               ),
             ),
-            SizedBox(
-              width: 40,
-            ),
-          ],
-        ),
-        Row(
-          children: [
-            Expanded(
-              child: Container(),
-            ),
-            Opacity(
-              opacity: _avatarAnimationController.value,
-              child: Padding(
-                padding: const EdgeInsets.only(left: 8.0),
-                child: CircleAvatar(
-                  radius: 30,
-                  backgroundColor: Colors.grey,
-                  foregroundImage: NetworkImage(widget.userImageUrl),
-                ),
-              ),
-            ),
-          ],
-        )
-      ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/effects/text_animation/text_bubble_widget.dart
+++ b/lib/features/effects/text_animation/text_bubble_widget.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+class TextBubbleFrameWidget extends StatelessWidget {
+  const TextBubbleFrameWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextBubbleWidget(
+              message: '오늘도 화이팅 화이팅!!',
+              userImageUrl:
+                  'https://i.namu.wiki/i/TrdI_AZmxU2LZKqbM03iBQ42-hh9iSA3Hre27jXgLXwbQxKFV6OJ0hB2qksroJwTUvBU6yogPa3QbfCRKtWHqA.webp',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TextBubbleWidget extends StatelessWidget {
+  const TextBubbleWidget({
+    super.key,
+    required this.message,
+    required this.userImageUrl,
+  });
+
+  final String message;
+  final String userImageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 16.0),
+                child: Container(
+                  decoration: const BoxDecoration(
+                      color: Colors.amber,
+                      borderRadius: BorderRadius.only(
+                        topLeft: Radius.circular(16.0),
+                        topRight: Radius.circular(16.0),
+                        bottomLeft: Radius.circular(16.0),
+                      )),
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      message,
+                      style: TextStyle(fontSize: 16.0),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(
+              width: 40,
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: Container(),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 8.0),
+              child: CircleAvatar(
+                radius: 30,
+                backgroundColor: Colors.grey,
+                foregroundImage: NetworkImage(userImageUrl),
+              ),
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 작업 내용 설명
1. 텍스트 반응 애니메이션 구상 (현재 디자인 없음)
2. 텍스트 반응 애니메이션 구현
3. 사용 방법 정리

## 관련 이슈
- #77 
- #86

## 작업의 결과물
시간이 지나면 사라지거나, 말풍선을 탭하면 즉시 사라지는 애니메이션이 나오도록 구현해두었음.

![Simulator Screen Recording - iPhone 13 Pro - 2023-11-16 at 01 54 32](https://github.com/cau-bootcamp/wehavit/assets/39216546/5ed24228-2a01-461d-8461-ac44398a1d5a)

## 작업의 비고사항 및 한계점
- 이전에 PR 올린 Photo Animation과 유사한 형식으로 작성하였음
- 디자인이 나오면 요 기능은 대폭 갈아엎게 될 수 있기 때문에, 간단하게 반응을 볼 수 있는 기능만 구현해두었음.

## To Reviewers
- 기능 머지 화이팅!

Close 
#77 #86