### PR TITLE
[#193] fix: home view pan gesture 작동 수정

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -234,7 +234,7 @@ SPEC CHECKSUMS:
   FirebaseMessaging: 9bc34a98d2e0237e1b121915120d4d48ddcf301e
   FirebaseStorage: 8333c4b183764cdd170d9539a61322b71c23adff
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
+  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_native_image: 9c0b7451838484458e5b0fae007b86a4c2d4bdfe
   google_sign_in_ios: 1bfaf6607b44cd1b24c4d4bc39719870440f9ce1
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -311,7 +311,7 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
 
   @override
   EitherFuture<bool> sendReactionToTargetConfirmPost(
-    String targetConfirmPostId,
+    ConfirmPostEntity targetEntity,
     ReactionEntity reactionEntity,
   ) async {
     try {
@@ -320,7 +320,7 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
       await firestore
           .collection(
             FirebaseCollectionName.getConfirmPostReactionCollectionName(
-              targetConfirmPostId,
+              targetEntity.id!,
             ),
           )
           .add(reactionModel.toJson());
@@ -328,7 +328,7 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
       await firestore
           .collection(
             FirebaseCollectionName.getUserReactionBoxCollectionName(
-              reactionEntity.complimenterUid,
+              targetEntity.owner!,
             ),
           )
           .add(reactionModel.toJson());
@@ -560,7 +560,10 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
   @override
   EitherFuture<List<ReactionEntity>> getUnreadReactionsAndDelete() async {
     try {
-      final fetchUid = (await getMyUserId()).fold((l) => null, (uid) => uid);
+      final fetchUid = (await getMyUserId()).fold(
+        (l) => null,
+        (uid) => uid,
+      );
 
       if (fetchUid == null) {
         return Future(

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -27,7 +27,7 @@ abstract class WehavitDatasource {
   EitherFuture<bool> deleteConfirmPost(ConfirmPostEntity confirmPost);
 
   EitherFuture<bool> sendReactionToTargetConfirmPost(
-    String targetConfirmPostId,
+    ConfirmPostEntity targetEntity,
     ReactionEntity reactionEntity,
   );
 

--- a/lib/data/repositories/reaction_repository_impl.dart
+++ b/lib/data/repositories/reaction_repository_impl.dart
@@ -10,11 +10,11 @@ class ReactionRepositoryImpl implements ReactionRepository {
 
   @override
   EitherFuture<bool> addReactionToConfirmPost(
-    String targetConfirmPostId,
+    ConfirmPostEntity targetEntity,
     ReactionEntity reactionEntity,
   ) {
     return _wehavitDatasource.sendReactionToTargetConfirmPost(
-      targetConfirmPostId,
+      targetEntity,
       reactionEntity,
     );
   }

--- a/lib/domain/repositories/reaction_repository.dart
+++ b/lib/domain/repositories/reaction_repository.dart
@@ -5,7 +5,7 @@ abstract class ReactionRepository {
   EitherFuture<List<ReactionEntity>> getUnreadReactionListAndDelete();
 
   EitherFuture<bool> addReactionToConfirmPost(
-    String targetConfirmPostId,
+    ConfirmPostEntity targetEntity,
     ReactionEntity reactionModel,
   );
 

--- a/lib/domain/usecases/send_comment_reaction_to_confirm_post_usecase.dart
+++ b/lib/domain/usecases/send_comment_reaction_to_confirm_post_usecase.dart
@@ -30,7 +30,7 @@ class SendCommentReactionToConfirmPostUsecase
     );
 
     return _reactionRepository.addReactionToConfirmPost(
-      params.$1.id!,
+      params.$1,
       reactionEntity,
     );
   }

--- a/lib/domain/usecases/send_emoji_reaction_to_confirm_post_usercase.dart
+++ b/lib/domain/usecases/send_emoji_reaction_to_confirm_post_usercase.dart
@@ -35,7 +35,7 @@ class SendEmojiReactionToConfirmPostUsecase
     );
 
     return _reactionRepository.addReactionToConfirmPost(
-      params.$1.id!,
+      params.$1,
       reactionEntity,
     );
   }

--- a/lib/domain/usecases/send_quickshot_reaction_to_confirm_post_usecase.dart
+++ b/lib/domain/usecases/send_quickshot_reaction_to_confirm_post_usecase.dart
@@ -49,7 +49,7 @@ class SendQuickShotReactionToConfirmPostUsecase
     );
 
     return _reactionRepository.addReactionToConfirmPost(
-      params.$1.id!,
+      params.$1,
       reactionEntity,
     );
   }

--- a/lib/presentation/effects/camera_quickshot/reaction_camera_widget.dart
+++ b/lib/presentation/effects/camera_quickshot/reaction_camera_widget.dart
@@ -108,8 +108,10 @@ class _ReactionCameraWidgetState extends ConsumerState<ReactionCameraWidget> {
             ),
           ),
           Positioned(
-            left: widget.panPosition.x,
-            top: widget.panPosition.y,
+            left: widget.panPosition.x -
+                _reactionCameraWidgetModel.cameraButtonRadius,
+            top: widget.panPosition.y -
+                _reactionCameraWidgetModel.cameraButtonRadius,
             child: Container(
               width: _reactionCameraWidgetModel.cameraButtonRadius * 2,
               height: _reactionCameraWidgetModel.cameraButtonRadius * 2,

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -222,7 +222,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                                   itemCount: right.length,
                                   itemBuilder: (context, index) {
                                     return ConfirmPostWidget(
-                                      key: UniqueKey(),
+                                      key: Key(right[index].id!),
                                       entity: right[index],
                                       panUpdateCallback: updatePanPosition,
                                       panEndCallback: endOnCapturingPosition,
@@ -391,11 +391,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   }
 
   void updatePanPosition(Point<double> position) {
-    // TODO: panPosition update로 현재 touch position을 보여줘야 함
-    // print(position);ㄷ
-    // setState(() {
-    //   panPosition = position;
-    // });
+    setState(() {
+      panPosition = position;
+    });
   }
 
   Future<void> endOnCapturingPosition(

--- a/lib/presentation/home/widget/confirm_post_widget.dart
+++ b/lib/presentation/home/widget/confirm_post_widget.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/common/utils/emoji_assets.dart';

--- a/lib/presentation/home/widget/confirm_post_widget.dart
+++ b/lib/presentation/home/widget/confirm_post_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/common/utils/emoji_assets.dart';
@@ -78,9 +79,9 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
 
       setAnimationVariables();
       confirmPostList = await _mainViewModelProvider.getConfirmPostListFor(
-          resolutionId: widget.entity.resolutionId!);
+        resolutionId: widget.entity.resolutionId!,
+      );
 
-      setState(() {});
       _initOccurred = true;
     }
   }
@@ -543,7 +544,6 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
           });
         },
         onPanEnd: (details) async {
-
           if (_reactionCameraWidgetModelProvider
               .isPosInCameraAreaOf(panningPosition)) {
             widget.panEndCallback(panningPosition, widget.entity);

--- a/lib/presentation/reaction/provider/reaction_animation_widget_state_provider.dart
+++ b/lib/presentation/reaction/provider/reaction_animation_widget_state_provider.dart
@@ -12,8 +12,7 @@ class ReactionAnimationWidgetManager extends StateNotifier<void> {
 
   late GetUnreadReactionListUsecase getUnreadReactionListUsecase;
 
-  Future<List<ReactionGroupModel>>
-      getUnreadReactionModelGroupListFromLastConfirmPost() async {
+  Future<List<ReactionGroupModel>> getUnreadReactionGroupList() async {
     final fetchResult = await getUnreadReactionListUsecase(
       NoParams(),
     );

--- a/lib/presentation/reaction/widget/reaction_animation_widget.dart
+++ b/lib/presentation/reaction/widget/reaction_animation_widget.dart
@@ -72,7 +72,7 @@ class _ReactionAnimationWidgetState
         ref.read(reactionAnimationWidgetManagerProvider.notifier);
     _fetchUserDataFromIdUsecase = ref.watch(fetchUserDataFromIdUsecaseProvider);
 
-    showReactionFromLastConfrimPost();
+    showUnreadReactions();
   }
 
   @override
@@ -138,9 +138,9 @@ class _ReactionAnimationWidgetState
   }
 
   // TODO: 이 함수를 화면이 켜졌을 때 호출하도록 로직 구현하기
-  Future<void> showReactionFromLastConfrimPost() async {
-    final fetchResult = await _reactionAnimationWidgetManager
-        .getUnreadReactionModelGroupListFromLastConfirmPost();
+  Future<void> showUnreadReactions() async {
+    final fetchResult =
+        await _reactionAnimationWidgetManager.getUnreadReactionGroupList();
 
     for (var reactionGroupModel in fetchResult) {
       final fetchUserModelResult = await _fetchUserDataFromIdUsecase.call(


### PR DESCRIPTION
# 설명
HomeView에서 Quickshot 촬영을 위해 Pan Gesture 을 사용하면, 버튼이 정지하는 문제가 있어, 해당 기능이 동작하도록 수정하였음

Closes #193 

## 작업 종류
- [x] 버그 수정 (기존 기능에 영향을 미치지 **않는** 수정)
- [ ] 새로운 feature (기존 기능에 영향을 미치지 **않는** 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 **주는** 수정)
- [ ] 문서 수정
- [ ] 기타 (please describe):

# 작업 내역
- 버그 수정

## 작업 결과물
정상적으로 HomeView 의 pan gesture indicator가 작동함
<img src="https://github.com/cau-bootcamp/wehavit/assets/39216546/6cad9e3d-db54-4ee4-8743-80c09a5637c2" width=400>


## 참고 사항(선택)
코드 한 줄 수정하면 되는 문제였음! 
setState 시 하위 뷰 redraw → Key 문제로 하위 뷰를 새로 그리면서 pangesture가 붙어있는 위젯 자체가 새로 만들어져 발생한 문제

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
