### PR TITLE
[#98] HOTFIX: 이름이 수정된 파일에 대한 ref 제거

### DIFF
--- a/lib/features/effects/effects.dart
+++ b/lib/features/effects/effects.dart
@@ -1,3 +1,2 @@
 export 'balloon_animation/balloon_manager.dart';
-export 'balloon_sample_page.dart';
 export 'emoji_firework_animation/emoji_firework_manager.dart';


### PR DESCRIPTION
## 설명
develop과 feat/#86의 conflict 해결 과정에서
이름이 변경된 파일 (balloon_sample_view.dart → animation_sample_view.dart)에 대한 reference가 제대로 수정되지 않아, import 코드가 남아있는 문제가 발생하였음.


## FIX 방법
- export 코드 한 줄 제거