### PR TITLE
[#119] feat: 마이페이지 뷰 UI에 그래프 데이터 연결

### DIFF
--- a/lib/common/constants/firebase_field_name.dart
+++ b/lib/common/constants/firebase_field_name.dart
@@ -47,3 +47,17 @@ class FirebaseLiveConfirmPostFieldName {
   static const message = 'message';
   static const userId = 'userId';
 }
+
+@immutable
+class FirebaseConfirmPostFieldName {
+  static const content = 'content';
+  static const createdAt = 'createdAt';
+  static const fan = 'fan';
+  static const imageUrl = 'imageUrl';
+  static const owner = 'owner';
+  static const recentStrike = 'recentStrike';
+  static const resolutionGoalStatement = 'resolutionGoalStatement';
+  static const resolutionId = 'resolutionId';
+  static const title = 'title';
+  static const updatedAt = 'updatedAt';
+}

--- a/lib/features/my_page/data/datasources/resolution_datasource.dart
+++ b/lib/features/my_page/data/datasources/resolution_datasource.dart
@@ -1,9 +1,12 @@
 import 'package:wehavit/common/utils/custom_types.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/data/entities/resolution_entity.dart';
 
 abstract class ResolutionDatasource {
   EitherFuture<List<ResolutionEntity>> getActiveResolutionEntityList();
   EitherFuture<List<ResolutionEntity>> getAllResolutionEntityList();
   EitherFuture<bool> uploadResolutionEntity(ResolutionEntity entity);
-  // EitherFuture<List<ConfirmPostModel>> get
+  EitherFuture<List<ConfirmPostModel>> getConfirmPostListForResolutionId({
+    required String resolutionId,
+  });
 }

--- a/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
+++ b/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
@@ -4,6 +4,7 @@ import 'package:wehavit/common/constants/firebase_field_name.dart';
 import 'package:wehavit/common/errors/failure.dart';
 import 'package:wehavit/common/utils/custom_types.dart';
 import 'package:wehavit/common/utils/firebase_collection_name.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/data/datasources/resolution_datasource.dart';
 import 'package:wehavit/features/my_page/data/entities/resolution_entity.dart';
 
@@ -23,12 +24,19 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
     try {
       final fetchResult = await FirebaseFirestore.instance
           .collection(FirebaseCollectionName.resolutions)
-          .where(FirebaseResolutionFieldName.resolutionIsActive,
-              isEqualTo: true)
+          .where(
+            FirebaseResolutionFieldName.resolutionIsActive,
+            isEqualTo: true,
+          )
           .get();
 
       resolutionEntityList = fetchResult.docs
-          .map((doc) => ResolutionEntity.fromFirebaseDocument(doc.data()))
+          .map(
+            (doc) => ResolutionEntity.fromFirebaseDocument(
+              doc.data(),
+              doc.reference.path,
+            ),
+          )
           .toList();
 
       return Future(() => right(resolutionEntityList));
@@ -59,7 +67,12 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
           .get();
 
       resolutionEntityList = fetchResult.docs
-          .map((doc) => ResolutionEntity.fromFirebaseDocument(doc.data()))
+          .map(
+            (doc) => ResolutionEntity.fromFirebaseDocument(
+              doc.data(),
+              doc.reference.path,
+            ),
+          )
           .toList();
 
       return Future(() => right(resolutionEntityList));
@@ -91,6 +104,35 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
       return Future(
         () => left(
           const Failure('catch error on uploadResolutionEntity'),
+        ),
+      );
+    }
+  }
+
+  @override
+  EitherFuture<List<ConfirmPostModel>> getConfirmPostListForResolutionId({
+    required String resolutionId,
+  }) async {
+    try {
+      final fetchResult = await FirebaseFirestore.instance
+          .collection(FirebaseCollectionName.confirmPosts)
+          .where(
+            FirebaseConfirmPostFieldName.resolutionId,
+            isEqualTo: '/$resolutionId',
+          )
+          .get();
+
+      final confirmPostModelList = fetchResult.docs.map((doc) {
+        return ConfirmPostModel.fromFireStoreDocument(doc);
+      }).toList();
+
+      print(confirmPostModelList);
+
+      return Future(() => right(confirmPostModelList));
+    } on Exception {
+      return Future(
+        () => left(
+          const Failure('catch error on getConfirmPostListForResolutionId'),
         ),
       );
     }

--- a/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
+++ b/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
@@ -118,15 +118,13 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
           .collection(FirebaseCollectionName.confirmPosts)
           .where(
             FirebaseConfirmPostFieldName.resolutionId,
-            isEqualTo: '/$resolutionId',
+            isEqualTo: FirebaseFirestore.instance.doc('/$resolutionId'),
           )
           .get();
 
       final confirmPostModelList = fetchResult.docs.map((doc) {
         return ConfirmPostModel.fromFireStoreDocument(doc);
       }).toList();
-
-      print(confirmPostModelList);
 
       return Future(() => right(confirmPostModelList));
     } on Exception {

--- a/lib/features/my_page/data/entities/resolution_entity.dart
+++ b/lib/features/my_page/data/entities/resolution_entity.dart
@@ -3,8 +3,10 @@ import 'package:wehavit/common/constants/firebase_field_name.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 
 class ResolutionEntity {
-  ResolutionEntity.fromFirebaseDocument(Map<String, dynamic> data)
-      : goal = data[FirebaseResolutionFieldName.resolutionGoalStatement],
+  ResolutionEntity.fromFirebaseDocument(
+    Map<String, dynamic> data,
+    this.resolutionId,
+  )   : goal = data[FirebaseResolutionFieldName.resolutionGoalStatement],
         action = data[FirebaseResolutionFieldName.resolutionActionStatement],
         period = data[FirebaseResolutionFieldName.resolutionPeriod],
         startDate =
@@ -18,6 +20,7 @@ class ResolutionEntity {
     startDate = DateTime.now();
     isActive = true;
     period = model.isDaySelectedList.toIntPeriod();
+    resolutionId = model.resolutionId;
   }
 
   late String goal;
@@ -25,6 +28,7 @@ class ResolutionEntity {
   late int period;
   late DateTime startDate;
   late bool isActive;
+  late String resolutionId;
 }
 
 extension ResolutionEntityConvertFunctions on ResolutionEntity {
@@ -49,6 +53,7 @@ extension ResolutionEntityConvertFunctions on ResolutionEntity {
       isDaySelectedList: period.toBoolListPeriod(),
       startDate: startDate,
       oathStatement: '',
+      resolutionId: resolutionId,
     );
     return model;
   }

--- a/lib/features/my_page/data/repositories/resolution_repository_impl.dart
+++ b/lib/features/my_page/data/repositories/resolution_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/errors/failure.dart';
 import 'package:wehavit/common/utils/custom_types.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/data/datasources/resolution_datasource.dart';
 import 'package:wehavit/features/my_page/data/datasources/resolution_datasource_provider.dart';
 import 'package:wehavit/features/my_page/data/entities/resolution_entity.dart';
@@ -38,5 +39,14 @@ class ResolutionRepositoryImpl implements ResolutionRepository {
   ) async {
     final entity = ResolutionEntity.fromResolutionModel(model);
     return _resolutionDatasource.uploadResolutionEntity(entity);
+  }
+
+  @override
+  EitherFuture<List<ConfirmPostModel>> getConfirmPostListForResolutionId({
+    required String resolutionId,
+  }) {
+    return _resolutionDatasource.getConfirmPostListForResolutionId(
+      resolutionId: resolutionId,
+    );
   }
 }

--- a/lib/features/my_page/domain/models/resolution_model.dart
+++ b/lib/features/my_page/domain/models/resolution_model.dart
@@ -3,6 +3,7 @@ import 'package:wehavit/common/constants/firebase_field_name.dart';
 
 class ResolutionModel {
   ResolutionModel({
+    required this.resolutionId,
     required this.isActive,
     required this.goalStatement,
     required this.actionStatement,
@@ -11,8 +12,10 @@ class ResolutionModel {
     required this.startDate,
   });
 
-  ResolutionModel.fromMapData(Map<String, dynamic> data)
-      : goalStatement =
+  ResolutionModel.fromMapData(
+    Map<String, dynamic> data,
+    this.resolutionId,
+  )   : goalStatement =
             data[FirebaseResolutionFieldName.resolutionGoalStatement],
         actionStatement =
             data[FirebaseResolutionFieldName.resolutionActionStatement],
@@ -21,8 +24,10 @@ class ResolutionModel {
             (data[FirebaseResolutionFieldName.resolutionStartDate] as Timestamp)
                 .toDate(),
         isActive = data[FirebaseResolutionFieldName.resolutionIsActive],
-        oathStatement = data[FirebaseResolutionFieldName];
+        oathStatement =
+            data[FirebaseResolutionFieldName.resolutionOathStatement];
 
+  String resolutionId;
   String goalStatement;
   String actionStatement;
   String oathStatement;
@@ -37,6 +42,7 @@ class ResolutionModel {
     String? oathStatement,
     bool? isActive,
     DateTime? startDate,
+    String? resolutionId,
   }) {
     return ResolutionModel(
       goalStatement: goalStatement ?? this.goalStatement,
@@ -45,6 +51,7 @@ class ResolutionModel {
       isDaySelectedList: isDaySelectedList ?? this.isDaySelectedList,
       isActive: isActive ?? this.isActive,
       startDate: startDate ?? this.startDate,
+      resolutionId: resolutionId ?? this.resolutionId,
     );
   }
 }

--- a/lib/features/my_page/domain/repositories/resolution_repository.dart
+++ b/lib/features/my_page/domain/repositories/resolution_repository.dart
@@ -1,7 +1,11 @@
 import 'package:wehavit/common/utils/custom_types.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 
 abstract class ResolutionRepository {
   EitherFuture<List<ResolutionModel>> getActiveResolutionModelList();
   EitherFuture<bool> uploadResolutionModel(ResolutionModel model);
+  EitherFuture<List<ConfirmPostModel>> getConfirmPostListForResolutionId({
+    required String resolutionId,
+  });
 }

--- a/lib/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart
+++ b/lib/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
+import 'package:wehavit/features/my_page/domain/repositories/resolution_repository.dart';
+import 'package:wehavit/features/my_page/domain/repositories/resolution_repository_provider.dart';
+
+final getConfirmPostListForResolutionIdUsecaseProvider =
+    Provider<GetConfirmPostListForResolutionIdUsecase>((ref) {
+  final resolutionRepository = ref.watch(resolutionRepositoryProvider);
+  return GetConfirmPostListForResolutionIdUsecase(resolutionRepository);
+});
+
+class GetConfirmPostListForResolutionIdUsecase
+    extends UseCase<List<ConfirmPostModel>, String> {
+  GetConfirmPostListForResolutionIdUsecase(this._resolutionRepository);
+
+  final ResolutionRepository _resolutionRepository;
+
+  @override
+  EitherFuture<List<ConfirmPostModel>> call(params) {
+    return _resolutionRepository.getConfirmPostListForResolutionId(
+      resolutionId: params,
+    );
+  }
+}

--- a/lib/features/my_page/presentation/providers/add_resolution_provider.dart
+++ b/lib/features/my_page/presentation/providers/add_resolution_provider.dart
@@ -43,6 +43,7 @@ class AddResolutionNotifier extends StateNotifier<AddResolutionModel> {
       isDaySelectedList: state.isDaySelectedList,
       isActive: true,
       startDate: DateTime.now(),
+      resolutionId: '',
     );
 
     return _uploadResolutionUsecase.call(newModel);

--- a/lib/features/my_page/presentation/providers/my_page_resolution_list_provider.dart
+++ b/lib/features/my_page/presentation/providers/my_page_resolution_list_provider.dart
@@ -6,7 +6,6 @@ import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 import 'package:wehavit/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart';
 import 'package:wehavit/features/my_page/domain/usecases/get_resolution_list_usecase.dart';
 import 'package:wehavit/features/my_page/domain/usecases/get_resolution_list_usecase_provider.dart';
-import 'package:wehavit/features/reaction/domain/usecase/get_reaction_not_read_from_last_confirm_post_usecase.dart';
 
 final myPageResolutionListProvider = StateNotifierProvider<
     MyPageResolutionListProvider,

--- a/lib/features/my_page/presentation/providers/my_page_resolution_list_provider.dart
+++ b/lib/features/my_page/presentation/providers/my_page_resolution_list_provider.dart
@@ -1,25 +1,57 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
+import 'package:wehavit/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart';
 import 'package:wehavit/features/my_page/domain/usecases/get_resolution_list_usecase.dart';
 import 'package:wehavit/features/my_page/domain/usecases/get_resolution_list_usecase_provider.dart';
+import 'package:wehavit/features/reaction/domain/usecase/get_reaction_not_read_from_last_confirm_post_usecase.dart';
 
 final myPageResolutionListProvider = StateNotifierProvider<
     MyPageResolutionListProvider,
-    Either<Failure, List<ResolutionModel>>>((ref) {
+    Either<Failure,
+        (List<ResolutionModel>, List<Future<List<ConfirmPostModel>>>)>>((ref) {
   return MyPageResolutionListProvider(ref);
 });
 
-class MyPageResolutionListProvider
-    extends StateNotifier<Either<Failure, List<ResolutionModel>>> {
-  MyPageResolutionListProvider(Ref ref) : super(const Right([])) {
+class MyPageResolutionListProvider extends StateNotifier<
+    Either<Failure,
+        (List<ResolutionModel>, List<Future<List<ConfirmPostModel>>>)>> {
+  MyPageResolutionListProvider(Ref ref) : super(const Right(([], []))) {
     getResolutionListUsecase = ref.watch(getResolutionListUseCaseProvider);
+    getConfirmPostListForResolutionIdUsecase =
+        ref.watch(getConfirmPostListForResolutionIdUsecaseProvider);
   }
 
   late final GetResolutionListUsecase getResolutionListUsecase;
+  late final GetConfirmPostListForResolutionIdUsecase
+      getConfirmPostListForResolutionIdUsecase;
 
   Future<void> getActiveResolutionList() async {
-    state = await getResolutionListUsecase.call(NoParams());
+    final resolutionFetchResult =
+        await getResolutionListUsecase.call(NoParams());
+
+    final List<ResolutionModel> resolutionList = resolutionFetchResult.fold(
+      (failure) => [],
+      (fetchResult) => fetchResult,
+    );
+
+    final List<Future<List<ConfirmPostModel>>> confirmPostList =
+        resolutionList.map((resolutionModel) async {
+      final confirmListFetchResult =
+          await getConfirmPostListForResolutionIdUsecase(
+        resolutionModel.resolutionId,
+      );
+
+      final List<ConfirmPostModel> confirmList = confirmListFetchResult.fold(
+        (failure) => [],
+        (fetchResult) => fetchResult,
+      );
+
+      return confirmList;
+    }).toList();
+
+    state = right((resolutionList, confirmPostList));
   }
 }

--- a/lib/features/my_page/presentation/screens/my_page_screen.dart
+++ b/lib/features/my_page/presentation/screens/my_page_screen.dart
@@ -2,7 +2,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:wehavit/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart';
 import 'package:wehavit/features/my_page/presentation/providers/my_page_resolution_list_provider.dart';
 import 'package:wehavit/features/my_page/presentation/widgets/resolution_dashboard_widget.dart';
 

--- a/lib/features/my_page/presentation/screens/my_page_screen.dart
+++ b/lib/features/my_page/presentation/screens/my_page_screen.dart
@@ -13,9 +13,6 @@ class MyPageScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     var resolutionListProvider = ref.watch(myPageResolutionListProvider);
     var currentUser = FirebaseAuth.instance.currentUser;
-    late GetConfirmPostListForResolutionIdUsecase
-        getConfirmPostListForResolutionIdUsecase =
-        ref.read(getConfirmPostListForResolutionIdUsecaseProvider);
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/features/my_page/presentation/screens/my_page_screen.dart
+++ b/lib/features/my_page/presentation/screens/my_page_screen.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:wehavit/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart';
 import 'package:wehavit/features/my_page/presentation/providers/my_page_resolution_list_provider.dart';
 import 'package:wehavit/features/my_page/presentation/widgets/resolution_dashboard_widget.dart';
 
@@ -12,6 +13,9 @@ class MyPageScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     var resolutionListProvider = ref.watch(myPageResolutionListProvider);
     var currentUser = FirebaseAuth.instance.currentUser;
+    late GetConfirmPostListForResolutionIdUsecase
+        getConfirmPostListForResolutionIdUsecase =
+        ref.read(getConfirmPostListForResolutionIdUsecaseProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -67,10 +71,13 @@ class MyPageScreen extends ConsumerWidget {
               (left) => null,
               (right) => Expanded(
                 child: ListView.builder(
-                  itemCount: right.length + 1,
+                  itemCount: right.$1.length + 1,
                   itemBuilder: (context, index) {
-                    if (index < right.length) {
-                      return ResolutionDashboardWidget(model: right[index]);
+                    if (index < right.$1.length) {
+                      return ResolutionDashboardWidget(
+                        model: right.$1[index],
+                        confirmPostList: right.$2[index],
+                      );
                     } else {
                       return Container(
                         margin: const EdgeInsets.symmetric(vertical: 8),

--- a/lib/features/my_page/presentation/widgets/resolution_dashboard_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_dashboard_widget.dart
@@ -62,7 +62,8 @@ class _ResolutionDashboardWidgetState
                               decoration:
                                   const BoxDecoration(color: Colors.white),
                               child: ResolutionLinearGaugeGraphWidget(
-                                data: snapshot.data!,
+                                sourceData: snapshot.data!,
+                                lastPeriod: false,
                               ),
                             ),
                             Container(
@@ -70,7 +71,8 @@ class _ResolutionDashboardWidgetState
                               decoration:
                                   const BoxDecoration(color: Colors.white),
                               child: ResolutionLinearGaugeGraphWidget(
-                                data: snapshot.data!,
+                                sourceData: snapshot.data!,
+                                lastPeriod: true,
                               ),
                               // width: 200,
                               // height: 50,
@@ -88,16 +90,12 @@ class _ResolutionDashboardWidgetState
               ),
             ),
           ),
-          Expanded(
+          const Expanded(
             child: Padding(
-              padding: const EdgeInsets.only(right: 16.0),
+              padding: EdgeInsets.only(right: 16.0),
               child: AspectRatio(
                 aspectRatio: 1,
-                child: Container(
-                  padding: const EdgeInsets.all(4),
-                  decoration: const BoxDecoration(color: Colors.amber),
-                  child: const ResolutionDoughnutGraphWidget(),
-                ),
+                child: ResolutionDoughnutGraphWidget(),
               ),
             ),
           ),

--- a/lib/features/my_page/presentation/widgets/resolution_dashboard_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_dashboard_widget.dart
@@ -1,22 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 import 'package:wehavit/features/my_page/presentation/widgets/resolution_doughnut_graph_widget.dart';
 import 'package:wehavit/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart';
 
-class ResolutionDashboardWidget extends StatefulWidget {
-  const ResolutionDashboardWidget({Key? key, required this.model})
-      : super(key: key);
+class ResolutionDashboardWidget extends ConsumerStatefulWidget {
+  const ResolutionDashboardWidget({
+    super.key,
+    required this.model,
+    required this.confirmPostList,
+  });
 
   final ResolutionModel model;
+  final Future<List<ConfirmPostModel>> confirmPostList;
 
   @override
-  State<ResolutionDashboardWidget> createState() =>
+  ConsumerState<ResolutionDashboardWidget> createState() =>
       _ResolutionDashboardWidgetState();
 }
 
-class _ResolutionDashboardWidgetState extends State<ResolutionDashboardWidget> {
+class _ResolutionDashboardWidgetState
+    extends ConsumerState<ResolutionDashboardWidget> {
   late String goalStatement = widget.model.goalStatement;
   late String actionStatement = widget.model.actionStatement;
+
+  @override
+  void initState() {
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,18 +50,39 @@ class _ResolutionDashboardWidgetState extends State<ResolutionDashboardWidget> {
                 children: [
                   Text(goalStatement),
                   Text(actionStatement),
-                  const SizedBox(height: 20),
-                  Container(
-                    padding: const EdgeInsets.all(2),
-                    decoration: const BoxDecoration(color: Colors.white),
-                    child: const ResolutionLinearGaugeGraphWidget(),
-                  ),
-                  Container(
-                    padding: const EdgeInsets.all(2),
-                    decoration: const BoxDecoration(color: Colors.white),
-                    child: const ResolutionLinearGaugeGraphWidget(),
-                    // width: 200,
-                    // height: 50,
+                  FutureBuilder<List<ConfirmPostModel>>(
+                    future: widget.confirmPostList,
+                    builder: (context, snapshot) {
+                      if (snapshot.hasData) {
+                        return Column(
+                          children: [
+                            const SizedBox(height: 20),
+                            Container(
+                              padding: const EdgeInsets.all(2),
+                              decoration:
+                                  const BoxDecoration(color: Colors.white),
+                              child: ResolutionLinearGaugeGraphWidget(
+                                data: snapshot.data!,
+                              ),
+                            ),
+                            Container(
+                              padding: const EdgeInsets.all(2),
+                              decoration:
+                                  const BoxDecoration(color: Colors.white),
+                              child: ResolutionLinearGaugeGraphWidget(
+                                data: snapshot.data!,
+                              ),
+                              // width: 200,
+                              // height: 50,
+                            ),
+                          ],
+                        );
+                      } else if (snapshot.hasError) {
+                        return const Placeholder();
+                      } else {
+                        return Container();
+                      }
+                    },
                   ),
                 ],
               ),

--- a/lib/features/my_page/presentation/widgets/resolution_dashboard_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_dashboard_widget.dart
@@ -90,12 +90,25 @@ class _ResolutionDashboardWidgetState
               ),
             ),
           ),
-          const Expanded(
+          Expanded(
             child: Padding(
-              padding: EdgeInsets.only(right: 16.0),
+              padding: const EdgeInsets.only(right: 16.0),
               child: AspectRatio(
                 aspectRatio: 1,
-                child: ResolutionDoughnutGraphWidget(),
+                child: FutureBuilder<List<ConfirmPostModel>>(
+                  future: widget.confirmPostList,
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData) {
+                      return ResolutionDoughnutGraphWidget(
+                        sourceData: snapshot.data!,
+                      );
+                    } else if (snapshot.hasError) {
+                      return const Placeholder();
+                    } else {
+                      return Container();
+                    }
+                  },
+                ),
               ),
             ),
           ),

--- a/lib/features/my_page/presentation/widgets/resolution_doughnut_graph_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_doughnut_graph_widget.dart
@@ -1,9 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/presentation/widgets/resolution_accomplishment_donut_graph_datamodel.dart';
 
 class ResolutionDoughnutGraphWidget extends StatelessWidget {
-  const ResolutionDoughnutGraphWidget({super.key});
+  ResolutionDoughnutGraphWidget({
+    super.key,
+    required List<ConfirmPostModel> sourceData,
+  }) {
+    sourceData.sort((a, b) => a.toString().compareTo(b.toString()));
+    data = sourceData.where((element) {
+      return todaysDate.difference(element.createdAt!).inDays < 14;
+    }).toList();
+
+    rationOfDoneDays = (data.length / 14) * 100;
+  }
+
+  late final List<ConfirmPostModel> data;
+  final todaysDate = DateTime.now();
+  late final double rationOfDoneDays;
 
   List<DoughnutSeries<ResolutionAccomplishmentDonutGraphDataModel, String>>
       _getDefaultDoughnutSeries() {
@@ -11,8 +26,14 @@ class ResolutionDoughnutGraphWidget extends StatelessWidget {
         String>>[
       DoughnutSeries<ResolutionAccomplishmentDonutGraphDataModel, String>(
         dataSource: <ResolutionAccomplishmentDonutGraphDataModel>[
-          ResolutionAccomplishmentDonutGraphDataModel(x: 'do', y: 90),
-          ResolutionAccomplishmentDonutGraphDataModel(x: 'skip', y: 10),
+          ResolutionAccomplishmentDonutGraphDataModel(
+            x: 'do',
+            y: rationOfDoneDays,
+          ),
+          ResolutionAccomplishmentDonutGraphDataModel(
+            x: 'skip',
+            y: 100 - rationOfDoneDays,
+          ),
         ],
         xValueMapper:
             (ResolutionAccomplishmentDonutGraphDataModel datum, int index) =>

--- a/lib/features/my_page/presentation/widgets/resolution_doughnut_graph_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_doughnut_graph_widget.dart
@@ -13,12 +13,12 @@ class ResolutionDoughnutGraphWidget extends StatelessWidget {
       return todaysDate.difference(element.createdAt!).inDays < 14;
     }).toList();
 
-    rationOfDoneDays = (data.length / 14) * 100;
+    ratioOfDoneDays = (data.length / 14) * 100;
   }
 
   late final List<ConfirmPostModel> data;
   final todaysDate = DateTime.now();
-  late final double rationOfDoneDays;
+  late final double ratioOfDoneDays;
 
   List<DoughnutSeries<ResolutionAccomplishmentDonutGraphDataModel, String>>
       _getDefaultDoughnutSeries() {
@@ -28,11 +28,11 @@ class ResolutionDoughnutGraphWidget extends StatelessWidget {
         dataSource: <ResolutionAccomplishmentDonutGraphDataModel>[
           ResolutionAccomplishmentDonutGraphDataModel(
             x: 'do',
-            y: rationOfDoneDays,
+            y: ratioOfDoneDays,
           ),
           ResolutionAccomplishmentDonutGraphDataModel(
             x: 'skip',
-            y: 100 - rationOfDoneDays,
+            y: 100 - ratioOfDoneDays,
           ),
         ],
         xValueMapper:

--- a/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_gauges/gauges.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 
 class ResolutionLinearGaugeGraphWidget extends StatelessWidget {
-  const ResolutionLinearGaugeGraphWidget({super.key});
+  const ResolutionLinearGaugeGraphWidget({super.key, required this.data});
+
+  final List<ConfirmPostModel> data;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
@@ -3,9 +3,25 @@ import 'package:syncfusion_flutter_gauges/gauges.dart';
 import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 
 class ResolutionLinearGaugeGraphWidget extends StatelessWidget {
-  const ResolutionLinearGaugeGraphWidget({super.key, required this.data});
+  ResolutionLinearGaugeGraphWidget({
+    super.key,
+    required List<ConfirmPostModel> sourceData,
+    required this.lastPeriod,
+  }) {
+    sourceData.sort((a, b) => a.toString().compareTo(b.toString()));
+    data = sourceData.where((element) {
+      if (lastPeriod) {
+        return todaysDate.difference(element.createdAt!).inDays < 28 &&
+            todaysDate.difference(element.createdAt!).inDays >= 14;
+      } else {
+        return todaysDate.difference(element.createdAt!).inDays < 14;
+      }
+    }).toList();
+  }
 
-  final List<ConfirmPostModel> data;
+  late final List<ConfirmPostModel> data;
+  final bool lastPeriod;
+  final todaysDate = DateTime.now();
 
   @override
   Widget build(BuildContext context) {
@@ -16,10 +32,17 @@ class ResolutionLinearGaugeGraphWidget extends StatelessWidget {
       maximum: 13,
       markerPointers: List<LinearWidgetPointer>.generate(
         14,
-        (int index) => _buildLinearWidgetPointer(
-          index.toDouble(),
-          index % 4 == 1 ? Colors.black : Colors.white,
-        ),
+        (int index) {
+          return _buildLinearWidgetPointer(
+            index.toDouble(),
+            data.any(
+              (element) =>
+                  todaysDate.difference(element.createdAt!).inDays == index,
+            )
+                ? Colors.black
+                : Colors.white,
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## 작업 내용 설명
1. 그래프에 넣을 데이터 가공 방식 구상하기
2. 데이터 fetch 해와서 데이터 가공하기
3. 가공한 데이터 그래프에 전달해, 화면에 그려주기

## 관련 이슈
- #22 
- #119 

## 작업의 결과물
데이터가 없는 경우에는 위 글처럼 아무런 그래프에 데이터가 없음
데이터가 있는 경우에는 아래 글처럼 그래프에 데이터가 그려짐
(아래 그래프에서는 최근 14일 중 [3, 4, 9]일 전에 인증을 남겼음)

<img width="300" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/8d72ce07-8a63-4d73-9560-ede0ee66da8d">


## 작업의 비고사항 및 한계점
- 언제를 기준으로 구간을 자를지에 대한 기획적인 논의가 필요할 것 같아서, 우선은 **[오늘\~14일) / [14일\~28일) 2개의 구간으로 나눠 그래프에 데이터가 들어가도록 세팅해둔 상태**입니다.

- 단순히 그래프를 그려주기 위해 데이터의 개수만 필요한데, 현재는 "내가 가진 도전에 대한 ConfirmPost 데이터를 모두 들고와 List에 담은 뒤에, 원하는 구간에 대한 List의 length를 이용하는 방식"이 비효율적이라고 느껴짐. 
  → 요 방식에서 '개수'만 가져오도록 하는 개선 방법이 있을까요?
- 이후에 각 도전 목표에 대한 상세 페이지가 만들어지는 경우에는 해당 페이지에서 요 데이터를 가져가서 쓸 수 있기 때문에 유용하겠지만, 
그럼에도 목표별 상세 페이지에 들어가기 이전에 모든 데이터를 fetch 하는게 어색하고 비효율적이라고 느껴집니다. ㅜㅜ

## To Reviewers
- 비고사항 읽어주세요~~

Close 
#119 