### PR TITLE
[#146] feat: add fans when late/live confirm post upload 

### DIFF
--- a/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
+++ b/lib/features/late_writing/presentation/provider/late_writing_view_provider.dart
@@ -34,7 +34,7 @@ class LateWritingViewModelProvider extends StateNotifier<LateWritingViewModel> {
 
   Future<void> postCurrentConfirmPost() async {
     final fetchResult = await state.resolutionList;
-    final currentWritingResolutionModel = fetchResult
+    final ResolutionModel currentWritingResolutionModel = fetchResult
         .getRight()
         .fold(() => [], (t) => t)[state.resolutionIndex] as ResolutionModel;
 
@@ -45,9 +45,9 @@ class LateWritingViewModelProvider extends StateNotifier<LateWritingViewModel> {
         title: state.titleTextEditingController.text,
         content: state.contentTextEditingController.text,
         imageUrl: state.imageFileUrl ?? '',
-        // TODO: OWNER, FAN, ResentStrike 넣어주는 로직 작성 필요함
+        // will be set in repository impl
         owner: '',
-        fan: [],
+        fan: currentWritingResolutionModel.fanList,
         recentStrike: 0,
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),

--- a/lib/features/late_writing/presentation/screen/late_writing_view.dart
+++ b/lib/features/late_writing/presentation/screen/late_writing_view.dart
@@ -25,7 +25,7 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
-        title: const Text('title'),
+        title: const Text('늦은 인증글 작성'),
       ),
       body: Padding(
         padding:
@@ -158,6 +158,10 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
                           child: ElevatedButton(
                             onPressed: () async {
                               viewModelProvider.postCurrentConfirmPost();
+                              // 인증글 작성 완료 다이얼로그(임시)
+                              await showLatePostCompleteDialog(context);
+                              viewModel.contentTextEditingController.clear();
+                              viewModel.titleTextEditingController.clear();
                             },
                             child: const Text('Save'),
                           ),
@@ -179,6 +183,25 @@ class _LateWritingViewState extends ConsumerState<LateWritingView> {
           ),
         ),
       ),
+    );
+  }
+
+  Future<dynamic> showLatePostCompleteDialog(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('인증글 작성 완료!'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('확인'),
+            ),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/features/live_writing/data/datasources/confirm_post_remote_datasource.dart
+++ b/lib/features/live_writing/data/datasources/confirm_post_remote_datasource.dart
@@ -12,4 +12,8 @@ abstract class ConfirmPostDatasource {
   EitherFuture<bool> deleteConfirmPost(DocumentReference<ConfirmPostModel> ref);
 
   EitherFuture<bool> getConfirmPostByUserId(String userId);
+
+  EitherFuture<ConfirmPostModel> getConfirmPostOfTodayByResolutionGoalId(
+    String resolutionId,
+  );
 }

--- a/lib/features/live_writing/data/repositories/confirm_post_repository_impl.dart
+++ b/lib/features/live_writing/data/repositories/confirm_post_repository_impl.dart
@@ -20,11 +20,33 @@ class ConfirmPostRepositoryImpl implements ConfirmPostRepository {
 
   @override
   EitherFuture<bool> createConfirmPost(ConfirmPostModel confirmPost) async {
-    confirmPost = confirmPost.copyWith(
-      owner: FirebaseAuth.instance.currentUser!.uid,
-    );
+    final String resolutionId = confirmPost.resolutionId!;
     try {
-      _confirmPostRemoteDatasourceImpl.uploadConfirmPost(confirmPost);
+      final existingPost = await _confirmPostRemoteDatasourceImpl
+          .getConfirmPostOfTodayByResolutionGoalId(resolutionId);
+
+      existingPost.fold(
+        (l) {
+          // create new post if not exist
+          confirmPost = confirmPost.copyWith(
+            owner: FirebaseAuth.instance.currentUser!.uid,
+          );
+
+          _confirmPostRemoteDatasourceImpl.uploadConfirmPost(confirmPost);
+        },
+        (cf) {
+          // update existing post
+          confirmPost = confirmPost.copyWith(
+            id: cf.id,
+            owner: FirebaseAuth.instance.currentUser!.uid,
+            createdAt: cf.createdAt,
+            updatedAt: DateTime.now(),
+          );
+
+          _confirmPostRemoteDatasourceImpl.updateConfirmPost(confirmPost);
+        },
+      );
+
       return Future(() => right(true));
     } on FirebaseException catch (e) {
       return left(Failure(e.message ?? 'FirebaseException'));
@@ -33,23 +55,26 @@ class ConfirmPostRepositoryImpl implements ConfirmPostRepository {
 
   @override
   EitherFuture<bool> deleteConfirmPost(
-      DocumentReference<ConfirmPostModel> confirmPostRef) {
+    DocumentReference<ConfirmPostModel> confirmPostRef,
+  ) {
     // TODO: implement deleteConfirmPost
     return Future(
-        () => left(const Failure('deleteConfirmPost not implemented')));
+      () => left(const Failure('deleteConfirmPost not implemented')),
+    );
   }
 
   @override
   EitherFuture<ConfirmPostModel> getConfirmPostByUserId(String userId) {
     // TODO: implement getConfirmPostByUserId
     return Future(
-        () => left(const Failure('getConfirmPostByUserId not implemented')));
+      () => left(const Failure('getConfirmPostByUserId not implemented')),
+    );
   }
 
   @override
   EitherFuture<bool> updateConfirmPost(ConfirmPostModel confirmPost) {
-    // TODO: implement updateConfirmPost
     return Future(
-        () => left(const Failure('updateConfirmPost not implemented')));
+      () => left(const Failure('updateConfirmPost not implemented')),
+    );
   }
 }

--- a/lib/features/live_writing/presentation/widgets/my_live_writing_widget.dart
+++ b/lib/features/live_writing/presentation/widgets/my_live_writing_widget.dart
@@ -32,7 +32,8 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
   late EitherFuture<UserModel> myUserModel;
   XFile? imageFile;
   String imageUrl = '';
-  bool isLoadingImage = false;
+
+  // bool isLoadingImage = false;
 
   @override
   Future<void> didChangeDependencies() async {
@@ -44,8 +45,9 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
 
   @override
   Widget build(BuildContext context) {
-    var titleController = useTextEditingController();
-    var contentController = useTextEditingController();
+    final titleController = useTextEditingController();
+    final contentController = useTextEditingController();
+    final isLoadingImage = useState(false);
 
     useEffect(
       () {
@@ -69,7 +71,7 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
       return !(titleController.text == '' ||
           contentController.text == '' ||
           imageFile == null ||
-          isLoadingImage == true);
+          isLoadingImage.value == true);
     }
 
     return Align(
@@ -110,12 +112,13 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
                                 top: 14.0,
                                 bottom: 8.0,
                               ),
-                              child: imageContainerWidget(),
+                              child: imageContainerWidget(isLoadingImage),
                             ),
                             restOrSubmitButtonsWidget(
                               isSubmittable,
                               titleController,
                               contentController,
+                              isLoadingImage,
                             ),
                           ],
                         ),
@@ -197,7 +200,7 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
     );
   }
 
-  Container imageContainerWidget() {
+  Container imageContainerWidget(ValueNotifier<bool> isLoadingImage) {
     return Container(
       width: 151,
       height: 104,
@@ -213,9 +216,9 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
               source: ImageSource.gallery,
             );
             if (pickedFile != null) {
-              isLoadingImage = true;
+              isLoadingImage.value = true;
               imageUrl = await setImage(pickedFile);
-              isLoadingImage = false;
+              isLoadingImage.value = false;
             } else {
               debugPrint('이미지 선택안함');
             }
@@ -248,6 +251,7 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
     bool Function() isSubmittable,
     TextEditingController titleController,
     TextEditingController contentController,
+    ValueNotifier<bool> isLoadingImage,
   ) {
     return Visibility(
       visible: !isSubmitted,
@@ -306,7 +310,7 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
                 );
               }
             },
-            child: Text(isLoadingImage ? '처리중' : '휴식'),
+            child: Text(isLoadingImage.value ? '처리중' : '휴식'),
           ),
           ElevatedButton(
             onPressed: () async {
@@ -349,7 +353,7 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
                 );
               }
             },
-            child: Text(isLoadingImage ? '처리중' : '완료'),
+            child: Text(isLoadingImage.value ? '처리중' : '완료'),
           ),
         ],
       ),

--- a/lib/features/live_writing/presentation/widgets/my_live_writing_widget.dart
+++ b/lib/features/live_writing/presentation/widgets/my_live_writing_widget.dart
@@ -279,8 +279,9 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
                   recentStrike: 0,
                   createdAt: DateTime.now(),
                   updatedAt: DateTime.now(),
+                  // repository impl에서 자동으로 채워짐
                   owner: '',
-                  fan: [],
+                  fan: widget.resolutionModel.fanList,
                   attributes: {
                     'has_participated_live': true,
                     'has_rested': true,
@@ -323,7 +324,7 @@ class _MyLiveWritingWidgetState extends ConsumerState<MyLiveWritingWidget> {
                   createdAt: DateTime.now(),
                   updatedAt: DateTime.now(),
                   owner: '',
-                  fan: [],
+                  fan: widget.resolutionModel.fanList,
                   attributes: {
                     'has_participated_live': true,
                     'has_rested': false,


### PR DESCRIPTION
# 설명

늦은 인증 글 작성시 혹은 실시간 인증글 작성 시에 owner 및 fan 정보를 같이 저장합니다.
fan정보는 기존의 resolution의 것을 가져옵니다.

이미 인증글이 존재하는 경우 덮어씁니다.

Closes #146 

## 작업 종류

관련 내용에 체크해주세요.

- [x] 버그 수정 (기존 기능에 영향을 미치지 **않는** 수정)
- [x] 새로운 feature (기존 기능에 영향을 미치지 **않는** 기능 추가)
- [x] Breaking change (기존 기능에 영향을 **주는** 수정)
- [ ] 문서 수정
- [ ] 기타 (please describe):

# 작업 내역

작업 내역을 설명합니다.

- [x] fan 정보 저장하도록 rep
- [x] 중복된 인증 글을 방지를 위해 이미 존재하는 인증글이 있을 경우 덮어씀 (breaking change)
- [x] UI bug fix (carousel에서 처리중 버튼이 계속 유지되는 것을 수정)

## 작업 결과물

<img height="512" alt="capture" src="https://github.com/cau-bootcamp/wehavit/assets/38830620/1fde14af-94c3-43bf-ac7e-6622227b87e9">

<img width="512" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/38830620/3d95500e-f1aa-4ba9-a7b4-0a075289cc7b">


## 참고 사항(선택)

작업을 진행하면서 참고한 사항이나 참고할 사항이 있다면 적어주세요.
(ex. 나중에 수정해야 할 부분, 참고한 사이트, 참고한 코드 등)

# 체크 리스트

- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
