### PR TITLE
[#129] fix: reaction model typo and friend status filitering

### DIFF
--- a/lib/common/constants/firebase_field_name.dart
+++ b/lib/common/constants/firebase_field_name.dart
@@ -23,7 +23,7 @@ class FirebaseResolutionFieldName {
 
 @immutable
 class FirebaseReactionFieldName {
-  static const complementerUid = 'complementerUid';
+  static const complimenterUid = 'complimenterUid';
   static const comment = 'comment';
   static const emoji = 'emoji';
   static const hasRead = 'hasRead';

--- a/lib/features/live_writing/data/repositories/live_writing_friend_repository_impl.dart
+++ b/lib/features/live_writing/data/repositories/live_writing_friend_repository_impl.dart
@@ -13,7 +13,6 @@ class LiveWritingFriendRepositoryImpl extends LiveWritingFriendRepository {
   LiveWritingFriendRepositoryImpl();
 
   final livePostDocumentPrefix = 'LIVE-';
-  final int friendStateAccepted = 1;
 
   @override
   Future<List<String>> getVisibleFriendEmailList() async {
@@ -21,16 +20,17 @@ class LiveWritingFriendRepositoryImpl extends LiveWritingFriendRepository {
         .collection(FirebaseCollectionName.friends)
         .get();
 
-    final friendsAccepted = friendsSnapshots.docs.where((data) {
-      return data.data()['friendState'] == friendStateAccepted;
-    });
+    final friendsAccepted = friendsSnapshots.docs;
+
+    // TODO. 친구 수락이 구현될 경우 사용
+    // final int friendStateAccepted = 1;
+    // friendsAccepted.where((data) {
+    //   return data.data()['friendState'] == friendStateAccepted;
+    // });
 
     return friendsAccepted.map<String>((data) {
       return data.data()[FirebaseFriendFieldName.friendEmail];
     }).toList();
-
-    // TEST. 임시로 실시간 공유할 친구 두 명 반환
-    // return ['69dlXoGSBKhzrySuhb8t9MvqzdD3', 'zZaP501Kc8ccUvR9ogPOsjSeD1s2'];
   }
 
   @override
@@ -97,7 +97,7 @@ class LiveWritingFriendRepositoryImpl extends LiveWritingFriendRepository {
     try {
       await FirebaseFirestore.instance
           .collection(
-            '${FirebaseCollectionName.liveConfirmPosts}/LIVE-$targetEmail/${FirebaseCollectionName.encourages}',
+            '${FirebaseCollectionName.liveConfirmPosts}/$livePostDocumentPrefix$targetEmail/${FirebaseCollectionName.encourages}',
           )
           .add(
             reactionModel.toJson(),

--- a/lib/features/live_writing/data/repositories/live_writing_mine_repository_impl.dart
+++ b/lib/features/live_writing/data/repositories/live_writing_mine_repository_impl.dart
@@ -20,16 +20,13 @@ class LiveWritingPostRepositoryImpl extends MyLiveWritingRepository {
           '$livePostDocumentPrefix${FirebaseAuth.instance.currentUser!.email}',
         )
         .set(
-          {
-            FirebaseLiveConfirmPostFieldName.userId:
-                FirebaseAuth.instance.currentUser!.uid,
-            FirebaseLiveConfirmPostFieldName.message: message,
-          },
-          SetOptions(merge: true),
-        )
-        .then((value) =>
-            debugPrint('New live confirm document with message created'))
-        .catchError((error) => debugPrint('Failed to add document: $error'));
+      {
+        FirebaseLiveConfirmPostFieldName.userId:
+            FirebaseAuth.instance.currentUser!.uid,
+        FirebaseLiveConfirmPostFieldName.message: message,
+      },
+      SetOptions(merge: true),
+    ).catchError((error) => debugPrint('Failed to add document: $error'));
   }
 
   @override
@@ -42,16 +39,13 @@ class LiveWritingPostRepositoryImpl extends MyLiveWritingRepository {
           '$livePostDocumentPrefix${FirebaseAuth.instance.currentUser!.email}',
         )
         .set(
-          {
-            FirebaseLiveConfirmPostFieldName.userId:
-                FirebaseAuth.instance.currentUser!.uid,
-            FirebaseLiveConfirmPostFieldName.title: title,
-          },
-          SetOptions(merge: true),
-        )
-        .then((value) =>
-            debugPrint('New live confirm document with title created'))
-        .catchError((error) => debugPrint('Failed to add document: $error'));
+      {
+        FirebaseLiveConfirmPostFieldName.userId:
+            FirebaseAuth.instance.currentUser!.uid,
+        FirebaseLiveConfirmPostFieldName.title: title,
+      },
+      SetOptions(merge: true),
+    ).catchError((error) => debugPrint('Failed to add document: $error'));
   }
 
   @override

--- a/lib/features/swipe_view/data/datasource/reaction_datasource_impl.dart
+++ b/lib/features/swipe_view/data/datasource/reaction_datasource_impl.dart
@@ -42,7 +42,7 @@ class ReactionDatasourceImpl implements ReactionDatasource {
       )
           .add(
         {
-          FirebaseReactionFieldName.complementerUid:
+          FirebaseReactionFieldName.complimenterUid:
               FirebaseAuth.instance.currentUser!.uid,
           FirebaseReactionFieldName.reactionType: reactionModel.reactionType,
           FirebaseReactionFieldName.emoji: reactionModel.emoji,


### PR DESCRIPTION
## 라이브 인증글 작성할 때 친구가 안 뜨는 버그를 해결했습니다.

두 가지의 수정이 있습니다.

친구 신청 상태를 확인하는 코드를 삭제했습니다. (미사용)
 - ReactionModel의 오타를 수정했습니다.
 - Complementer -> Comlimenter

Close: #129