### PR TITLE
[#151] fix: 반응 전송 기능 수정

### DIFF
--- a/lib/features/reaction/presentation/provider/reaction_animation_widget_state_provider.dart
+++ b/lib/features/reaction/presentation/provider/reaction_animation_widget_state_provider.dart
@@ -52,7 +52,10 @@ class ReactionAnimationWidgetManager extends StateNotifier<void> {
           reactionGroupModelList[index].textReactionModel = reaction;
           break;
         case ReactionType.emoji:
-          reactionGroupModelList[index].emojiReacionModelList.add(reaction);
+          if (reactionGroupModelList[index].emojiReacionModelList == null) {
+            reactionGroupModelList[index].emojiReacionModelList = [];
+          }
+          reactionGroupModelList[index].emojiReacionModelList!.add(reaction);
           break;
         case ReactionType.instantPhoto:
           reactionGroupModelList[index].imageReacionModel = reaction;
@@ -70,7 +73,7 @@ class ReactionGroupModel {
   });
 
   String complimenterUid;
-  List<ReactionModel> emojiReacionModelList = [];
+  List<ReactionModel>? emojiReacionModelList;
   ReactionModel? imageReacionModel;
   ReactionModel? textReactionModel;
 }

--- a/lib/features/reaction/presentation/widget/reaction_animation_widget.dart
+++ b/lib/features/reaction/presentation/widget/reaction_animation_widget.dart
@@ -128,10 +128,12 @@ class _ReactionAnimationWidgetState
     String message,
     String userImageUrl,
   ) {
-    emojiFireWorkManager.addFireworkWidget(
-      offset: offset,
-      emojiReactionCountList: emojiReactionCountList,
-    );
+    if (emojiReactionCountList.isNotEmpty) {
+      emojiFireWorkManager.addFireworkWidget(
+        offset: offset,
+        emojiReactionCountList: emojiReactionCountList,
+      );
+    }
 
     _textBubbleAnimationManager.addTextBubble(
       message: message,
@@ -149,24 +151,37 @@ class _ReactionAnimationWidgetState
         reactionGroupModel.complimenterUid,
       );
 
-      List<int> emojiCountList = List.generate(
-          reactionGroupModel.emojiReacionModelList.first.emoji.length,
-          (index) => 0);
-      for (var emojiReaction in reactionGroupModel.emojiReacionModelList) {
-        emojiReaction.emoji.mapWithIndex((value, index) {
-          emojiCountList[index] += value;
-        });
+      List<int> emojiCountList;
+      if (reactionGroupModel.emojiReacionModelList != null) {
+        emojiCountList = List.generate(
+          reactionGroupModel.emojiReacionModelList!.first.emoji.length,
+          (index) => 0,
+        );
+
+        for (var emojiReaction in reactionGroupModel.emojiReacionModelList!) {
+          emojiReaction.emoji.forEach((key, value) {
+            emojiCountList[int.parse(key.substring(1, 3))] += value;
+          });
+        }
+      } else {
+        emojiCountList = [];
       }
 
       setState(() {
-        final userImageUrl = fetchUserModelResult.fold(
-          (failure) {
-            return 'https://png.pngtree.com/thumb_back/fh260/background/20210409/pngtree-rules-of-biotex-cat-image_600076.jpg';
-          },
-          (userModel) {
-            return userModel.imageUrl;
-          },
-        );
+        String userImageUrl;
+        if (reactionGroupModel.imageReacionModel != null) {
+          userImageUrl = reactionGroupModel.imageReacionModel!.instantPhotoUrl;
+        } else {
+          userImageUrl = fetchUserModelResult.fold(
+            (failure) {
+              return 'https://png.pngtree.com/thumb_back/fh260/background/20210409/pngtree-rules-of-biotex-cat-image_600076.jpg';
+            },
+            (userModel) {
+              return userModel.imageUrl;
+            },
+          );
+        }
+
         addBalloonAnimation(
           imageUrl: userImageUrl,
           emojiCountList: emojiCountList,

--- a/lib/features/swipe_view/data/datasource/reaction_datasource_impl.dart
+++ b/lib/features/swipe_view/data/datasource/reaction_datasource_impl.dart
@@ -38,7 +38,7 @@ class ReactionDatasourceImpl implements ReactionDatasource {
 
       FirebaseFirestore.instance
           .collection(
-        '${FirebaseCollectionName.confirmPosts}/_$targetConfirmPostId/${FirebaseCollectionName.encourages}',
+        '${FirebaseCollectionName.confirmPosts}/$targetConfirmPostId/${FirebaseCollectionName.encourages}',
       )
           .add(
         {
@@ -52,7 +52,6 @@ class ReactionDatasourceImpl implements ReactionDatasource {
           FirebaseReactionFieldName.hasRead: false,
         },
       );
-
       return Future(() => right(true));
     } on Exception {
       debugPrint('DEBUG : Error on sendReactionToTargetConfirmPost Function');
@@ -69,8 +68,10 @@ class ReactionDatasourceImpl implements ReactionDatasource {
     try {
       String storagePath =
           '$confirmPostid/_${FirebaseAuth.instance.currentUser!.uid}_${DateTime.now().toIso8601String()}';
-      await FirebaseStorage.instance.ref(storagePath).putFile(File(filePath));
-      return Future(() => right(storagePath));
+      final ref = FirebaseStorage.instance.ref(storagePath);
+
+      await ref.putFile(File(filePath));
+      return Future(() async => right(await ref.getDownloadURL()));
     } on Exception catch (e) {
       return Future(() => left(Failure(e.toString())));
     }

--- a/lib/features/swipe_view/presentation/provider/swipe_view_model_provider.dart
+++ b/lib/features/swipe_view/presentation/provider/swipe_view_model_provider.dart
@@ -135,7 +135,7 @@ class SwipeViewModelProvider extends StateNotifier<SwipeViewModel> {
               {'t${index.toString().padLeft(2, '0')}': value},
             ),
           );
-      print(emojiMap);
+
       final reactionModel = ReactionModel(
         complimenterUid: currentUserUid,
         reactionType: ReactionType.emoji.index,

--- a/lib/features/swipe_view/presentation/provider/swipe_view_model_provider.dart
+++ b/lib/features/swipe_view/presentation/provider/swipe_view_model_provider.dart
@@ -132,10 +132,10 @@ class SwipeViewModelProvider extends StateNotifier<SwipeViewModel> {
       final Map<String, int> emojiMap = {};
       state.sendingEmojis.asMap().forEach(
             (index, value) => emojiMap.addAll(
-              {'t$index': value},
+              {'t${index.toString().padLeft(2, '0')}': value},
             ),
           );
-
+      print(emojiMap);
       final reactionModel = ReactionModel(
         complimenterUid: currentUserUid,
         reactionType: ReactionType.emoji.index,

--- a/lib/features/swipe_view/presentation/screen/swipe_view.dart
+++ b/lib/features/swipe_view/presentation/screen/swipe_view.dart
@@ -180,7 +180,6 @@ class SwipeViewState extends ConsumerState<SwipeView>
                                 onTapUp: (details) async =>
                                     emojiSheetWidget(context)
                                         .whenComplete(() async {
-                                  print("DEBUG_SEND EMOJI REACTION");
                                   _swipeViewModelProvider.sendEmojiReaction();
                                 }),
                                 child: Container(

--- a/lib/features/swipe_view/presentation/screen/swipe_view.dart
+++ b/lib/features/swipe_view/presentation/screen/swipe_view.dart
@@ -180,6 +180,7 @@ class SwipeViewState extends ConsumerState<SwipeView>
                                 onTapUp: (details) async =>
                                     emojiSheetWidget(context)
                                         .whenComplete(() async {
+                                  print("DEBUG_SEND EMOJI REACTION");
                                   _swipeViewModelProvider.sendEmojiReaction();
                                 }),
                                 child: Container(


### PR DESCRIPTION
# 설명
반응 전송 로직에 남아있던 여러 문제 사항 수정

Closes #151 

## 작업 종류
- [X] 버그 수정 (기존 기능에 영향을 미치지 **않는** 수정)
- [ ] 새로운 feature (기존 기능에 영향을 미치지 **않는** 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 **주는** 수정)
- [ ] 문서 수정
- [ ] 기타 (please describe):

# 작업 내역

작업 내역을 설명합니다.
- 사진으로 반응 전송 시 프로필 사진으로만 버블을 보여주던 문제 수정
- 이모지 반응 남기면 다른 이모지를 보여주던 버그 수정

## 작업 결과물
|촬영한 반응 남기기|
|---|
|![Simulator Screen Recording - iPhone 13 Pro - 2023-12-03 at 15 13 34](https://github.com/cau-bootcamp/wehavit/assets/39216546/9d569d94-3353-4f95-8151-214f74f74bd5)|

## 참고 사항(선택)
이모지 리스트를 파이어베이스에서 가져왔을 때 List라 생각하고 index 접근을 시도했는데, map 형식으로 들어오면 정렬이 안된채로 그대로 index 접근으로 이상한 이모지를 가져오는 문제가 있었음 → 정렬을 위해 파이어베이스의 이모지 번호 형식을 변경함. 
<img width="531" alt="스크린샷 2023-12-03 오후 3 15 53" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/e38dcd13-be41-4eca-9d98-69060a6d348f">


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
