### PR TITLE
[#121] feat: SwipeView에 통계창 연결하기 

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,7 +32,7 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.17.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '10.18.0'
 
   target 'RunnerTests' do
     inherit! :search_paths

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,59 +7,59 @@ PODS:
     - AppAuth/Core
   - camera_avfoundation (0.0.1):
     - Flutter
-  - cloud_firestore (4.13.1):
-    - Firebase/Firestore (= 10.17.0)
+  - cloud_firestore (4.13.2):
+    - Firebase/Firestore (= 10.18.0)
     - firebase_core
     - Flutter
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - Firebase/Auth (10.17.0):
+  - Firebase/Auth (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.17.0)
-  - Firebase/CoreOnly (10.17.0):
-    - FirebaseCore (= 10.17.0)
-  - Firebase/Firestore (10.17.0):
+    - FirebaseAuth (~> 10.18.0)
+  - Firebase/CoreOnly (10.18.0):
+    - FirebaseCore (= 10.18.0)
+  - Firebase/Firestore (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.17.0)
-  - Firebase/Storage (10.17.0):
+    - FirebaseFirestore (~> 10.18.0)
+  - Firebase/Storage (10.18.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.17.0)
-  - firebase_auth (4.14.0):
-    - Firebase/Auth (= 10.17.0)
+    - FirebaseStorage (~> 10.18.0)
+  - firebase_auth (4.14.1):
+    - Firebase/Auth (= 10.18.0)
     - firebase_core
     - Flutter
-  - firebase_core (2.22.0):
-    - Firebase/CoreOnly (= 10.17.0)
+  - firebase_core (2.23.0):
+    - Firebase/CoreOnly (= 10.18.0)
     - Flutter
-  - firebase_storage (11.5.1):
-    - Firebase/Storage (= 10.17.0)
+  - firebase_storage (11.5.2):
+    - Firebase/Storage (= 10.18.0)
     - firebase_core
     - Flutter
-  - FirebaseAppCheckInterop (10.17.0)
-  - FirebaseAuth (10.17.0):
+  - FirebaseAppCheckInterop (10.18.0)
+  - FirebaseAuth (10.18.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.17.0)
-  - FirebaseCore (10.17.0):
+  - FirebaseAuthInterop (10.18.0)
+  - FirebaseCore (10.18.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.17.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreExtension (10.18.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.17.0):
+  - FirebaseCoreInternal (10.18.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseFirestore (10.17.0):
-    - FirebaseFirestore/AutodetectLeveldb (= 10.17.0)
-  - FirebaseFirestore/AutodetectLeveldb (10.17.0):
+  - FirebaseFirestore (10.18.0):
+    - FirebaseFirestore/AutodetectLeveldb (= 10.18.0)
+  - FirebaseFirestore/AutodetectLeveldb (10.18.0):
     - FirebaseFirestore/Base
     - FirebaseFirestore/WithLeveldb
-  - FirebaseFirestore/Base (10.17.0)
-  - FirebaseFirestore/WithLeveldb (10.17.0):
+  - FirebaseFirestore/Base (10.18.0)
+  - FirebaseFirestore/WithLeveldb (10.18.0):
     - FirebaseFirestore/Base
-  - FirebaseStorage (10.17.0):
+  - FirebaseStorage (10.18.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -114,7 +114,7 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `10.17.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `10.18.0`)
   - Flutter (from `Flutter`)
   - flutter_native_image (from `.symlinks/plugins/flutter_native_image/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/ios`)
@@ -153,7 +153,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_storage/ios"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 10.17.0
+    :tag: 10.18.0
   Flutter:
     :path: Flutter
   flutter_native_image:
@@ -168,24 +168,24 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 10.17.0
+    :tag: 10.18.0
 
 SPEC CHECKSUMS:
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
   camera_avfoundation: 3125e8cd1a4387f6f31c6c63abb8a55892a9eeeb
-  cloud_firestore: c0e21891b99d3ac3d91abfe476ac88830a7c9939
-  Firebase: f4ac0b02927af9253ae094d23deecf0890da7374
-  firebase_auth: 6a41305f668ac6f9bcbefdedfcba5aacb8367e92
-  firebase_core: efc9455611b8769fa90fbdae5da182600bd6901c
-  firebase_storage: c10cf9a1c953d6cb41873c735f3740c43111b3c4
-  FirebaseAppCheckInterop: 534d033d8d0436b4ab066a8205013d271e18a2b9
-  FirebaseAuth: 8d285d9f6e39cc8e23be53a4edd83a923ea629d8
-  FirebaseAuthInterop: 86bc376e41419f2dc05c16aa42fe8301171a93aa
-  FirebaseCore: 534544dd98cabcf4bf8598d88ec683b02319a528
-  FirebaseCoreExtension: 47720bb330d7041047c0935a34a3a4b92f818074
-  FirebaseCoreInternal: 2cf9202e226e3f78d2bf6d56c472686b935bfb7f
-  FirebaseFirestore: 908c26cb057c0147dd61c990da292aee7e605d8e
-  FirebaseStorage: 4af6f9ea67b6a8e4e3cbd75e006b4776a50e8b12
+  cloud_firestore: 20bb019115acfc53278ed4c8bc5ddda77fc673bb
+  Firebase: 414ad272f8d02dfbf12662a9d43f4bba9bec2a06
+  firebase_auth: 88053a759923970e580789d167a43b6031568ef5
+  firebase_core: 29d66baf806970cda37c93621b27cd369b27db1b
+  firebase_storage: a66f6f57d1ab04fb0bff6993b211b7c89f24e759
+  FirebaseAppCheckInterop: 3cd914842ba46f4304050874cd284de82f154ffd
+  FirebaseAuth: 12314b438fa76048540c8fb86d6cfc9e08595176
+  FirebaseAuthInterop: 5818713dcd7239beb96c1125e4b14d6a5a910e5f
+  FirebaseCore: 2322423314d92f946219c8791674d2f3345b598f
+  FirebaseCoreExtension: 62b201498aa10535801cdf3448c7f4db5e24ed80
+  FirebaseCoreInternal: 8eb002e564b533bdcf1ba011f33f2b5c10e2ed4a
+  FirebaseFirestore: 584e3f563142f63d20e9ec9c505370d674d44eba
+  FirebaseStorage: 8333c4b183764cdd170d9539a61322b71c23adff
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_native_image: 9c0b7451838484458e5b0fae007b86a4c2d4bdfe
   google_sign_in_ios: 1256ff9d941db546373826966720b0c24804bcdd
@@ -199,6 +199,6 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
 
-PODFILE CHECKSUM: 534410671fdcc872655e97878536cb04151ed90a
+PODFILE CHECKSUM: 812bb7698d90a99ed11ff6edabbbdd547dacf130
 
 COCOAPODS: 1.14.2

--- a/lib/features/live_writing/domain/models/confirm_post_model.dart
+++ b/lib/features/live_writing/domain/models/confirm_post_model.dart
@@ -32,7 +32,7 @@ class ConfirmPostModel with _$ConfirmPostModel {
     @Default('')
     String? id,
     required String? resolutionGoalStatement,
-    required DocumentReference<Map<String, dynamic>>? resolutionId,
+    required String? resolutionId,
     required String? title,
     required String? content,
     required String? imageUrl,

--- a/lib/features/live_writing/domain/models/confirm_post_model.freezed.dart
+++ b/lib/features/live_writing/domain/models/confirm_post_model.freezed.dart
@@ -23,8 +23,7 @@ mixin _$ConfirmPostModel {
   @JsonKey(includeFromJson: false, includeToJson: false)
   String? get id => throw _privateConstructorUsedError;
   String? get resolutionGoalStatement => throw _privateConstructorUsedError;
-  DocumentReference<Map<String, dynamic>>? get resolutionId =>
-      throw _privateConstructorUsedError;
+  String? get resolutionId => throw _privateConstructorUsedError;
   String? get title => throw _privateConstructorUsedError;
   String? get content => throw _privateConstructorUsedError;
   String? get imageUrl => throw _privateConstructorUsedError;
@@ -50,7 +49,7 @@ abstract class $ConfirmPostModelCopyWith<$Res> {
   $Res call(
       {@JsonKey(includeFromJson: false, includeToJson: false) String? id,
       String? resolutionGoalStatement,
-      DocumentReference<Map<String, dynamic>>? resolutionId,
+      String? resolutionId,
       String? title,
       String? content,
       String? imageUrl,
@@ -100,7 +99,7 @@ class _$ConfirmPostModelCopyWithImpl<$Res, $Val extends ConfirmPostModel>
       resolutionId: freezed == resolutionId
           ? _value.resolutionId
           : resolutionId // ignore: cast_nullable_to_non_nullable
-              as DocumentReference<Map<String, dynamic>>?,
+              as String?,
       title: freezed == title
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
@@ -152,7 +151,7 @@ abstract class _$$ConfirmPostModelImplCopyWith<$Res>
   $Res call(
       {@JsonKey(includeFromJson: false, includeToJson: false) String? id,
       String? resolutionGoalStatement,
-      DocumentReference<Map<String, dynamic>>? resolutionId,
+      String? resolutionId,
       String? title,
       String? content,
       String? imageUrl,
@@ -200,7 +199,7 @@ class __$$ConfirmPostModelImplCopyWithImpl<$Res>
       resolutionId: freezed == resolutionId
           ? _value.resolutionId
           : resolutionId // ignore: cast_nullable_to_non_nullable
-              as DocumentReference<Map<String, dynamic>>?,
+              as String?,
       title: freezed == title
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
@@ -283,7 +282,7 @@ class _$ConfirmPostModelImpl implements _ConfirmPostModel {
   @override
   final String? resolutionGoalStatement;
   @override
-  final DocumentReference<Map<String, dynamic>>? resolutionId;
+  final String? resolutionId;
   @override
   final String? title;
   @override
@@ -386,7 +385,7 @@ abstract class _ConfirmPostModel implements ConfirmPostModel {
   factory _ConfirmPostModel(
       {@JsonKey(includeFromJson: false, includeToJson: false) final String? id,
       required final String? resolutionGoalStatement,
-      required final DocumentReference<Map<String, dynamic>>? resolutionId,
+      required final String? resolutionId,
       required final String? title,
       required final String? content,
       required final String? imageUrl,
@@ -406,7 +405,7 @@ abstract class _ConfirmPostModel implements ConfirmPostModel {
   @override
   String? get resolutionGoalStatement;
   @override
-  DocumentReference<Map<String, dynamic>>? get resolutionId;
+  String? get resolutionId;
   @override
   String? get title;
   @override

--- a/lib/features/live_writing/domain/models/confirm_post_model.g.dart
+++ b/lib/features/live_writing/domain/models/confirm_post_model.g.dart
@@ -10,8 +10,7 @@ _$ConfirmPostModelImpl _$$ConfirmPostModelImplFromJson(
         Map<String, dynamic> json) =>
     _$ConfirmPostModelImpl(
       resolutionGoalStatement: json['resolutionGoalStatement'] as String?,
-      resolutionId:
-          const DocumentReferenceJsonConverter().fromJson(json['resolutionId']),
+      resolutionId: json['resolutionId'] as String?,
       title: json['title'] as String?,
       content: json['content'] as String?,
       imageUrl: json['imageUrl'] as String?,
@@ -31,8 +30,7 @@ Map<String, dynamic> _$$ConfirmPostModelImplToJson(
         _$ConfirmPostModelImpl instance) =>
     <String, dynamic>{
       'resolutionGoalStatement': instance.resolutionGoalStatement,
-      'resolutionId':
-          const DocumentReferenceJsonConverter().toJson(instance.resolutionId),
+      'resolutionId': instance.resolutionId,
       'title': instance.title,
       'content': instance.content,
       'imageUrl': instance.imageUrl,

--- a/lib/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart
+++ b/lib/features/live_writing_waiting/presentation/view/widget/live_waiting_avatar_animation_widget.dart
@@ -1,12 +1,14 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:wehavit/common/models/user_model/user_model.dart';
 
 class LiveWaitingAvatarAnimatingWidget extends StatefulWidget {
-  LiveWaitingAvatarAnimatingWidget({super.key, required this.userImageUrl});
+  const LiveWaitingAvatarAnimatingWidget({
+    super.key,
+    required this.userImageUrl,
+  });
 
-  String userImageUrl;
+  final String userImageUrl;
 
   @override
   State<LiveWaitingAvatarAnimatingWidget> createState() =>
@@ -87,7 +89,7 @@ class _LiveWaitingAvatarAnimatingWidgetState
               ),
               fit: BoxFit.cover,
             ),
-            borderRadius: BorderRadius.all(Radius.circular(100.0)),
+            borderRadius: const BorderRadius.all(Radius.circular(100.0)),
             border: Border.all(
               color: Colors.white,
               width: 4.0,

--- a/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
+++ b/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
@@ -118,7 +118,7 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
           .collection(FirebaseCollectionName.confirmPosts)
           .where(
             FirebaseConfirmPostFieldName.resolutionId,
-            isEqualTo: FirebaseFirestore.instance.doc('/$resolutionId'),
+            isEqualTo: resolutionId,
           )
           .get();
 

--- a/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
@@ -52,7 +52,7 @@ class ResolutionLinearGaugeGraphWidget extends StatelessWidget {
       value: value,
       enableAnimation: false,
       child: Container(
-        constraints: BoxConstraints(maxHeight: 30),
+        constraints: const BoxConstraints(maxHeight: 30),
         width: 13,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(4),

--- a/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
+++ b/lib/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart
@@ -52,7 +52,7 @@ class ResolutionLinearGaugeGraphWidget extends StatelessWidget {
       value: value,
       enableAnimation: false,
       child: Container(
-        height: 30,
+        constraints: BoxConstraints(maxHeight: 30),
         width: 13,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(4),

--- a/lib/features/swipe_view/presentation/model/swipe_view_model.dart
+++ b/lib/features/swipe_view/presentation/model/swipe_view_model.dart
@@ -44,4 +44,7 @@ class SwipeViewModel {
   bool isLayoutGrowed = true;
   late AnimationController animationController;
   late Animation animation;
+
+  // Varaibles For Graph
+  List<Future<List<ConfirmPostModel>>> confirmPostList = [];
 }

--- a/lib/features/swipe_view/presentation/provider/swipe_view_confirm_post_list_provider.dart
+++ b/lib/features/swipe_view/presentation/provider/swipe_view_confirm_post_list_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:wehavit/common/errors/failure.dart';
+import 'package:wehavit/common/utils/custom_types.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
+import 'package:wehavit/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart';
+
+final swipeViewConfirmPostListProvider = StateNotifierProvider<
+    SwipeViewConfirmPostListProvider, Future<List<ConfirmPostModel>>>(
+  (ref) => SwipeViewConfirmPostListProvider(ref),
+);
+
+class SwipeViewConfirmPostListProvider
+    extends StateNotifier<Future<List<ConfirmPostModel>>> {
+  SwipeViewConfirmPostListProvider(Ref ref) : super(Future(() => [])) {
+    getConfirmPostListForResolutionIdUsecase =
+        ref.watch(getConfirmPostListForResolutionIdUsecaseProvider);
+  }
+
+  late final GetConfirmPostListForResolutionIdUsecase
+      getConfirmPostListForResolutionIdUsecase;
+
+  Future<List<ConfirmPostModel>> getConfirmPostListFor({
+    required String resolutionId,
+  }) async {
+    final confirmListFetchResult =
+        await getConfirmPostListForResolutionIdUsecase(resolutionId);
+
+    return Future(
+      () => confirmListFetchResult.fold(
+        (failure) => [],
+        (modelList) => modelList,
+      ),
+    );
+  }
+}

--- a/lib/features/swipe_view/presentation/provider/swipe_view_confirm_post_list_provider.dart
+++ b/lib/features/swipe_view/presentation/provider/swipe_view_confirm_post_list_provider.dart
@@ -1,7 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fpdart/fpdart.dart';
-import 'package:wehavit/common/errors/failure.dart';
-import 'package:wehavit/common/utils/custom_types.dart';
 import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/my_page/domain/usecases/get_confirm_post_list_for_resolution_id.dart';
 

--- a/lib/features/swipe_view/presentation/screen/swipe_view.dart
+++ b/lib/features/swipe_view/presentation/screen/swipe_view.dart
@@ -377,7 +377,7 @@ class SwipeViewState extends ConsumerState<SwipeView>
       vsync: this,
       duration: const Duration(milliseconds: 200),
     );
-    _swipeViewModel.animation = Tween<double>(begin: 0, end: 100).animate(
+    _swipeViewModel.animation = Tween<double>(begin: 0, end: 130).animate(
       CurvedAnimation(
         parent: _swipeViewModel.animationController,
         curve: Curves.linear,

--- a/lib/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart
+++ b/lib/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart
@@ -45,21 +45,26 @@ class _ResolutionDashboardWidgetState
                   if (snapshot.hasData) {
                     return Column(
                       children: [
-                        // const SizedBox(height: 20),
-                        Container(
-                          padding: const EdgeInsets.all(2),
-                          decoration: const BoxDecoration(color: Colors.white),
-                          child: ResolutionLinearGaugeGraphWidget(
-                            sourceData: snapshot.data!,
-                            lastPeriod: false,
+                        Expanded(
+                          child: Container(
+                            padding: const EdgeInsets.all(2),
+                            decoration:
+                                const BoxDecoration(color: Colors.white),
+                            child: ResolutionLinearGaugeGraphWidget(
+                              sourceData: snapshot.data!,
+                              lastPeriod: false,
+                            ),
                           ),
                         ),
-                        Container(
-                          padding: const EdgeInsets.all(2),
-                          decoration: const BoxDecoration(color: Colors.white),
-                          child: ResolutionLinearGaugeGraphWidget(
-                            sourceData: snapshot.data!,
-                            lastPeriod: true,
+                        Expanded(
+                          child: Container(
+                            padding: const EdgeInsets.all(2),
+                            decoration:
+                                const BoxDecoration(color: Colors.white),
+                            child: ResolutionLinearGaugeGraphWidget(
+                              sourceData: snapshot.data!,
+                              lastPeriod: true,
+                            ),
                           ),
                         ),
                       ],

--- a/lib/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart
+++ b/lib/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
-import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 import 'package:wehavit/features/my_page/presentation/widgets/resolution_doughnut_graph_widget.dart';
 import 'package:wehavit/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart';
 

--- a/lib/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart
+++ b/lib/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
+import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
+import 'package:wehavit/features/my_page/presentation/widgets/resolution_doughnut_graph_widget.dart';
+import 'package:wehavit/features/my_page/presentation/widgets/resolution_linear_gauge_graph_widget.dart';
+
+class SwipeDashboardWidget extends ConsumerStatefulWidget {
+  const SwipeDashboardWidget({
+    super.key,
+    required this.confirmPostList,
+  });
+
+  final Future<List<ConfirmPostModel>> confirmPostList;
+
+  @override
+  ConsumerState<SwipeDashboardWidget> createState() =>
+      _ResolutionDashboardWidgetState();
+}
+
+class _ResolutionDashboardWidgetState
+    extends ConsumerState<SwipeDashboardWidget> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      decoration: const BoxDecoration(
+        color: Colors.green,
+        borderRadius: BorderRadius.all(Radius.circular(15)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Expanded(
+            flex: 2,
+            child: Container(
+              margin: const EdgeInsets.all(16),
+              child: FutureBuilder<List<ConfirmPostModel>>(
+                future: widget.confirmPostList,
+                builder: (context, snapshot) {
+                  if (snapshot.hasData) {
+                    return Column(
+                      children: [
+                        // const SizedBox(height: 20),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: const BoxDecoration(color: Colors.white),
+                          child: ResolutionLinearGaugeGraphWidget(
+                            sourceData: snapshot.data!,
+                            lastPeriod: false,
+                          ),
+                        ),
+                        Container(
+                          padding: const EdgeInsets.all(2),
+                          decoration: const BoxDecoration(color: Colors.white),
+                          child: ResolutionLinearGaugeGraphWidget(
+                            sourceData: snapshot.data!,
+                            lastPeriod: true,
+                          ),
+                        ),
+                      ],
+                    );
+                  } else if (snapshot.hasError) {
+                    return const Placeholder();
+                  } else {
+                    return Container();
+                  }
+                },
+              ),
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(right: 16.0),
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: FutureBuilder<List<ConfirmPostModel>>(
+                  future: widget.confirmPostList,
+                  builder: (context, snapshot) {
+                    if (snapshot.hasData) {
+                      return ResolutionDoughnutGraphWidget(
+                        sourceData: snapshot.data!,
+                      );
+                    } else if (snapshot.hasError) {
+                      return const Placeholder();
+                    } else {
+                      return Container();
+                    }
+                  },
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/swipe_view/presentation/screen/widget/swipe_view_cell.dart
+++ b/lib/features/swipe_view/presentation/screen/widget/swipe_view_cell.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/models/user_model/user_model.dart';
-import 'package:wehavit/common/utils/custom_types.dart';
 import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/swipe_view/presentation/model/swipe_view_model.dart';
 import 'package:wehavit/features/swipe_view/presentation/provider/swipe_view_confirm_post_list_provider.dart';

--- a/lib/features/swipe_view/presentation/screen/widget/swipe_view_cell.dart
+++ b/lib/features/swipe_view/presentation/screen/widget/swipe_view_cell.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/models/user_model/user_model.dart';
+import 'package:wehavit/common/utils/custom_types.dart';
 import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/swipe_view/presentation/model/swipe_view_model.dart';
+import 'package:wehavit/features/swipe_view/presentation/provider/swipe_view_confirm_post_list_provider.dart';
 import 'package:wehavit/features/swipe_view/presentation/provider/swipe_view_model_provider.dart';
+import 'package:wehavit/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart';
 
 class SwipeViewCellWidget extends ConsumerStatefulWidget {
   const SwipeViewCellWidget({super.key, required this.model});
@@ -17,6 +20,7 @@ class SwipeViewCellWidget extends ConsumerStatefulWidget {
 
 class _SwipeViewCellWidgetState extends ConsumerState<SwipeViewCellWidget> {
   late final SwipeViewModel _swipeViewModel;
+  late final Future<List<ConfirmPostModel>> _confirmPostList;
 
   @override
   void initState() {
@@ -24,9 +28,14 @@ class _SwipeViewCellWidgetState extends ConsumerState<SwipeViewCellWidget> {
   }
 
   @override
-  void didChangeDependencies() {
+  Future<void> didChangeDependencies() async {
     super.didChangeDependencies();
     _swipeViewModel = ref.watch(swipeViewModelProvider);
+    _confirmPostList = ref.watch(swipeViewConfirmPostListProvider);
+
+    ref.read(swipeViewConfirmPostListProvider.notifier).getConfirmPostListFor(
+          resolutionId: widget.model.resolutionId!.id,
+        );
   }
 
   @override
@@ -120,8 +129,8 @@ class _SwipeViewCellWidgetState extends ConsumerState<SwipeViewCellWidget> {
               height: _swipeViewModel.animation.value,
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4.0),
-                child: Container(
-                  color: Colors.amber,
+                child: SwipeDashboardWidget(
+                  confirmPostList: _confirmPostList,
                 ),
               ),
             ),

--- a/lib/features/swipe_view/presentation/screen/widget/swipe_view_cell.dart
+++ b/lib/features/swipe_view/presentation/screen/widget/swipe_view_cell.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/models/user_model/user_model.dart';
 import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
 import 'package:wehavit/features/swipe_view/presentation/model/swipe_view_model.dart';
-import 'package:wehavit/features/swipe_view/presentation/provider/swipe_view_confirm_post_list_provider.dart';
 import 'package:wehavit/features/swipe_view/presentation/provider/swipe_view_model_provider.dart';
 import 'package:wehavit/features/swipe_view/presentation/screen/widget/swipe_dashboard_widget.dart';
 
@@ -19,7 +18,6 @@ class SwipeViewCellWidget extends ConsumerStatefulWidget {
 
 class _SwipeViewCellWidgetState extends ConsumerState<SwipeViewCellWidget> {
   late final SwipeViewModel _swipeViewModel;
-  late final Future<List<ConfirmPostModel>> _confirmPostList;
 
   @override
   void initState() {
@@ -30,11 +28,6 @@ class _SwipeViewCellWidgetState extends ConsumerState<SwipeViewCellWidget> {
   Future<void> didChangeDependencies() async {
     super.didChangeDependencies();
     _swipeViewModel = ref.watch(swipeViewModelProvider);
-    _confirmPostList = ref.watch(swipeViewConfirmPostListProvider);
-
-    ref.read(swipeViewConfirmPostListProvider.notifier).getConfirmPostListFor(
-          resolutionId: widget.model.resolutionId!.id,
-        );
   }
 
   @override
@@ -129,7 +122,8 @@ class _SwipeViewCellWidgetState extends ConsumerState<SwipeViewCellWidget> {
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4.0),
                 child: SwipeDashboardWidget(
-                  confirmPostList: _confirmPostList,
+                  confirmPostList: _swipeViewModel
+                      .confirmPostList[_swipeViewModel.currentCellIndex],
                 ),
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -696,30 +696,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: f38a2c91c12f31726ca13015fbab3d2e9440edcb7c17b8b36ed9b85ed6eee6a2
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.0.11"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: "23770c69594f5260a79fe9d84e29f8b175d1b05d128e751c904b3cdf910e5dfc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.9"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: b06739349ec2477e943055aea30172c5c7000225f79dad4702e2ec0eda79a6ff
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
   lints:
     dependency: transitive
     description:
@@ -748,18 +724,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -1041,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.11.0"
   state_notifier:
     dependency: transitive
     description:
@@ -1057,10 +1033,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -1113,10 +1089,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.0"
   timing:
     dependency: transitive
     description:
@@ -1169,10 +1145,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1206,5 +1182,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.1.3 <4.0.0"
   flutter: ">=3.13.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "8942974ee5dc932427704ede5e0db8b5f2b8f22172964544b56e6bd37f6c3634"
+      sha256: dd68ecea9f1e3556d385521bd21c7bafd6311a8c1e11abe2595ca27974f468ee
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.12"
+    version: "1.3.13"
   analyzer:
     dependency: transitive
     description:
@@ -213,34 +213,34 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: fabfa9b20e752ea55841b0177620a817baf3c7cd12854f339f7daadb6969ee5a
+      sha256: ea38eb00eadeec0525ca5239f7513d5410eb5eebeb84f718cb0d221c96ac3e81
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.1"
+    version: "4.13.2"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "32cfa6cebf3408e541f074083fa429505af855896425eeab1c4f13edc3f68450"
+      sha256: "8dcb8d201453ebf743eb937a42aa755dfebdc609f6aede1f54d46efb6b6267a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.0.6"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: d8e36c1a60c69eb6d5bc239e497a1f284627ef8eb42258776bbfc98ce615e869
+      sha256: f0370f7953d663532f66f6fc71e0493fd65b76aeace71bbeeafa2eada604a070
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.5"
+    version: "3.8.6"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
+      sha256: b2151ce26a06171005b379ecff6e08d34c470180ffe16b8e14b6d52be292b55f
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.0"
   collection:
     dependency: transitive
     description:
@@ -285,26 +285,26 @@ packages:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: f9a828b696930cf8307f9a3617b2b65c9b370e484dc845d69100cadb77506778
+      sha256: "198ec6b8e084d22f508a76556c9afcfb71706ad3f42b083fe0ee923351a96d90"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "0.5.7"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: c6f656a4d83385fc0656ae60410ed06bb382898c45627bfb8bbaa323aea97883
+      sha256: dfcfa987d2bd9d0ba751ef4bdef0f6c1aa0062f2a67fe716fd5f3f8b709d6418
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "0.5.7"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: e20a67737adcf0cf2465e734dd624af535add11f9edd1f2d444909b5b0749650
+      sha256: f84c3fe2f27ef3b8831953e477e59d4a29c2952623f9eac450d7b40d9cdd94cc
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "0.5.7"
   dart_style:
     dependency: transitive
     description:
@@ -349,34 +349,34 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: a9281f9b149ad4cffbfe91725ee5159c63aca2f27c05e2e87052fc240abe212c
+      sha256: db5014f5dc1f34f3454cf6b984d2d63712a1a93bba5b1a96e5cac67d6e575fb1
       url: "https://pub.dev"
     source: hosted
-    version: "4.14.0"
+    version: "4.14.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: def138b34bb97310ff748d1864f3ccd5b49d7424f35825f0df5455f16218ba99
+      sha256: "4d1973e2fcbf7d8665ed9b0766a617d45c9eb5dd08c1a6218ddfe45565fd777b"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.4"
+    version: "7.0.5"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: e5fbb3453fbfff0dd8dfed5e3560248391f76a4c59ae9b331704e3443cffde77
+      sha256: "78899b86647dd91f520fe9cb42e93eb0d696cda7375cbb2225c6dfc5cce631aa"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.7"
+    version: "5.8.8"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "45f3f9babfc6f56fb94c3cd11584cf3c9672868228373b699b94427010e01dc3"
+      sha256: "471b46ea6a9af503184d4de691566887daedd312aec5baac5baa42d819f56446"
       url: "https://pub.dev"
     source: hosted
-    version: "2.22.0"
+    version: "2.23.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -397,26 +397,26 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_storage
-      sha256: "2535c38b915d1fa1d2b1f3ee0d84b8a2de49c7f03887cbd74f92d5cd0960ba05"
+      sha256: "4fd6b8ff3db962512503bd0ea4df0cfb0ed6f7c8549c16e8b9f5f51cef68a23b"
       url: "https://pub.dev"
     source: hosted
-    version: "11.5.1"
+    version: "11.5.2"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
-      sha256: c25b2a2d09bc8a93b32d99c712e11caa37aa218168a2a9629f3b0dc77a696e03
+      sha256: c9988b196fd0d298dde89d22b3fd4e1bb69ef284717394ba3d7190565b9554fa
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "5.1.0"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
-      sha256: "8ee35c3ba8507fa87341b81fadd8496b14f1045b0f996e8e76968f4850d0c8cf"
+      sha256: a4370c1432b11381440352116fff10e07af39d504629de7fba4627fb5aeeecdd
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.13"
+    version: "3.6.14"
   fixnum:
     dependency: transitive
     description:
@@ -474,10 +474,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "49b55e8a467229eedb801bd0864baa7f891c39cc00f790189ba8479e9ad0fa06"
+      sha256: d261b0f2461e0595b96f92ed807841eb72cea84a6b12b8fd0c76e5ed803e7921
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.8"
   flutter_screenutil:
     dependency: "direct main"
     description:
@@ -620,10 +620,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: "4fee3c75360e353128149df23ed93414477082bb130f9e23723b1a79a54bc6d0"
+      sha256: b271e06606e718cf8185db9a792d1af00e2049e7bf5da09583654e020c00fbaa
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.8"
   hotreloader:
     dependency: transitive
     description:
@@ -820,10 +820,10 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
+      sha256: f4f88d4a900933e7267e2b353594774fc0d07fb072b47eedcd5b54e1ea3269f8
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.7"
   pool:
     dependency: transitive
     description:
@@ -860,42 +860,42 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "01fa385aa5d6db42fd602d8c400c28ae1c83d1fd6fbae1cbf0f4c78bac58d4b2"
+      sha256: "08451ddbaad6eae73e2422d8109775885623340d721c6637b8719c9f4b478848"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.8"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "22a089135785f27e601075023f93c6622c43ef28c3ba1bef303cfbc314028e64"
+      sha256: d4dabc35358413bf4611fcb6abb46308a67c4ef4cd5e69fd3367b11925c59f57
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.0"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "670dc172c835a1638fe942552449f99adb40ea3faa2d4988081db3c2bd1a4891"
+      sha256: "02c9bced96ed3ed8d9970820d1ce7b16600955bc01aa8b2276f09dd3d9d29ed9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: f7c897ffac15f8b845b99ef88a1c8923df74ac8a2a96cd53eb9ecd5459baac27
+      sha256: "94b6c49bba879729611d690d434796e3b4e7c72a27e88b482b92c505e90f90d9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.6"
+    version: "2.3.8"
   riverpod_lint:
     dependency: "direct dev"
     description:
       name: riverpod_lint
-      sha256: a2602c6b7fc34a7e36be63ce6399ed0cab66827b6649ba4382e218df34b72754
+      sha256: "6fc64ae102ba39b0889b7aa7f4ef6c5a8f71a2ad215b90c787f319a9407a128b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.6"
   rxdart:
     dependency: transitive
     description:
@@ -1057,26 +1057,26 @@ packages:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_charts
-      sha256: "300afb7ffb157207d88c489728bb043e3de2e3a399a34835babacf7841cab897"
+      sha256: "719af736c2fa189a0d6574e0bf23bc32df8ee9589980d456bcf391a8bd55aa1b"
       url: "https://pub.dev"
     source: hosted
-    version: "23.1.44"
+    version: "23.2.4"
   syncfusion_flutter_core:
     dependency: transitive
     description:
       name: syncfusion_flutter_core
-      sha256: "6f3056c548f4e039a8994904836881753c4c7643cd2142d3c226fcb45ec200fe"
+      sha256: "8a1220f978491f56431c66dacf1bb97bf2abcd1458b542fe0dfbf1a630c67260"
       url: "https://pub.dev"
     source: hosted
-    version: "23.1.44"
+    version: "23.2.4"
   syncfusion_flutter_gauges:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_gauges
-      sha256: dc3165a56990919d2de70c09d7c52ee6f8e8964c264e5a8b7fa5ac17b1d9e3dc
+      sha256: "0ac8a518ffe630c33c61c1576b40ddad080fe85a007de4f0b1be48bcdddb5fd0"
       url: "https://pub.dev"
     source: hosted
-    version: "23.1.44"
+    version: "23.2.4"
   term_glyph:
     dependency: transitive
     description:
@@ -1129,10 +1129,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a13d5503b4facefc515c8c587ce3cf69577a7b064a9f1220e005449cf1f64aad
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -1161,10 +1161,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
+      sha256: "7c99c0e1e2fa190b48d25c81ca5e42036d5cac81430ef249027d97b0935c553f"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.9"
+    version: "5.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   flutter_native_image: ^0.0.6+1
   path: ^1.8.3
   path_provider: ^2.1.1
-  firebase_storage: ^11.5.0
+  firebase_storage: ^11.5.2
   intl: ^0.18.1
 
 dev_dependencies:


### PR DESCRIPTION
# 설명
MyPage에서 작업했던 위젯을 기반으로 SwipeView에서 각 인증글에 대한 통계 정보를 간략하게 확인할 수 있도록 그래프 데이터 로직 작성하였음. 

- #119 을 기반으로
- #121 을 작업하였음.

Closes #119, #121 

## 작업 종류
- [ ] 버그 수정 (다른 기능에 영향을 미치지 않는 수정)
- [x] 새로운 feature (다른 기존 기능에 영향을 미치는 기능 추가)
- [ ] Breaking change (다른 기존 기능에 영향을 미치는 수정)
- [ ] 문서 수정
- [ ] 기타 (please describe):

# 작업 내역
- #119 에서 사용한 위젯 코드를 재사용하여 SwipeView에 적용
- 각 ConfirmPost에 대해 ConfirmPostList를 가져오는 로직을 작성
- View Constraint 수정으로 View Layout Exception이 발생하지 않도록 개선

## 작업 결과물
|데이터 가져와 그래프 그려주기|키보드 여닫기에 대한 뷰 레이아웃 적용|
|---|---|
|![Simulator Screen Recording - iPhone 13 Pro - 2023-11-22 at 20 14 27](https://github.com/cau-bootcamp/wehavit/assets/39216546/c7ee7c8a-c5e2-4efc-940f-dfcce7006600)|![Simulator Screen Recording - iPhone 13 Pro - 2023-11-22 at 20 25 54](https://github.com/cau-bootcamp/wehavit/assets/39216546/51ca6340-1bc5-4d5f-96fa-57465c5e1ad1)|


## 참고 사항(선택)
- ConfirmPostModel의 resolutionId가 DocumentReference type으로 "\users\USER_ID\resolutions\RESOLUTION_ID" 의 형태로 저장되어 있는 부분을 String type으로 문서 id에 해당하는 ResolutionId 만 저장하고 불러오도록 모델 및 파이어베이스 구조를 수정하였습니다. 
- Firebase 패키지의 버전이 몰래 11.5.0 → 11.5.2로 올라가버려서, Firebase 패키지들의 버전이 10.18.0으로 올라가버렸습니다... ~흑흑 왜지왜지...~ 버전 내려서 pod setting 다시 하려고 해도 10.18.0으로 패키지 버전이 남아있는 상황이예요. 그래서 ios의 podfile에서 빌드 속도 향상 코드에서도 10.18.0으로 변경해주셔야 합니다. 요 PR에 해당 사항 반영해뒀습니다. 


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
