### PR TITLE
[#110] feat: 대기화면에 대한 UI 구조 간략 작성

### DIFF
--- a/lib/common/routers/route_location.dart
+++ b/lib/common/routers/route_location.dart
@@ -16,4 +16,5 @@ class RouteLocation {
   static const String liveWriting = '$waitingRoom/liveWriting';
   static const String swipeView = '/swipeView';
   static const String animationSampleView = '/animationSampleView';
+  static const String liveWaitingSampleView = '/liveWaitingSampleView';
 }

--- a/lib/common/routers/route_provider.dart
+++ b/lib/common/routers/route_provider.dart
@@ -7,6 +7,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/features/effects/animation_sample_page.dart';
 import 'package:wehavit/features/features.dart';
 import 'package:wehavit/features/live_writing/presentation/screens/live_writing_page.dart';
+import 'package:wehavit/features/live_writing_waiting/live_waiting_sample_view.dart';
 import 'package:wehavit/features/my_page/presentation/screens/add_resolution_screen.dart';
 import 'package:wehavit/features/my_page/presentation/screens/my_page_screen.dart';
 import 'package:wehavit/features/swipe_view/presentation/screen/swipe_view.dart';
@@ -181,6 +182,18 @@ class AnimationSampleViewRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const AnimationSamplePage();
+  }
+}
+
+@TypedGoRoute<LiveWaitingSampleViewRoute>(path: LiveWaitingSampleViewRoute.path)
+class LiveWaitingSampleViewRoute extends GoRouteData {
+  const LiveWaitingSampleViewRoute();
+
+  static const path = RouteLocation.liveWaitingSampleView;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const LiveWaitingSampleView();
   }
 }
 

--- a/lib/common/routers/route_provider.g.dart
+++ b/lib/common/routers/route_provider.g.dart
@@ -16,6 +16,7 @@ List<RouteBase> get $appRoutes => [
       $liveWritingRoute,
       $swipeViewRoute,
       $animationSampleViewRoute,
+      $liveWaitingSampleViewRoute,
     ];
 
 RouteBase get $splashRoute => GoRouteData.$route(
@@ -209,6 +210,29 @@ extension $AnimationSampleViewRouteExtension on AnimationSampleViewRoute {
 
   String get location => GoRouteData.$location(
         '/animationSampleView',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $liveWaitingSampleViewRoute => GoRouteData.$route(
+      path: '/liveWaitingSampleView',
+      factory: $LiveWaitingSampleViewRouteExtension._fromState,
+    );
+
+extension $LiveWaitingSampleViewRouteExtension on LiveWaitingSampleViewRoute {
+  static LiveWaitingSampleViewRoute _fromState(GoRouterState state) =>
+      const LiveWaitingSampleViewRoute();
+
+  String get location => GoRouteData.$location(
+        '/liveWaitingSampleView',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/lib/common/routers/test_page.dart
+++ b/lib/common/routers/test_page.dart
@@ -88,6 +88,12 @@ class TestPage extends ConsumerWidget {
               },
               buttonText: 'Animation Sample View',
             ),
+            MoveButton(
+              onPressCallback: () async {
+                context.push('/liveWaitingSampleView');
+              },
+              buttonText: 'Live Waiting Sample View',
+            ),
           ],
         ),
       ),

--- a/lib/features/live_writing_waiting/live_waiting_sample_view.dart
+++ b/lib/features/live_writing_waiting/live_waiting_sample_view.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:wehavit/features/live_writing_waiting/presentation/view/live_waiting_view.dart';
+
+class LiveWaitingSampleView extends StatelessWidget {
+  const LiveWaitingSampleView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        constraints: BoxConstraints.expand(),
+        child: LiveWritingView(),
+      ),
+    );
+  }
+}

--- a/lib/features/live_writing_waiting/live_waiting_sample_view.dart
+++ b/lib/features/live_writing_waiting/live_waiting_sample_view.dart
@@ -7,9 +7,26 @@ class LiveWaitingSampleView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.black,
       body: Container(
         constraints: BoxConstraints.expand(),
-        child: LiveWritingView(),
+        child: Stack(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black,
+                    Colors.amber,
+                  ],
+                ),
+              ),
+            ),
+            LiveWritingView(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/live_writing_waiting/presentation/view/live_waiting_avatar_animation_widget.dart
+++ b/lib/features/live_writing_waiting/presentation/view/live_waiting_avatar_animation_widget.dart
@@ -1,0 +1,84 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+class LiveWaitingAvatarAnimatingWidget extends StatefulWidget {
+  const LiveWaitingAvatarAnimatingWidget({super.key});
+
+  @override
+  State<LiveWaitingAvatarAnimatingWidget> createState() =>
+      _LiveWaitingAvatarAnimatingWidgetState();
+}
+
+class _LiveWaitingAvatarAnimatingWidgetState
+    extends State<LiveWaitingAvatarAnimatingWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _lifeTimeAnimationController;
+  late final Animation _lifeTimeAnimation;
+  late final Animation _positionXAnimation;
+  late final Animation _positionYAnimation;
+
+  final int _lifeCycleAnimationDuration = 2500; // millisecond
+  double randomOffset = Random().nextDouble();
+
+  @override
+  void initState() {
+    super.initState();
+
+    _lifeTimeAnimationController = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: _lifeCycleAnimationDuration),
+    );
+    _lifeTimeAnimation = Tween<double>(begin: 0, end: 1).animate(
+      CurvedAnimation(
+        parent: _lifeTimeAnimationController,
+        curve: Curves.linear,
+      ),
+    );
+    _lifeTimeAnimationController.addListener(() {
+      setState(() {});
+    });
+    _lifeTimeAnimationController.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        _lifeTimeAnimationController.repeat();
+      }
+    });
+
+    _positionXAnimation = Tween<double>(begin: 0, end: 10).animate(
+      CurvedAnimation(
+        parent: _lifeTimeAnimationController,
+        curve: Curves.linear,
+      ),
+    );
+    _positionYAnimation = Tween<double>(begin: -150, end: 1000).animate(
+      CurvedAnimation(
+        parent: _lifeTimeAnimationController,
+        curve: Curves.easeOut,
+      ),
+    );
+
+    Future.delayed(
+      Duration(
+        milliseconds: (2000 * randomOffset).toInt(),
+      ),
+      () => _lifeTimeAnimationController.forward(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: 100 + randomOffset * 150 + sin(_positionXAnimation.value) * 30,
+      bottom: _positionYAnimation.value,
+      child: Opacity(
+        opacity: 0.6 + (1 - _lifeTimeAnimation.value).toDouble() * 0.4,
+        child: CircleAvatar(
+          radius: 50 + sin(randomOffset) * 10,
+          foregroundImage: const NetworkImage(
+            'https://www.pumpkin.care/wp-content/uploads/2021/01/Ragdoll-Hero-jpg.webp',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
+++ b/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:wehavit/features/live_writing_waiting/presentation/view/live_waiting_avatar_animation_widget.dart';
+import 'package:wehavit/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart';
 
 class LiveWritingView extends StatefulWidget {
   const LiveWritingView({super.key});
@@ -12,29 +12,29 @@ class _LiveWritingViewState extends State<LiveWritingView> {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-        child: Stack(
-      alignment: Alignment.center,
-      children: [
-        Stack(
-          clipBehavior: Clip.none,
-          children: [
-            LiveWaitingAvatarAnimatingWidget(),
-            LiveWaitingAvatarAnimatingWidget(),
-            LiveWaitingAvatarAnimatingWidget(),
-            LiveWaitingAvatarAnimatingWidget(),
-            LiveWaitingAvatarAnimatingWidget(),
-          ],
-        ),
-        Positioned(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Stack(
+            clipBehavior: Clip.none,
+            children: List.generate(
+              5,
+              (_) => LiveWaitingAvatarAnimatingWidget(
+                userImageUrl:
+                    "https://mblogthumb-phinf.pstatic.net/MjAyMDA0MDlfMzgg/MDAxNTg2NDEyNjMwNTU2.tj79WwOeb17w8C0PQWXqebTyUyTT6pfCNVOoCSzBOaIg.8vfG4lXr0u-LZdHOoWGUSIKzsXwoa5zGuYkdrwqu1vcg.PNG.klipk2/먼지1.png?type=w800",
+              ),
+            ),
+          ),
+          Positioned(
             top: 100,
             child: Column(
               children: [
                 Text(
                   "곧 뭐시기를 시작합니다",
                   style: TextStyle(
-                    fontSize: 30,
-                    fontWeight: FontWeight.bold,
-                  ),
+                      fontSize: 30,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white),
                 ),
                 SizedBox(
                   height: 20,
@@ -42,20 +42,23 @@ class _LiveWritingViewState extends State<LiveWritingView> {
                 Text(
                   "입장 중",
                   style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.w600,
-                  ),
+                      fontSize: 20,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white),
                 ),
                 Text(
                   "00:00",
                   style: TextStyle(
                     fontSize: 44,
                     fontWeight: FontWeight.bold,
+                    color: Colors.white,
                   ),
                 ),
               ],
-            ))
-      ],
-    ));
+            ),
+          )
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
+++ b/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:wehavit/features/live_writing_waiting/presentation/view/live_waiting_avatar_animation_widget.dart';
+
+class LiveWritingView extends StatefulWidget {
+  const LiveWritingView({super.key});
+
+  @override
+  State<LiveWritingView> createState() => _LiveWritingViewState();
+}
+
+class _LiveWritingViewState extends State<LiveWritingView> {
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+        child: Stack(
+      alignment: Alignment.center,
+      children: [
+        Stack(
+          clipBehavior: Clip.none,
+          children: [
+            LiveWaitingAvatarAnimatingWidget(),
+            LiveWaitingAvatarAnimatingWidget(),
+            LiveWaitingAvatarAnimatingWidget(),
+            LiveWaitingAvatarAnimatingWidget(),
+            LiveWaitingAvatarAnimatingWidget(),
+          ],
+        ),
+        Positioned(
+            top: 100,
+            child: Column(
+              children: [
+                Text(
+                  "곧 뭐시기를 시작합니다",
+                  style: TextStyle(
+                    fontSize: 30,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                SizedBox(
+                  height: 20,
+                ),
+                Text(
+                  "입장 중",
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Text(
+                  "00:00",
+                  style: TextStyle(
+                    fontSize: 44,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ))
+      ],
+    ));
+  }
+}

--- a/lib/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart
+++ b/lib/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart
@@ -1,9 +1,12 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:wehavit/common/models/user_model/user_model.dart';
 
 class LiveWaitingAvatarAnimatingWidget extends StatefulWidget {
-  const LiveWaitingAvatarAnimatingWidget({super.key});
+  LiveWaitingAvatarAnimatingWidget({super.key, required this.userImageUrl});
+
+  String userImageUrl;
 
   @override
   State<LiveWaitingAvatarAnimatingWidget> createState() =>
@@ -44,7 +47,8 @@ class _LiveWaitingAvatarAnimatingWidgetState
       }
     });
 
-    _positionXAnimation = Tween<double>(begin: 0, end: 10).animate(
+    _positionXAnimation =
+        Tween<double>(begin: 0, end: Random().nextDouble() * 10).animate(
       CurvedAnimation(
         parent: _lifeTimeAnimationController,
         curve: Curves.linear,
@@ -72,10 +76,22 @@ class _LiveWaitingAvatarAnimatingWidgetState
       bottom: _positionYAnimation.value,
       child: Opacity(
         opacity: 0.6 + (1 - _lifeTimeAnimation.value).toDouble() * 0.4,
-        child: CircleAvatar(
-          radius: 50 + sin(randomOffset) * 10,
-          foregroundImage: const NetworkImage(
-            'https://www.pumpkin.care/wp-content/uploads/2021/01/Ragdoll-Hero-jpg.webp',
+        child: Container(
+          width: 100 + sin(randomOffset) * 20,
+          height: 100 + sin(randomOffset) * 20,
+          decoration: BoxDecoration(
+            color: const Color(0xff7c94b6),
+            image: DecorationImage(
+              image: NetworkImage(
+                widget.userImageUrl,
+              ),
+              fit: BoxFit.cover,
+            ),
+            borderRadius: BorderRadius.all(Radius.circular(100.0)),
+            border: Border.all(
+              color: Colors.white,
+              width: 4.0,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## 작업 내용 설명
1. userImageUrl을 받아와서 위젯에 넣어주면 이미지를 그리도록 기능 구현
2. 간단한 애니메이션 적용
3. 적용 가능하도록 Stack으로 구조 빼서 작성하였음

## 관련 이슈
- #110
- #5 

## 작업의 결과물
디자인
<img width="691" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/74a54542-c0a1-42f4-8452-43732a930527">
반영한 작업물
![Simulator Screen Recording - iPhone 13 Pro - 2023-11-21 at 19 29 40](https://github.com/cau-bootcamp/wehavit/assets/39216546/c4a04697-b512-4a57-84ce-8766bc97a6ba)

## 작업의 비고사항 및 한계점
- `LiveWaitingAvatarAnimatingWidget(userImageUrl: imageUrl)` 의 형태로 사용할 수 있도록 만들었습니다.
- 실시간 대기 때 접속한 사용자들의 이미지를 받아와 리스트에 추가해주기만 하면 되어용!

## To Reviewers
- 사랑해요

Close #110 