### PR TITLE
[#110] fix: LiveWaitingView에 외부에서 버블을 추가할 수 있도록 구조 개선

### DIFF
--- a/lib/features/live_writing_waiting/live_waiting_sample_view.dart
+++ b/lib/features/live_writing_waiting/live_waiting_sample_view.dart
@@ -1,8 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/features/live_writing_waiting/presentation/view/live_waiting_view.dart';
 
-class LiveWaitingSampleView extends StatelessWidget {
+class LiveWaitingSampleView extends ConsumerStatefulWidget {
   const LiveWaitingSampleView({super.key});
+
+  @override
+  ConsumerState<LiveWaitingSampleView> createState() =>
+      _LiveWaitingSampleViewState();
+}
+
+class _LiveWaitingSampleViewState extends ConsumerState<LiveWaitingSampleView> {
+  late LiveWaitingViewUserImageUrlList _imageUrlListProvider;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _imageUrlListProvider =
+        ref.read(liveWaitingViewUserImageUrlListProvider.notifier);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -11,6 +27,7 @@ class LiveWaitingSampleView extends StatelessWidget {
       body: Container(
         constraints: BoxConstraints.expand(),
         child: Stack(
+          alignment: Alignment.center,
           children: [
             Container(
               decoration: BoxDecoration(
@@ -24,6 +41,14 @@ class LiveWaitingSampleView extends StatelessWidget {
                 ),
               ),
             ),
+            ElevatedButton(
+                onPressed: () {
+                  _imageUrlListProvider.addUserImageUrl(
+                    imageUrl:
+                        'https://avatars.githubusercontent.com/u/63251068?v=4',
+                  );
+                },
+                child: Text("Add User")),
             LiveWritingView(),
           ],
         ),

--- a/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
+++ b/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
@@ -1,16 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart';
 
-class LiveWritingView extends StatefulWidget {
+/// ## 사용 방법
+/// 1. Provider를 ref로 read 해준 뒤
+/// ```
+///   late LiveWaitingViewUserImageUrlList _imageUrlListProvider;
+///   _imageUrlListProvider = ref.read(liveWaitingViewUserImageUrlListProvider.notifier);
+/// ```
+/// 2. LiveWritingView를 Stack에 담아주고
+/// ```
+/// Stack(
+///   children: [ ... ,
+///     LiveWritingView()
+///   ...
+///   ]
+/// )
+///
+/// ```
+/// 3. 아래처럼 urlString을 추가하는 함수를 호출해 화면에 버블을 그리거나 제거할 수 있음
+/// ```
+///   // 추가
+///   _imageUrlListProvider.addUserImageUrl(imageUrl: 'urlString');
+///   // 제거
+///   _imageUrlListProvider.removeUserImageUrl(imageUrl: 'urlString');
+/// ```
+class LiveWritingView extends ConsumerStatefulWidget {
   const LiveWritingView({super.key});
 
   @override
-  State<LiveWritingView> createState() => _LiveWritingViewState();
+  ConsumerState<LiveWritingView> createState() => _LiveWritingViewState();
 }
 
-class _LiveWritingViewState extends State<LiveWritingView> {
+class _LiveWritingViewState extends ConsumerState<LiveWritingView> {
+  late List<String> _liveWaitingViewUserImageUrlList;
+
+  final String enteringTitle = '곧 뭐시기를 시작합니다!';
+  final String enteringDescription = '입장중...';
+
   @override
   Widget build(BuildContext context) {
+    _liveWaitingViewUserImageUrlList =
+        ref.watch(liveWaitingViewUserImageUrlListProvider);
+
     return SafeArea(
       child: Stack(
         alignment: Alignment.center,
@@ -18,10 +50,9 @@ class _LiveWritingViewState extends State<LiveWritingView> {
           Stack(
             clipBehavior: Clip.none,
             children: List.generate(
-              5,
-              (_) => LiveWaitingAvatarAnimatingWidget(
-                userImageUrl:
-                    "https://mblogthumb-phinf.pstatic.net/MjAyMDA0MDlfMzgg/MDAxNTg2NDEyNjMwNTU2.tj79WwOeb17w8C0PQWXqebTyUyTT6pfCNVOoCSzBOaIg.8vfG4lXr0u-LZdHOoWGUSIKzsXwoa5zGuYkdrwqu1vcg.PNG.klipk2/먼지1.png?type=w800",
+              _liveWaitingViewUserImageUrlList.length,
+              (idx) => LiveWaitingAvatarAnimatingWidget(
+                userImageUrl: _liveWaitingViewUserImageUrlList[idx],
               ),
             ),
           ),
@@ -30,7 +61,7 @@ class _LiveWritingViewState extends State<LiveWritingView> {
             child: Column(
               children: [
                 Text(
-                  "곧 뭐시기를 시작합니다",
+                  enteringTitle,
                   style: TextStyle(
                       fontSize: 30,
                       fontWeight: FontWeight.bold,
@@ -40,7 +71,7 @@ class _LiveWritingViewState extends State<LiveWritingView> {
                   height: 20,
                 ),
                 Text(
-                  "입장 중",
+                  enteringDescription,
                   style: TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.w600,
@@ -56,9 +87,27 @@ class _LiveWritingViewState extends State<LiveWritingView> {
                 ),
               ],
             ),
-          )
+          ),
         ],
       ),
     );
+  }
+}
+
+final liveWaitingViewUserImageUrlListProvider =
+    StateNotifierProvider<LiveWaitingViewUserImageUrlList, List<String>>(
+  (ref) => LiveWaitingViewUserImageUrlList(),
+);
+
+class LiveWaitingViewUserImageUrlList extends StateNotifier<List<String>> {
+  LiveWaitingViewUserImageUrlList() : super([]);
+
+  void addUserImageUrl({required String imageUrl}) {
+    state = List.from(state..add(imageUrl));
+    // state = state..append(imageUrl);
+  }
+
+  void removeUserImageUrl({required String imageUrl}) {
+    state = state..remove(imageUrl);
   }
 }

--- a/lib/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart
+++ b/lib/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart
@@ -1,12 +1,14 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:wehavit/common/models/user_model/user_model.dart';
 
 class LiveWaitingAvatarAnimatingWidget extends StatefulWidget {
-  LiveWaitingAvatarAnimatingWidget({super.key, required this.userImageUrl});
+  const LiveWaitingAvatarAnimatingWidget({
+    super.key,
+    required this.userImageUrl,
+  });
 
-  String userImageUrl;
+  final String userImageUrl;
 
   @override
   State<LiveWaitingAvatarAnimatingWidget> createState() =>


### PR DESCRIPTION
# 설명
Provider를 사용하여, 외부에서 LiveWaitingView의 state에 userImageUrl을 추가하여 복잡한 콜백이나 접근 없이 쉽게 버블을 추가하는 로직을 구현할 수 있도록 개선하였음.

작업 내역을 설명하고 어떤 이슈와 관련되어 있는지 명시합니다.
Fixes #110 

## 작업 종류
- [x] 버그 수정 (다른 기능에 영향을 미치지 않는 수정)
- [ ] 새로운 feature (다른 기존 기능에 영향을 미치는 기능 추가)
- [ ] Breaking change (다른 기존 기능에 영향을 미치는 수정)
- [ ] 문서 수정
- [ ] 기타 (please describe):

# 작업 내역

작업 내역을 설명합니다.

- [ ] 작업 내역 1 Provider로 LiveWaitingView의 상태를 관리하도록 개선
- [ ] 작업 내역 2 Provider로 외부에서 쉽게 버블을 추가할 수 있도록 개선

## 작업 결과물
LiveWaitingView 클래스에 적용 방법 및 버블 추가, 제거 방법 작성해두었음.
```
/// 실시간 인증 전 대기화면
/// 
/// ## 사용 방법
/// 1. Provider를 ref로 read 해준 뒤
/// ```
///   late LiveWaitingViewUserImageUrlList _imageUrlListProvider;
///   _imageUrlListProvider = ref.read(liveWaitingViewUserImageUrlListProvider.notifier);
/// ```
/// 2. LiveWritingView를 Stack에 담아주고
/// ```
/// Stack(
///   children: [ ... ,
///     LiveWritingView()
///   ...
///   ]
/// )
///
/// ```
/// 3. 아래처럼 urlString을 추가하는 함수를 호출해 화면에 버블을 그리거나 제거할 수 있음
/// ```
///   // 추가
///   _imageUrlListProvider.addUserImageUrl(imageUrl: 'urlString');
///   // 제거
///   _imageUrlListProvider.removeUserImageUrl(imageUrl: 'urlString');
/// ```
```

## 참고 사항(선택)
- 사랑해요

# 체크 리스트

- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
