### PR TITLE
[#157] 실시간 인증글 작성 시 타이머 로직 추가

### DIFF
--- a/lib/features/live_writing/data/repositories/live_writing_mine_repository_impl.dart
+++ b/lib/features/live_writing/data/repositories/live_writing_mine_repository_impl.dart
@@ -83,23 +83,27 @@ class LiveWritingPostRepositoryImpl extends MyLiveWritingRepository {
 
   @override
   Stream<List<ReactionModel>> getReactionListStream() {
-    final stream = FirebaseFirestore.instance
-        .collection(FirebaseCollectionName.liveConfirmPosts)
-        .doc(
-          '$livePostDocumentPrefix${FirebaseAuth.instance.currentUser!.email}',
-        )
-        .collection(FirebaseCollectionName.encourages)
-        .snapshots()
-        .map((event) => event.docs)
-        .map(
-          (docs) => docs
-              .map(
-                (doc) => ReactionModel.fromFireStoreDocument(doc),
-              )
-              .toList(),
-        );
-
-    return stream;
+    try {
+      final stream = FirebaseFirestore.instance
+          .collection(FirebaseCollectionName.liveConfirmPosts)
+          .doc(
+            '$livePostDocumentPrefix${FirebaseAuth.instance.currentUser!.email}',
+          )
+          .collection(FirebaseCollectionName.encourages)
+          .snapshots()
+          .map((event) => event.docs)
+          .map(
+            (docs) => docs
+                .map(
+                  (doc) => ReactionModel.fromFireStoreDocument(doc),
+                )
+                .toList(),
+          );
+      return stream;
+    } catch (e) {
+      debugPrint(e.toString());
+      return Stream.empty();
+    }
   }
 
   @override

--- a/lib/features/live_writing/presentation/providers/active_resolution_provider.dart
+++ b/lib/features/live_writing/presentation/providers/active_resolution_provider.dart
@@ -6,7 +6,8 @@ import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 import 'package:wehavit/features/my_page/domain/usecases/get_resolution_list_usecase_provider.dart';
 
 final activeResolutionListProvider =
-    FutureProvider<Either<Failure, List<ResolutionModel>>>((ref) async {
-  var getResolutionListUsecase = ref.watch(getResolutionListUseCaseProvider);
+    FutureProvider.autoDispose<Either<Failure, List<ResolutionModel>>>(
+        (ref) async {
+  final getResolutionListUsecase = ref.watch(getResolutionListUseCaseProvider);
   return await getResolutionListUsecase.call(NoParams());
 });

--- a/lib/features/live_writing/presentation/screens/live_writing_view.dart
+++ b/lib/features/live_writing/presentation/screens/live_writing_view.dart
@@ -4,13 +4,17 @@ import 'dart:math';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:wehavit/common/constants/app_colors.dart';
+import 'package:wehavit/common/routers/route_location.dart';
 import 'package:wehavit/features/effects/emoji_firework_animation/emoji_firework_manager.dart';
 import 'package:wehavit/features/live_writing/live_writing.dart';
 import 'package:wehavit/features/live_writing/presentation/widgets/friend_live_post_widget.dart';
 import 'package:wehavit/features/live_writing/presentation/widgets/my_live_writing_widget.dart';
+import 'package:wehavit/features/live_writing_waiting/domain/models/counter_state.dart';
+import 'package:wehavit/features/live_writing_waiting/domain/models/waiting_model.dart';
 import 'package:wehavit/features/my_page/domain/models/resolution_model.dart';
 import 'package:wehavit/features/swipe_view/domain/model/reaction_model.dart';
 import 'package:wehavit/features/swipe_view/presentation/screen/widget/emoji_sheet_widget.dart';
@@ -59,6 +63,14 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
 
   @override
   Widget build(BuildContext context) {
+    // Timer Countdown Stream
+    final timerStream = useMemoized(
+      () => ref.read(waitingProvider.notifier).getWritingTimerStream(),
+    );
+    final timerStreamSnapshot = useStream(timerStream);
+
+    final timerCounterState = ref.watch(waitingProvider);
+
     final activeResolutionList = ref.watch(activeResolutionListProvider);
 
     final friendEmailsFuture = useMemoized(() => getVisibleFriends(ref));
@@ -72,6 +84,19 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
 
     // auto dispose을 방지하기 위해 watch 삽입
     final _ = ref.watch(liveWritingFriendRepositoryProvider);
+
+    useEffect(
+      () {
+        debugPrint('timerCounterState.counterStateEnum: '
+            '${timerCounterState.counterStateEnum}');
+
+        if (timerCounterState.counterStateEnum == CounterStateEnum.timeOver) {
+          context.go(RouteLocation.home);
+        }
+        return null;
+      },
+      [timerCounterState.counterStateEnum],
+    );
 
     useEffect(
       () {
@@ -151,9 +176,9 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
                     Container(
                       padding: const EdgeInsets.only(top: 34, bottom: 34),
                       width: double.infinity,
-                      child: const Column(
+                      child: Column(
                         children: [
-                          Text(
+                          const Text(
                             '남은 시간',
                             style: TextStyle(
                               fontSize: 18,
@@ -162,8 +187,8 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
                             ),
                           ),
                           Text(
-                            '00:07',
-                            style: TextStyle(
+                            timerStreamSnapshot.data ?? '',
+                            style: const TextStyle(
                               fontSize: 30,
                               fontWeight: FontWeight.bold,
                               color: CustomColors.whWhite,
@@ -224,7 +249,8 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
                       alignment: Alignment.bottomCenter,
                       child: const Center(
                         child: Text(
-                          '친구들과 함께 인증글을 작성하기 \n위해서는 목표를 추가해주세요.',
+                          '친구들과 함께 인증글을 작성하기\n'
+                          '위해서는 목표를 추가해주세요.',
                           textAlign: TextAlign.center,
                           style: TextStyle(
                             fontSize: 24,

--- a/lib/features/live_writing/presentation/screens/live_writing_view.dart
+++ b/lib/features/live_writing/presentation/screens/live_writing_view.dart
@@ -68,6 +68,8 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
     // ignore: unused_local_variable
     final reactionSnapshot = useStream<List<ReactionModel>>(reactionStream);
 
+    final resolutionModelList = useState(<ResolutionModel>[]);
+
     // auto dispose을 방지하기 위해 watch 삽입
     final _ = ref.watch(liveWritingFriendRepositoryProvider);
 
@@ -198,7 +200,7 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
               ),
               activeResolutionList.when(
                 data: (fetchedActiveResolutionList) {
-                  List<ResolutionModel> resolutionModelList = [];
+                  // List<ResolutionModel> resolutionModelList = [];
                   // load first goal statement
                   fetchedActiveResolutionList.fold(
                     (error) {
@@ -210,12 +212,14 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
                       if (resolutionList.isNotEmpty) {
                         // selectedResolutionGoal.value =
                         //     resolutionList.first.goalStatement;
-                        resolutionModelList = resolutionList;
+                        final sortedList = resolutionList
+                          ..sort((a, b) => a.startDate.compareTo(b.startDate));
+                        resolutionModelList.value = resolutionList;
                       }
                     },
                   );
 
-                  if (resolutionModelList.isEmpty) {
+                  if (resolutionModelList.value.isEmpty) {
                     return Container(
                       alignment: Alignment.bottomCenter,
                       child: const Center(
@@ -232,7 +236,7 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
                     );
                   }
 
-                  List<Widget> writingCellList = resolutionModelList.map(
+                  List<Widget> writingCellList = resolutionModelList.value.map(
                     (model) {
                       return Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 8.0),

--- a/lib/features/live_writing/presentation/screens/live_writing_view.dart
+++ b/lib/features/live_writing/presentation/screens/live_writing_view.dart
@@ -26,7 +26,8 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
     with SingleTickerProviderStateMixin {
   XFile? imageFile;
   ValueNotifier<bool> isSubmitted = ValueNotifier(false);
-  late List<ResolutionModel> resolutionModelList;
+
+  // List<ResolutionModel> resolutionModelList = [];
 
   int _current = 0;
   final CarouselController _controller = CarouselController();
@@ -197,21 +198,39 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
               ),
               activeResolutionList.when(
                 data: (fetchedActiveResolutionList) {
+                  List<ResolutionModel> resolutionModelList = [];
                   // load first goal statement
                   fetchedActiveResolutionList.fold(
-                    (error) => debugPrint(
-                      'Error, when fetching active resolution list: $error',
-                    ),
+                    (error) {
+                      debugPrint(
+                        'Error, when fetching active resolution list: $error',
+                      );
+                    },
                     (resolutionList) async {
                       if (resolutionList.isNotEmpty) {
                         // selectedResolutionGoal.value =
                         //     resolutionList.first.goalStatement;
                         resolutionModelList = resolutionList;
-                      } else {
-                        //
                       }
                     },
                   );
+
+                  if (resolutionModelList.isEmpty) {
+                    return Container(
+                      alignment: Alignment.bottomCenter,
+                      child: const Center(
+                        child: Text(
+                          '친구들과 함께 인증글을 작성하기 \n위해서는 목표를 추가해주세요.',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: 24,
+                            fontWeight: FontWeight.bold,
+                            color: CustomColors.whSemiWhite,
+                          ),
+                        ),
+                      ),
+                    );
+                  }
 
                   List<Widget> writingCellList = resolutionModelList.map(
                     (model) {
@@ -287,7 +306,7 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
                     Center(child: Text(error.toString())),
               ),
               Container(
-                constraints: BoxConstraints.expand(),
+                constraints: const BoxConstraints.expand(),
                 child: Stack(
                   alignment: Alignment.bottomCenter,
                   clipBehavior: Clip.none,

--- a/lib/features/live_writing/presentation/screens/live_writing_view.dart
+++ b/lib/features/live_writing/presentation/screens/live_writing_view.dart
@@ -239,7 +239,7 @@ class _LiveWritingViewState extends ConsumerState<LiveWritingView>
                         //     resolutionList.first.goalStatement;
                         final sortedList = resolutionList
                           ..sort((a, b) => a.startDate.compareTo(b.startDate));
-                        resolutionModelList.value = resolutionList;
+                        resolutionModelList.value = sortedList;
                       }
                     },
                   );

--- a/lib/features/live_writing_waiting/domain/models/waiting_model.dart
+++ b/lib/features/live_writing_waiting/domain/models/waiting_model.dart
@@ -4,27 +4,47 @@ import 'package:wehavit/features/live_writing_waiting/domain/models/counter_stat
 part 'waiting_model.g.dart';
 
 const int fixedTimeHour = 22; // 실시간 인증 시간, 고정: 22시
+const int fixedTimeMinute = 0; // 실시간 인증 시간, 고정: 00분
 const int availableWaitingTimeMinute = 3; // 글 쓰기 전 기다리는 시간: 3min
-const int availableWritingLimitMinute = 10; // 실시간 글 작성 제한 시간: 10min
+const int availableWritingLimitMinute = 5; // 실시간 글 작성 제한 시간: 5min
 
 @riverpod
 class Waiting extends _$Waiting {
-  final DateTime _targetTime = DateTime(DateTime.now().year, DateTime.now().month,
-    DateTime.now().day, fixedTimeHour,);
+  // TODO. This is for debug. If needed, uncomment this and set time to test
+  // static int fixedTimeHour = 1;
+  // static int fixedTimeMinute = 28;
+
+  final DateTime _writingStartTime = DateTime(
+    DateTime.now().year,
+    DateTime.now().month,
+    DateTime.now().day,
+    fixedTimeHour,
+    fixedTimeMinute,
+  );
+
+  final DateTime _writingEndTime = DateTime(
+    DateTime.now().year,
+    DateTime.now().month,
+    DateTime.now().day,
+    fixedTimeHour,
+    fixedTimeMinute + availableWritingLimitMinute,
+  );
 
   @override
   CounterState build() {
-    // 실시간 인증 전까지 3분 이내에는 대기
+    // 실시간 인증 전까지 availableWaitingTimeMinute분 이내에는 대기
     // 0 < _timeLeft.inSeconds <= 60*3
-    if (0 < _timeLeft.inSeconds && _timeLeft.inSeconds <= availableWaitingTimeMinute*60) {
+    if (0 < _waitingTimeLeft.inSeconds &&
+        _waitingTimeLeft.inSeconds <= availableWaitingTimeMinute * 60) {
       return const CounterState(
         counterStateEnum: CounterStateEnum.timeForWaiting,
       );
     }
 
-    // 실시간 인증 후 10분 이내에는 글 작성
+    // 실시간 인증 후 availableWritingLimitMinute분 이내에는 글 작성
     // -60*10 <= _timeLeft.inSeconds <= 0
-    if (-availableWritingLimitMinute*60 <= _timeLeft.inSeconds && _timeLeft.inSeconds <= 0) {
+    if (-availableWritingLimitMinute * 60 <= _waitingTimeLeft.inSeconds &&
+        _waitingTimeLeft.inSeconds <= 0) {
       return const CounterState(
         counterStateEnum: CounterStateEnum.timeForWriting,
       );
@@ -35,14 +55,14 @@ class Waiting extends _$Waiting {
     );
   }
 
-  Stream<String> getTimerStream() async* {
+  Stream<String> getWaitingTimerStream() async* {
     if (build().counterStateEnum == CounterStateEnum.timeForWaiting) {
       while (true) {
-        if (_timeLeft.inSeconds <= 0) {
+        if (_waitingTimeLeft.inSeconds <= 0) {
           setCounterState(CounterStateEnum.timeForWriting);
           break;
         }
-        yield getTimerString();
+        yield getTimerString(_waitingTimeLeft);
         await Future.delayed(const Duration(seconds: 1));
       }
     }
@@ -53,15 +73,35 @@ class Waiting extends _$Waiting {
     }
   }
 
-  Duration get _timeLeft => _targetTime.difference(DateTime.now());
+  Stream<String> getWritingTimerStream() async* {
+    if (build().counterStateEnum == CounterStateEnum.timeForWriting) {
+      while (true) {
+        if (_writingTimeLeft.inSeconds <= 0) {
+          setCounterState(CounterStateEnum.timeOver);
+          break;
+        }
+        yield getTimerString(_writingTimeLeft);
+        await Future.delayed(const Duration(seconds: 1));
+      }
+    }
+    if (build().counterStateEnum == CounterStateEnum.timeForWaiting) {
+      yield '아직 대기 중입니다.';
+    } else {
+      yield '종료되었습니다.';
+    }
+  }
 
-  String getTimerString() {
-    final Duration timeLeft = _timeLeft;
+  Duration get _waitingTimeLeft => _writingStartTime.difference(DateTime.now());
+
+  Duration get _writingTimeLeft => _writingEndTime.difference(DateTime.now());
+
+  String getTimerString(Duration timeLeft) {
+    // final Duration timeLeft = _waitingTimeLeft;
     final int hour = timeLeft.inHours;
     final int minute = timeLeft.inMinutes.remainder(60);
     final int second = timeLeft.inSeconds.remainder(60);
 
-    if (_timeLeft.inHours == 0) {
+    if (_waitingTimeLeft.inHours == 0) {
       return '${minute.toString().padLeft(2, '0')}:${second.toString().padLeft(2, '0')}';
     }
     return '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}:${second.toString().padLeft(2, '0')}';

--- a/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
+++ b/lib/features/live_writing_waiting/presentation/view/live_waiting_view.dart
@@ -34,8 +34,8 @@ class LiveWritingView extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // Timer Countdown Stream
-    final timerStream =
-        useMemoized(() => ref.read(waitingProvider.notifier).getTimerStream());
+    final timerStream = useMemoized(
+        () => ref.read(waitingProvider.notifier).getWaitingTimerStream());
     final timerStreamSnapshot = useStream(timerStream);
 
     // Syncing Online Status


### PR DESCRIPTION
# 설명

실시간 인증 글 작성은 10시부터 5분입니다.
5분 타이머가 추가되었고 작성 시간으로부터 5분이 경과되면 창을 메인화면으로 이동합니다.

그리고 작업을 하며 발견한 버그를 두 가지 수정했습니다.
 - 버그1. resolution 없는 경우 값이 초기화되어 페이지 크래쉬.
 - 버그2. resolution 추가해도 앱을 껐다킬때까지 인증글이 목록 리스트에 추가가 안 됨.

Fixes #157 

## 작업 종류

관련 내용에 체크해주세요.

- [x] 버그 수정 (기존 기능에 영향을 미치지 **않는** 수정)
- [x] 새로운 feature (기존 기능에 영향을 미치지 **않는** 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 **주는** 수정)
- [ ] 문서 수정
- [ ] 기타 (please describe):

# 작업 내역

작업 내역을 설명합니다.

- [x] resolution 관련 버그 수정
- [x] 5분 타이머 UI
- [x] 5분 타이머 경과 시 페이지 이동

## 작업 결과물

### 대기 시간 만료 시 실시간 인증글로 이동하는 장면
<img height="512" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/38830620/a469e706-270c-45b8-b781-fbbffdc0f2d3">

### 실시간 글 쓰기 시간 만료 시 메인 화면으로 이동하는 장면
<img height="512" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/38830620/a72c53a7-8c65-4de5-8eea-e5e14d52aa7b">

## 참고 사항(선택)

(버그 추정)
 - 메인뷰에서 내가 남긴 글이 바로 보여야 되는데 보이지 않는 것 같아요!

# 체크 리스트

- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
