### PR TITLE
[#208] feat: 그룹 내 일주일 간의 각각의 인증글에 대한 통계를 전달하는 로직 구현

### DIFF
--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -86,4 +86,8 @@ abstract class WehavitDatasource {
   );
 
   EitherFuture<void> readGroupAnnouncement(GroupAnnouncementEntity entity);
+
+  EitherFuture<GroupWeeklyReportEntity> getGroupWeeklyReport(
+    String groupId,
+  );
 }

--- a/lib/data/repositories/group_repository_impl.dart
+++ b/lib/data/repositories/group_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/data/datasources/datasources.dart';
 import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/entities/group_weekly_report_entity/group_weekly_resport_entity.dart';
 import 'package:wehavit/domain/repositories/group_repository.dart';
 
 class GroupRepositoryImpl implements GroupRepository {
@@ -91,5 +92,12 @@ class GroupRepositoryImpl implements GroupRepository {
   @override
   EitherFuture<void> readGroupAnnouncement(GroupAnnouncementEntity entity) {
     return _wehavitDatasource.readGroupAnnouncement(entity);
+  }
+
+  @override
+  EitherFuture<GroupWeeklyReportEntity> getGroupWeeklyReport(
+    String groupId,
+  ) {
+    return _wehavitDatasource.getGroupWeeklyReport(groupId);
   }
 }

--- a/lib/data/repositories/resolution_repository_impl.dart
+++ b/lib/data/repositories/resolution_repository_impl.dart
@@ -4,7 +4,6 @@ import 'package:wehavit/common/errors/failure.dart';
 import 'package:wehavit/common/utils/custom_types.dart';
 import 'package:wehavit/data/datasources/datasources.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/domain/entities/group_announcement_entity/group_announcement_entity.dart';
 import 'package:wehavit/domain/repositories/repositories.dart';
 
 class ResolutionRepositoryImpl implements ResolutionRepository {

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -191,3 +191,9 @@ final readGroupAnnouncementUsecaseProvider =
   final groupRepository = ref.watch(groupRepositoryProvider);
   return ReadGroupAnnouncementUsecase(groupRepository);
 });
+
+final getGroupWeeklyReportUsecaseProvider =
+    Provider<GetGroupWeeklyReportUsecase>((ref) {
+  final groupRepository = ref.watch(groupRepositoryProvider);
+  return GetGroupWeeklyReportUsecase(groupRepository);
+});

--- a/lib/domain/entities/entities.dart
+++ b/lib/domain/entities/entities.dart
@@ -2,6 +2,7 @@ export 'auth_result_entity/auth_result_entity.dart';
 export 'confirm_post_entity/confirm_post_entity.dart';
 export 'group_announcement_entity/group_announcement_entity.dart';
 export 'group_entity/group_entity.dart';
+export 'group_weekly_report_entity/group_weekly_resport_entity.dart';
 export 'reaction_entity/reaction_entity.dart';
 export 'resolution_entity/resolution_entity.dart';
 export 'user_data_entity/user_data_entity.dart';

--- a/lib/domain/entities/group_weekly_report_entity/group_weekly_resport_entity.dart
+++ b/lib/domain/entities/group_weekly_report_entity/group_weekly_resport_entity.dart
@@ -1,0 +1,25 @@
+import 'package:wehavit/domain/entities/entities.dart';
+
+class GroupWeeklyReportEntity {
+  GroupWeeklyReportEntity({
+    required this.groupId,
+    required this.groupWeeklyReportCellList,
+  });
+
+  String groupId;
+  List<GroupWeeklyReportCell> groupWeeklyReportCellList;
+}
+
+class GroupWeeklyReportCell {
+  GroupWeeklyReportCell(
+    this.memberEntity,
+    this.memberResolutionList,
+    this.memberSuccessResolutionMap,
+    this.doneResolutionIdListForEachDay,
+  );
+
+  UserDataEntity memberEntity;
+  List<ResolutionEntity> memberResolutionList;
+  Map<String, bool> memberSuccessResolutionMap;
+  List<List<String>> doneResolutionIdListForEachDay;
+}

--- a/lib/domain/repositories/group_repository.dart
+++ b/lib/domain/repositories/group_repository.dart
@@ -35,4 +35,8 @@ abstract class GroupRepository {
   );
 
   EitherFuture<void> readGroupAnnouncement(GroupAnnouncementEntity entity);
+
+  EitherFuture<GroupWeeklyReportEntity> getGroupWeeklyReport(
+    String groupId,
+  );
 }

--- a/lib/domain/usecases/get_group_weekly_report_usecase.dart
+++ b/lib/domain/usecases/get_group_weekly_report_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/repositories/repositories.dart';
+
+class GetGroupWeeklyReportUsecase {
+  GetGroupWeeklyReportUsecase(
+    this._groupRepository,
+  );
+
+  final GroupRepository _groupRepository;
+
+  EitherFuture<GroupWeeklyReportEntity> call({
+    required String groupId,
+  }) async {
+    return _groupRepository.getGroupWeeklyReport(groupId);
+  }
+}

--- a/lib/domain/usecases/usecases.dart
+++ b/lib/domain/usecases/usecases.dart
@@ -10,6 +10,7 @@ export 'get_confirm_post_list_usecase.dart';
 export 'get_friend_list_usecase.dart';
 export 'get_group_announcement_list_usecase.dart';
 export 'get_group_list_usecase.dart';
+export 'get_group_weekly_report_usecase.dart';
 export 'get_my_resolution_list_usecase.dart';
 export 'get_reaction_list_from_confirm_post_usecase.dart';
 export 'get_resolution_list_by_uid_usecase.dart';

--- a/lib/presentation/test_view/group/group_sample_view.dart
+++ b/lib/presentation/test_view/group/group_sample_view.dart
@@ -369,6 +369,18 @@ class _AnnouncementGroupSampleViewState
                 },
                 child: const Text('read'),
               ),
+              ElevatedButton(
+                onPressed: () async {
+                  final groupId = groupIdController.text;
+                  final report = await ref
+                      .read(getGroupWeeklyReportUsecaseProvider)
+                      .call(groupId: groupId)
+                      .then((value) =>
+                          value.fold((l) => null, (report) => report));
+                  print(report);
+                },
+                child: const Text('report'),
+              ),
               Divider(),
               Column(
                 children: groupAnnouncmenetList


### PR DESCRIPTION
# 설명
작업 내역을 설명하고 어떤 이슈와 관련되어 있는지 명시합니다.

Fixes #
Closes #208 
Resolves #

# 작업 내역
- 일주일간의 그룹원들의 작업 통계를 확인하기 위한 데이터를 만드는 로직 구현

## 작업 결과물
ReportEntity 하위에 ReportCell을 두었음 
Report Cell
- memberEntity : 어떤 유저의 정보인지)
- memberResolutionList : 이 유저가 공유한 목표 리스트)
- memberSuccessResolutionMap : 각 목표에 대한 성공/실패 여부를 {목표ID:T/F}의 형태로 보여줌
- doneResolutionIdListForEachDay : 각 요일 별로 인증한 목표id를 담은 List의 List
```
class GroupWeeklyReportEntity {
  String groupId;
  List<GroupWeeklyReportCell> groupWeeklyReportCellList;
}

class GroupWeeklyReportCell {
  UserDataEntity memberEntity;
  List<ResolutionEntity> memberResolutionList;
  Map<String, bool> memberSuccessResolutionMap;
  List<List<String>> doneResolutionIdListForEachDay;
}

```


## 참고 사항(선택)
작업을 진행하면서 참고한 사항이나 참고할 사항이 있다면 적어주세요.
(ex. 나중에 수정해야 할 부분, 참고한 사이트, 참고한 코드 등)

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
