### PR TITLE
[#102] feat: 늦은글 인증 로직 구현

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -94,6 +94,8 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (2.3.0)
+  - image_picker_ios (0.0.1):
+    - Flutter
   - nanopb (2.30909.1):
     - nanopb/decode (= 2.30909.1)
     - nanopb/encode (= 2.30909.1)
@@ -118,6 +120,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_native_image (from `.symlinks/plugins/flutter_native_image/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
@@ -160,6 +163,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_image/ios"
   google_sign_in_ios:
     :path: ".symlinks/plugins/google_sign_in_ios/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   shared_preferences_foundation:
@@ -193,6 +198,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
+  image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4

--- a/lib/common/routers/route_location.dart
+++ b/lib/common/routers/route_location.dart
@@ -17,4 +17,5 @@ class RouteLocation {
   static const String swipeView = '/swipeView';
   static const String animationSampleView = '/animationSampleView';
   static const String liveWaitingSampleView = '/liveWaitingSampleView';
+  static const String lateWritingView = '/lateWritingView';
 }

--- a/lib/common/routers/route_provider.dart
+++ b/lib/common/routers/route_provider.dart
@@ -7,6 +7,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/features/effects/animation_sample_page.dart';
 import 'package:wehavit/features/features.dart';
 import 'package:wehavit/features/home/presentation/screens/home_screen.dart';
+import 'package:wehavit/features/late_writing/presentation/screen/late_writing_view.dart';
 import 'package:wehavit/features/live_writing/presentation/screens/live_writing_page.dart';
 import 'package:wehavit/features/live_writing_waiting/live_waiting_sample_view.dart';
 import 'package:wehavit/features/my_page/presentation/screens/add_resolution_screen.dart';
@@ -207,6 +208,18 @@ class LiveWaitingSampleViewRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const LiveWaitingSampleView();
+  }
+}
+
+@TypedGoRoute<LateWritingViewRoute>(path: LateWritingViewRoute.path)
+class LateWritingViewRoute extends GoRouteData {
+  const LateWritingViewRoute();
+
+  static const path = RouteLocation.lateWritingView;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const LateWritingView();
   }
 }
 

--- a/lib/common/routers/route_provider.g.dart
+++ b/lib/common/routers/route_provider.g.dart
@@ -18,6 +18,7 @@ List<RouteBase> get $appRoutes => [
       $swipeViewRoute,
       $animationSampleViewRoute,
       $liveWaitingSampleViewRoute,
+      $lateWritingViewRoute,
     ];
 
 RouteBase get $homeRoute => GoRouteData.$route(
@@ -256,6 +257,29 @@ extension $LiveWaitingSampleViewRouteExtension on LiveWaitingSampleViewRoute {
 
   String get location => GoRouteData.$location(
         '/liveWaitingSampleView',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $lateWritingViewRoute => GoRouteData.$route(
+      path: '/lateWritingView',
+      factory: $LateWritingViewRouteExtension._fromState,
+    );
+
+extension $LateWritingViewRouteExtension on LateWritingViewRoute {
+  static LateWritingViewRoute _fromState(GoRouterState state) =>
+      const LateWritingViewRoute();
+
+  String get location => GoRouteData.$location(
+        '/lateWritingView',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/lib/common/routers/test_page.dart
+++ b/lib/common/routers/test_page.dart
@@ -94,6 +94,12 @@ class TestPage extends ConsumerWidget {
               },
               buttonText: 'Live Waiting Sample View',
             ),
+            MoveButton(
+              onPressCallback: () async {
+                context.push('/lateWritingView');
+              },
+              buttonText: 'Late Writing View',
+            ),
           ],
         ),
       ),

--- a/lib/common/utils/firebase_collection_name.dart
+++ b/lib/common/utils/firebase_collection_name.dart
@@ -6,7 +6,7 @@ class FirebaseCollectionName {
   const FirebaseCollectionName._();
 
   static const users = 'users';
-  static final resolutions = FirebaseAuth.instance.currentUser != null
+  static final myResolutions = FirebaseAuth.instance.currentUser != null
       ? 'users/${FirebaseAuth.instance.currentUser?.uid}/resolutions'
       : 'invalid_address';
   static final friends = FirebaseAuth.instance.currentUser != null

--- a/lib/features/late_writing/domain/usecase/get_my_resolution_list_usecase.dart
+++ b/lib/features/late_writing/domain/usecase/get_my_resolution_list_usecase.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
+import 'package:wehavit/features/my_page/domain/repositories/resolution_repository.dart';
+import 'package:wehavit/features/my_page/domain/repositories/resolution_repository_provider.dart';
+
+final getMyResolutionListUsecaseProvider =
+    Provider<GetMyResolutionListUsecase>((ref) {
+  final resolutionRepository = ref.watch(resolutionRepositoryProvider);
+  return GetMyResolutionListUsecase(
+    resolutionRepository,
+  );
+});
+
+class GetMyResolutionListUsecase
+    extends UseCase<List<ResolutionModel>, NoParams> {
+  GetMyResolutionListUsecase(this._resolutionRepository);
+
+  final ResolutionRepository _resolutionRepository;
+
+  @override
+  EitherFuture<List<ResolutionModel>> call(NoParams params) {
+    return _resolutionRepository.getActiveResolutionModelList();
+  }
+}

--- a/lib/features/late_writing/domain/usecase/post_late_confirm_post_usecase.dart
+++ b/lib/features/late_writing/domain/usecase/post_late_confirm_post_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/features/live_writing/domain/models/confirm_post_model.dart';
+import 'package:wehavit/features/live_writing/domain/repositories/confirm_post_repository.dart';
+
+class PostLateConfirmPostUsecase extends UseCase<bool, ConfirmPostModel> {
+  PostLateConfirmPostUsecase(this._repository);
+
+  final ConfirmPostRepository _repository;
+  @override
+  EitherFuture<bool> call(ConfirmPostModel params) async {
+    return await _repository.createConfirmPost(params);
+  }
+}

--- a/lib/features/late_writing/presentation/model/late_writing_view_model.dart
+++ b/lib/features/late_writing/presentation/model/late_writing_view_model.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:wehavit/common/utils/custom_types.dart';
+import 'package:wehavit/features/live_writing/live_writing.dart';
+import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
+
+class LateWritingViewModel {
+  TextEditingController titleTextEditingController = TextEditingController();
+  TextEditingController contentTextEditingController = TextEditingController();
+
+  EitherFuture<List<ResolutionModel>> resolutionList = Future(
+    () => right([]),
+  );
+  int resolutionIndex = 0;
+
+  String? imageFileUrl;
+}

--- a/lib/features/late_writing/presentation/model/late_writing_view_model.dart
+++ b/lib/features/late_writing/presentation/model/late_writing_view_model.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/utils/custom_types.dart';
-import 'package:wehavit/features/live_writing/live_writing.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 
 class LateWritingViewModel {

--- a/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
+++ b/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
@@ -59,13 +59,14 @@ class LateWritingViewModelProvider extends StateNotifier<LateWritingViewModel> {
     );
   }
 
-  void getPhotoLibraryImage() async {
+  Future<String?> getPhotoLibraryImage() async {
     final pickedFile =
         await ImagePicker().pickImage(source: ImageSource.gallery);
     if (pickedFile != null) {
-      state.imageFileUrl = pickedFile.path;
+      return pickedFile.path;
     } else {
       debugPrint('이미지 선택안함');
+      return null;
     }
   }
 }

--- a/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
+++ b/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
@@ -1,0 +1,59 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/features/late_writing/domain/usecase/get_my_resolution_list_usecase.dart';
+import 'package:wehavit/features/late_writing/presentation/model/late_writing_view_model.dart';
+import 'package:wehavit/features/live_writing/live_writing.dart';
+import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
+
+final lateWritingViewModelProvider =
+    StateNotifierProvider<LateWritingViewModelProvider, LateWritingViewModel>(
+  (ref) {
+    final createPostUsecase = ref.watch(createPostUseCaseProvider);
+    final getMyResolutionListUsecase =
+        ref.watch(getMyResolutionListUsecaseProvider);
+
+    return LateWritingViewModelProvider(
+      createPostUsecase,
+      getMyResolutionListUsecase,
+    );
+  },
+);
+
+class LateWritingViewModelProvider extends StateNotifier<LateWritingViewModel> {
+  LateWritingViewModelProvider(
+    this._createPostUseCase,
+    this._getMyResolutionListUsecase,
+  ) : super(LateWritingViewModel()) {
+    state.resolutionList = _getMyResolutionListUsecase(NoParams());
+  }
+
+  final CreatePostUseCase _createPostUseCase;
+  final GetMyResolutionListUsecase _getMyResolutionListUsecase;
+
+  Future<void> postCurrentConfirmPost() async {
+    final fetchResult = await state.resolutionList;
+    final currentWritingResolutionModel = fetchResult
+        .getRight()
+        .fold(() => [], (t) => t)[state.resolutionIndex] as ResolutionModel;
+
+    _createPostUseCase(
+      ConfirmPostModel(
+        resolutionGoalStatement: currentWritingResolutionModel.goalStatement,
+        resolutionId: currentWritingResolutionModel.resolutionId,
+        title: state.titleTextEditingController.text,
+        content: state.contentTextEditingController.text,
+        imageUrl: state.imageFileUrl ?? '',
+        // TODO: OWNER, FAN, ResentStrike 넣어주는 로직 작성 필요함
+        owner: '',
+        fan: [],
+        recentStrike: 0,
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        attributes: {
+          'has_participated_live': false,
+          'has_rested': false,
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
+++ b/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/features/late_writing/domain/usecase/get_my_resolution_list_usecase.dart';
 import 'package:wehavit/features/late_writing/presentation/model/late_writing_view_model.dart';
 import 'package:wehavit/features/live_writing/live_writing.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
+import 'package:image_picker/image_picker.dart';
 
 final lateWritingViewModelProvider =
     StateNotifierProvider<LateWritingViewModelProvider, LateWritingViewModel>(
@@ -55,5 +57,15 @@ class LateWritingViewModelProvider extends StateNotifier<LateWritingViewModel> {
         },
       ),
     );
+  }
+
+  void getPhotoLibraryImage() async {
+    final pickedFile =
+        await ImagePicker().pickImage(source: ImageSource.gallery);
+    if (pickedFile != null) {
+      state.imageFileUrl = pickedFile.path;
+    } else {
+      debugPrint('이미지 선택안함');
+    }
   }
 }

--- a/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
+++ b/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/features/late_writing/domain/usecase/get_my_resolution_list_usecase.dart';
 import 'package:wehavit/features/late_writing/presentation/model/late_writing_view_model.dart';
 import 'package:wehavit/features/live_writing/live_writing.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
-import 'package:image_picker/image_picker.dart';
 
 final lateWritingViewModelProvider =
     StateNotifierProvider<LateWritingViewModelProvider, LateWritingViewModel>(

--- a/lib/features/late_writing/presentation/screen/late_writing_view.dart
+++ b/lib/features/late_writing/presentation/screen/late_writing_view.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/features/late_writing/presentation/provider/late_writing_view_provider.dart';
+import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
+
+class LateWritingView extends ConsumerStatefulWidget {
+  const LateWritingView({super.key});
+
+  @override
+  ConsumerState<LateWritingView> createState() => _LateWritingViewState();
+}
+
+class _LateWritingViewState extends ConsumerState<LateWritingView> {
+  late final viewModel = ref.watch(lateWritingViewModelProvider);
+  late final viewModelProvider =
+      ref.read(lateWritingViewModelProvider.notifier);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("title"),
+      ),
+      body: SafeArea(
+        left: true,
+        right: true,
+        minimum: EdgeInsets.all(8),
+        child: FutureBuilder(
+          future: viewModel.resolutionList,
+          builder: (context, snapshot) {
+            if (snapshot.hasData && snapshot.data!.isRight()) {
+              final resolutionList = snapshot.data!
+                  .getRight()
+                  .fold(() => [], (t) => t) as List<ResolutionModel>;
+              return SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Text("작성할 목표"),
+                          GestureDetector(
+                            onTapUp: (details) async {
+                              showResolutionSelectionList(
+                                context,
+                                resolutionList,
+                              );
+                            },
+                            child: Text(
+                              resolutionList[viewModel.resolutionIndex]
+                                  .goalStatement,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    // 제목
+                    Container(
+                      child: Column(
+                        children: [
+                          Text("Title"),
+                          TextFormField(
+                            controller: viewModel.titleTextEditingController,
+                          )
+                        ],
+                      ),
+                    ),
+                    // 내용
+                    Container(
+                      child: Column(
+                        children: [
+                          Text("Content"),
+                          TextFormField(
+                            controller: viewModel.contentTextEditingController,
+                          )
+                        ],
+                      ),
+                    ),
+                    // 사진
+                    Container(
+                      child: Column(children: [
+                        Visibility(
+                          visible: viewModel.imageFileUrl == null,
+                          child: Container(),
+                          replacement: Container(),
+                        )
+                      ]),
+                    ),
+
+                    Container(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                            onPressed: () async {
+                              viewModelProvider.postCurrentConfirmPost();
+                            },
+                            child: Text("Save"))),
+                  ],
+                ),
+              );
+            } else if (!snapshot.hasData) {
+              return CircularProgressIndicator();
+            } else if (snapshot.hasError || snapshot.data!.isLeft()) {
+              return const Center(
+                child: Text('DEBUG - SOMETHING WENT WRONG'),
+              );
+            } else {
+              return Placeholder();
+            }
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<dynamic> showResolutionSelectionList(
+      BuildContext context, List<ResolutionModel> resolutionList) {
+    return showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              vertical: 40.0,
+              horizontal: 16.0,
+            ),
+            child: Column(
+              children: List<Widget>.generate(
+                resolutionList.length,
+                (index) => Container(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      setState(() {
+                        viewModel.resolutionIndex = index;
+                      });
+                      Navigator.of(context).pop();
+                    },
+                    child: Text(
+                      resolutionList[index].goalStatement,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/late_writing/presentation/screen/late_writing_view.dart
+++ b/lib/features/late_writing/presentation/screen/late_writing_view.dart
@@ -14,11 +14,14 @@ class LateWritingView extends ConsumerStatefulWidget {
 }
 
 class _LateWritingViewState extends ConsumerState<LateWritingView> {
-  late final viewModel = ref.watch(lateWritingViewModelProvider);
-  late final viewModelProvider =
-      ref.read(lateWritingViewModelProvider.notifier);
+  late LateWritingViewModel viewModel;
+  late LateWritingViewModelProvider viewModelProvider;
+
   @override
   Widget build(BuildContext context) {
+    viewModel = ref.watch(lateWritingViewModelProvider);
+    viewModelProvider = ref.read(lateWritingViewModelProvider.notifier);
+
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
@@ -94,10 +97,49 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
                               ),
                               TitleAndContentFormWidget(viewModel: viewModel),
                               // 사진
-                              PhotoSelectWidget(
-                                viewModel: viewModel,
-                                viewModelProvider: viewModelProvider,
-                              ),
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 16.0),
+                                child: Container(
+                                  width: double.infinity,
+                                  height: 250,
+                                  decoration: BoxDecoration(
+                                    border: Border.all(color: Colors.grey),
+                                    borderRadius: const BorderRadius.all(
+                                      Radius.circular(10.0),
+                                    ),
+                                  ),
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.opaque,
+                                    onTapUp: (details) async {
+                                      viewModel.imageFileUrl =
+                                          await viewModelProvider
+                                              .getPhotoLibraryImage();
+                                      setState(() {});
+                                    },
+                                    child: Visibility(
+                                      visible: viewModel.imageFileUrl != null,
+                                      replacement: const Center(
+                                        child: Text('사진 추가하기'),
+                                      ),
+                                      child: Container(
+                                        decoration: const BoxDecoration(
+                                          borderRadius: BorderRadius.all(
+                                            Radius.circular(10.0),
+                                          ),
+                                        ),
+                                        clipBehavior: Clip.hardEdge,
+                                        child: Image(
+                                          image: FileImage(
+                                            File(viewModel.imageFileUrl ?? ''),
+                                          ),
+                                          fit: BoxFit.cover,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              )
                             ],
                           ),
                           // Expanded(
@@ -218,65 +260,6 @@ class TitleAndContentFormWidget extends StatelessWidget {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class PhotoSelectWidget extends StatelessWidget {
-  const PhotoSelectWidget({
-    super.key,
-    required this.viewModel,
-    required this.viewModelProvider,
-  });
-
-  final LateWritingViewModel viewModel;
-  final LateWritingViewModelProvider viewModelProvider;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 16.0),
-      child: Container(
-        width: double.infinity,
-        height: 250,
-        decoration: BoxDecoration(
-          border: Border.all(color: Colors.grey),
-          borderRadius: const BorderRadius.all(
-            Radius.circular(10.0),
-          ),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            vertical: 8.0,
-          ),
-          child: Visibility(
-            visible: viewModel.imageFileUrl != null,
-            replacement: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTapUp: (details) {
-                viewModelProvider.getPhotoLibraryImage();
-              },
-              child: const Center(
-                child: Text('사진 추가하기'),
-              ),
-            ),
-            child: Container(
-              decoration: const BoxDecoration(
-                borderRadius: BorderRadius.all(
-                  Radius.circular(10.0),
-                ),
-              ),
-              clipBehavior: Clip.hardEdge,
-              child: Image(
-                image: FileImage(
-                  File(viewModel.imageFileUrl ?? ''),
-                ),
-                fit: BoxFit.cover,
-              ),
-            ),
-          ),
         ),
       ),
     );

--- a/lib/features/late_writing/presentation/screen/late_writing_view.dart
+++ b/lib/features/late_writing/presentation/screen/late_writing_view.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path/path.dart';
 import 'package:wehavit/features/late_writing/presentation/model/late_writing_view_model.dart';
 import 'package:wehavit/features/late_writing/presentation/provider/late_writing_view_provider.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
@@ -23,15 +22,13 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
-        title: Text("title"),
+        title: const Text('title'),
       ),
       body: Padding(
         padding:
             EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
         child: SafeArea(
-          left: true,
-          right: true,
-          minimum: EdgeInsets.all(8),
+          minimum: const EdgeInsets.all(8),
           child: FutureBuilder(
             future: viewModel.resolutionList,
             builder: (context, snapshot) {
@@ -42,107 +39,99 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
                 return Stack(
                   children: [
                     SingleChildScrollView(
-                      padding: EdgeInsets.only(bottom: 40),
-                      child: Container(
-                        child: Column(
-                          children: [
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Container(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      const Padding(
-                                        padding:
-                                            EdgeInsets.symmetric(vertical: 8.0),
-                                        child: Text(
-                                          '작성할 목표',
-                                          style: TextStyle(fontSize: 24.0),
-                                        ),
+                      padding: const EdgeInsets.only(bottom: 40),
+                      child: Column(
+                        children: [
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Padding(
+                                    padding:
+                                        EdgeInsets.symmetric(vertical: 8.0),
+                                    child: Text(
+                                      '작성할 목표',
+                                      style: TextStyle(fontSize: 24.0),
+                                    ),
+                                  ),
+                                  GestureDetector(
+                                    onTapUp: (details) async {
+                                      showResolutionSelectionList(
+                                        context,
+                                        resolutionList,
+                                      );
+                                    },
+                                    child: Container(
+                                      height: 50,
+                                      width: double.infinity,
+                                      decoration: BoxDecoration(
+                                        border: Border.all(),
+                                        borderRadius:
+                                            BorderRadius.circular(10.0),
                                       ),
-                                      GestureDetector(
-                                        onTapUp: (details) async {
-                                          showResolutionSelectionList(
-                                            context,
-                                            resolutionList,
-                                          );
-                                        },
-                                        child: Container(
-                                          height: 50,
-                                          width: double.infinity,
-                                          decoration: BoxDecoration(
-                                            border: Border.all(),
-                                            borderRadius:
-                                                BorderRadius.circular(10.0),
-                                          ),
-                                          child: Center(
-                                            child: Padding(
-                                              padding:
-                                                  const EdgeInsets.all(8.0),
-                                              child: SizedBox(
-                                                width: double.infinity,
-                                                child: Text(
-                                                  resolutionList[viewModel
-                                                          .resolutionIndex]
-                                                      .goalStatement,
-                                                  textAlign: TextAlign.left,
-                                                ),
-                                              ),
+                                      child: Center(
+                                        child: Padding(
+                                          padding: const EdgeInsets.all(8.0),
+                                          child: SizedBox(
+                                            width: double.infinity,
+                                            child: Text(
+                                              resolutionList[
+                                                      viewModel.resolutionIndex]
+                                                  .goalStatement,
+                                              textAlign: TextAlign.left,
                                             ),
                                           ),
                                         ),
                                       ),
-                                    ],
+                                    ),
                                   ),
-                                ),
-                                SizedBox(
-                                  height: 16.0,
-                                ),
-                                TitleAndContentFormWidget(viewModel: viewModel),
-                                // 사진
-                                photoSelectWidget(
-                                  viewModel: viewModel,
-                                  viewModelProvider: viewModelProvider,
-                                ),
-                              ],
-                            ),
-                            // Expanded(
-                            //   child: Container(),
-                            // ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    Container(
-                      child: Column(
-                        children: [
-                          Expanded(
-                            child: Container(),
+                                ],
+                              ),
+                              const SizedBox(
+                                height: 16.0,
+                              ),
+                              TitleAndContentFormWidget(viewModel: viewModel),
+                              // 사진
+                              PhotoSelectWidget(
+                                viewModel: viewModel,
+                                viewModelProvider: viewModelProvider,
+                              ),
+                            ],
                           ),
-                          Container(
-                            width: double.infinity,
-                            child: ElevatedButton(
-                              onPressed: () async {
-                                viewModelProvider.postCurrentConfirmPost();
-                              },
-                              child: Text("Save"),
-                            ),
-                          ),
+                          // Expanded(
+                          //   child: Container(),
+                          // ),
                         ],
                       ),
-                    )
+                    ),
+                    Column(
+                      children: [
+                        Expanded(
+                          child: Container(),
+                        ),
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            onPressed: () async {
+                              viewModelProvider.postCurrentConfirmPost();
+                            },
+                            child: const Text('Save'),
+                          ),
+                        ),
+                      ],
+                    ),
                   ],
                 );
               } else if (!snapshot.hasData) {
-                return CircularProgressIndicator();
+                return const CircularProgressIndicator();
               } else if (snapshot.hasError || snapshot.data!.isLeft()) {
                 return const Center(
                   child: Text('DEBUG - SOMETHING WENT WRONG'),
                 );
               } else {
-                return Placeholder();
+                return const Placeholder();
               }
             },
           ),
@@ -152,7 +141,9 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
   }
 
   Future<dynamic> showResolutionSelectionList(
-      BuildContext context, List<ResolutionModel> resolutionList) {
+    BuildContext context,
+    List<ResolutionModel> resolutionList,
+  ) {
     return showModalBottomSheet(
       context: context,
       builder: (context) {
@@ -165,7 +156,7 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
             child: Column(
               children: List<Widget>.generate(
                 resolutionList.length,
-                (index) => Container(
+                (index) => SizedBox(
                   width: double.infinity,
                   child: ElevatedButton(
                     onPressed: () {
@@ -210,22 +201,22 @@ class TitleAndContentFormWidget extends StatelessWidget {
           children: [
             TextFormField(
               controller: viewModel.titleTextEditingController,
-              decoration: InputDecoration(
-                hintText: "제목을 입력해주세요",
+              decoration: const InputDecoration(
+                hintText: '제목을 입력해주세요',
                 border: InputBorder.none,
               ),
             ),
-            Divider(
+            const Divider(
               thickness: 2.0,
             ),
             TextFormField(
               controller: viewModel.contentTextEditingController,
               maxLines: 5,
-              decoration: InputDecoration(
-                hintText: "오늘의 실천에 대해 한마디!",
+              decoration: const InputDecoration(
+                hintText: '오늘의 실천에 대해 한마디!',
                 border: InputBorder.none,
               ),
-            )
+            ),
           ],
         ),
       ),
@@ -233,8 +224,8 @@ class TitleAndContentFormWidget extends StatelessWidget {
   }
 }
 
-class photoSelectWidget extends StatelessWidget {
-  const photoSelectWidget({
+class PhotoSelectWidget extends StatelessWidget {
+  const PhotoSelectWidget({
     super.key,
     required this.viewModel,
     required this.viewModelProvider,
@@ -263,16 +254,20 @@ class photoSelectWidget extends StatelessWidget {
           child: Visibility(
             visible: viewModel.imageFileUrl != null,
             replacement: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTapUp: (details) {
-                  viewModelProvider.getPhotoLibraryImage();
-                },
-                child: const Center(
-                  child: Text('사진 추가하기'),
-                )),
+              behavior: HitTestBehavior.opaque,
+              onTapUp: (details) {
+                viewModelProvider.getPhotoLibraryImage();
+              },
+              child: const Center(
+                child: Text('사진 추가하기'),
+              ),
+            ),
             child: Container(
               decoration: const BoxDecoration(
-                  borderRadius: BorderRadius.all(Radius.circular(10.0))),
+                borderRadius: BorderRadius.all(
+                  Radius.circular(10.0),
+                ),
+              ),
               clipBehavior: Clip.hardEdge,
               child: Image(
                 image: FileImage(

--- a/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
+++ b/lib/features/my_page/data/datasources/resolution_remote_datasource_impl.dart
@@ -23,7 +23,7 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
 
     try {
       final fetchResult = await FirebaseFirestore.instance
-          .collection(FirebaseCollectionName.resolutions)
+          .collection(FirebaseCollectionName.myResolutions)
           .where(
             FirebaseResolutionFieldName.resolutionIsActive,
             isEqualTo: true,
@@ -63,7 +63,7 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
 
     try {
       final fetchResult = await FirebaseFirestore.instance
-          .collection(FirebaseCollectionName.resolutions)
+          .collection(FirebaseCollectionName.myResolutions)
           .get();
 
       resolutionEntityList = fetchResult.docs
@@ -96,7 +96,7 @@ class ResolutionRemoteDatasourceImpl implements ResolutionDatasource {
   ) async {
     try {
       FirebaseFirestore.instance
-          .collection(FirebaseCollectionName.resolutions)
+          .collection(FirebaseCollectionName.myResolutions)
           .add(entity.toFirebaseDocument());
 
       return Future(() => right(true));

--- a/lib/features/my_page/presentation/providers/my_page_resolution_list_provider.dart
+++ b/lib/features/my_page/presentation/providers/my_page_resolution_list_provider.dart
@@ -28,8 +28,7 @@ class MyPageResolutionListProvider extends StateNotifier<
       getConfirmPostListForResolutionIdUsecase;
 
   Future<void> getActiveResolutionList() async {
-    final resolutionFetchResult =
-        await getResolutionListUsecase.call(NoParams());
+    final resolutionFetchResult = await getResolutionListUsecase(NoParams());
 
     final List<ResolutionModel> resolutionList = resolutionFetchResult.fold(
       (failure) => [],

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import cloud_firestore
+import file_selector_macos
 import firebase_auth
 import firebase_core
 import firebase_storage
@@ -14,6 +15,7 @@ import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49"
+      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
       url: "https://pub.dev"
     source: hosted
-    version: "65.0.0"
+    version: "64.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07
+      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.2.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -696,30 +696,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: f38a2c91c12f31726ca13015fbab3d2e9440edcb7c17b8b36ed9b85ed6eee6a2
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.0.11"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: "23770c69594f5260a79fe9d84e29f8b175d1b05d128e751c904b3cdf910e5dfc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.9"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: b06739349ec2477e943055aea30172c5c7000225f79dad4702e2ec0eda79a6ff
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
   lints:
     dependency: transitive
     description:
@@ -748,18 +724,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -1041,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.11.0"
   state_notifier:
     dependency: transitive
     description:
@@ -1057,10 +1033,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -1113,10 +1089,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.0"
   timing:
     dependency: transitive
     description:
@@ -1169,10 +1145,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1206,5 +1182,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.1.3 <4.0.0"
   flutter: ">=3.13.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "723b4021e903217dfc445ec4cf5b42e27975aece1fc4ebbc1ca6329c2d9fb54e"
+      sha256: "69acb7007eb2a31dc901512bfe0f7b767168be34cb734835d54c070bfa74c1b2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.7.0"
+    version: "8.8.0"
   camera:
     dependency: "direct main"
     description:
@@ -261,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "445db18de832dba8d851e287aff8ccf169bed30d2e94243cb54c7d2f1ed2142c"
+      sha256: "2f9d2cbccb76127ba28528cb3ae2c2326a122446a83de5a056aaa3880d3882c5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+6"
+    version: "0.3.3+7"
   crypto:
     dependency: transitive
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: abd7625e16f51f554ea244d090292945ec4d4be7bfbaf2ec8cccea568919d334
+      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   equatable:
     dependency: "direct main"
     description:
@@ -345,6 +345,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2+1"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+3"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "0aa47a725c346825a2bd396343ce63ac00bda6eff2fbc43eabe99737dede8262"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+1"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -434,10 +466,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_animate
-      sha256: "62f346340a96192070e31e3f2a1bd30a28530f1fe8be978821e06cd56b74d6d2"
+      sha256: "1dbc1aabfb8ec1e9d9feed2b675c21fb6b0a11f99be53ec3bc0f1901af6a8eb7"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0+1"
+    version: "4.3.0"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -656,6 +688,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "7d7f2768df2a8b0a3cefa5ef4f84636121987d403130e70b17ef7e2cf650ba84"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: d6a6e78821086b0b737009b09363018309bbc6de3fd88cc5c26bc2bb44a4957f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.8+2"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "50bc9ae6a77eea3a8b11af5eb6c661eeb858fdd2f734c2a4fd17086922347ef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "76ec722aeea419d03aa915c2c96bf5b47214b053899088c9abb4086ceecf97a7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.8+4"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: ed9b00e63977c93b0d2d2b343685bed9c324534ba5abafbb3dfbd6a780b1b514
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: "direct main"
     description:
@@ -1129,10 +1225,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a13d5503b4facefc515c8c587ce3cf69577a7b064a9f1220e005449cf1f64aad
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   path_provider: ^2.1.1
   firebase_storage: ^11.5.2
   intl: ^0.18.1
+  image_picker: ^1.0.4
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   firebase_storage: ^11.5.2
   intl: ^0.18.1
 
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
@@ -14,6 +15,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseAuthPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   cloud_firestore
+  file_selector_windows
   firebase_auth
   firebase_core
   firebase_storage


### PR DESCRIPTION
# 설명
인증글을 늦게 작성하는 경우에 인증글을 업로드하는 로직을 구현하기
- #92 로직을 참고하여 기능을 구현할 예정.
Related to #92 
Closes #102 

## 작업 종류
- [ ] 버그 수정 (기존 기능에 영향을 미치지 **않는** 수정)
- [x] 새로운 feature (기존 기능에 영향을 미치지 **않는** 기능 추가)
- [x] Breaking change (기존 기능에 영향을 **주는** 수정)
- [ ] 문서 수정
- [ ] 기타 (please describe):

# 작업 내역
- 실시간 인증 방식 업로드 로직 활용해 늦은 인증글에 대한 repo, datasource 기능 작성
- 늦은 인증글 작성을 위한 디버깅용 테스트뷰 작성 및 검증

## 작업 결과물
| | | |
|---|---|---|
|<img width="435" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/01c5aa65-46a9-4552-8e13-3796f82a9687">|<img width="479" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/500093ca-26b6-4e6b-81b9-a3e019c76364">|<img width="435" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/ea5577c6-7a13-4d7b-8b18-744f05882ee6">|


## 참고 사항
주형이가 작업중인 owner, fan, strike 부분 작업 끝나면 여기에도 동일하게 반영해주어야 함! 

```
late_writing_view_provider.dart 49번째 줄
        // TODO: OWNER, FAN, ResentStrike 넣어주는 로직 작성 필요함
        owner: '',
        fan: [],
        recentStrike: 0,
```


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
