### PR TITLE
[#227] feat: 인증글 카드의 달성 게이지 적용 및 기타 로직 수정

### DIFF
--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -22,6 +22,7 @@ export 'theme/theme_extension.dart';
 export 'usecases/stream_usecase.dart';
 export 'usecases/usecase.dart';
 export 'utils/custom_types.dart';
+export 'utils/datetime+.dart';
 export 'utils/emoji_assets.dart';
 export 'utils/firebase_collection_name.dart';
 export 'utils/icon_assets.dart';

--- a/lib/common/utils/datetime+.dart
+++ b/lib/common/utils/datetime+.dart
@@ -1,0 +1,9 @@
+// ignore: file_names
+extension GetMonday on DateTime {
+  DateTime getMondayDateTime() {
+    DateTime startDate = DateTime(year, month, day)
+        .subtract(Duration(days: weekday - DateTime.monday));
+
+    return startDate;
+  }
+}

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -298,7 +298,7 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
   EitherFuture<bool> uploadConfirmPost(ConfirmPostEntity entity) async {
     try {
       final model = FirebaseConfirmPostModel.fromConfirmPostEntity(entity);
-
+      print(model.content);
       await firestore
           .collection(FirebaseCollectionName.confirmPosts)
           .add(model.toFirestoreMap());

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -17,7 +17,8 @@ abstract class WehavitDatasource {
     String resolutionId,
   );
 
-  EitherFuture<ConfirmPostEntity> getConfirmPostOfTodayByResolutionGoalId(
+  EitherFuture<ConfirmPostEntity> getConfirmPostOfTargetDateByResolutionGoalId(
+    DateTime targetDate,
     String resolutionId,
   );
 

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -111,8 +111,9 @@ abstract class WehavitDatasource {
     required String groupId,
   });
 
-  EitherFuture<int> getTargetResolutionDoneCountForThisWeek({
+  EitherFuture<int> getTargetResolutionDoneCountForWeek({
     required String resolutionId,
+    required DateTime startMonday,
   });
 
   EitherFuture<List<GroupEntity>> getResolutionSharingTargetGroupList(

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:wehavit/common/utils/timestamp_serializer.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 
 part 'firebase_resolution_model.g.dart';

--- a/lib/data/repositories/confirm_post_repository_impl.dart
+++ b/lib/data/repositories/confirm_post_repository_impl.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/widgets.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/errors/failure.dart';
 import 'package:wehavit/common/utils/custom_types.dart';
@@ -103,25 +102,16 @@ class ConfirmPostRepositoryImpl implements ConfirmPostRepository {
     required String groupId,
     required DateTime selectedDate,
   }) async {
-    try {
-      final getResult =
-          await _wehavitDatasource.getGroupConfirmPostEntityListByDate(
-        groupId,
-        selectedDate,
-      );
-      return getResult;
-    } on Exception catch (e) {
-      debugPrint(e.toString());
-      return Future(() => left(Failure(e.toString())));
-    }
+    return _wehavitDatasource.getGroupConfirmPostEntityListByDate(
+      groupId,
+      selectedDate,
+    );
   }
 
   @override
   EitherFuture<String> uploadConfirmPostImage({
     required String localFileUrl,
   }) async {
-    final uploadResult = await _wehavitDatasource
-        .uploadConfirmPostImageFromLocalUrl(localFileUrl);
-    return uploadResult;
+    return _wehavitDatasource.uploadConfirmPostImageFromLocalUrl(localFileUrl);
   }
 }

--- a/lib/data/repositories/confirm_post_repository_impl.dart
+++ b/lib/data/repositories/confirm_post_repository_impl.dart
@@ -18,8 +18,11 @@ class ConfirmPostRepositoryImpl implements ConfirmPostRepository {
   ) async {
     final String resolutionId = confirmPostEntity.resolutionId!;
     try {
-      final existingPost = await _wehavitDatasource
-          .getConfirmPostOfTodayByResolutionGoalId(resolutionId);
+      final existingPost =
+          await _wehavitDatasource.getConfirmPostOfTargetDateByResolutionGoalId(
+        confirmPostEntity.createdAt!,
+        resolutionId,
+      );
 
       existingPost.fold(
         (l) {

--- a/lib/data/repositories/resolution_repository_impl.dart
+++ b/lib/data/repositories/resolution_repository_impl.dart
@@ -46,9 +46,13 @@ class ResolutionRepositoryImpl implements ResolutionRepository {
   }
 
   @override
-  EitherFuture<int> getResolutionDoneCountForThisWeek(String resolutionId) {
-    return _wehavitDatasource.getTargetResolutionDoneCountForThisWeek(
+  EitherFuture<int> getResolutionDoneCountForWeek({
+    required String resolutionId,
+    required DateTime startMonday,
+  }) {
+    return _wehavitDatasource.getTargetResolutionDoneCountForWeek(
       resolutionId: resolutionId,
+      startMonday: startMonday,
     );
   }
 

--- a/lib/domain/repositories/resolution_repository.dart
+++ b/lib/domain/repositories/resolution_repository.dart
@@ -12,7 +12,10 @@ abstract class ResolutionRepository {
 
   EitherFuture<void> unshareResolutionToGroup(String $1, String $2);
 
-  EitherFuture<int> getResolutionDoneCountForThisWeek(String resolutionId);
+  EitherFuture<int> getResolutionDoneCountForWeek({
+    required String resolutionId,
+    required DateTime startMonday,
+  });
 
   EitherFuture<List<GroupEntity>> getResolutionSharingTargetGroupList(
     String resolutionId,

--- a/lib/domain/usecases/get_target_resolution_done_count_for_week_usecase.dart
+++ b/lib/domain/usecases/get_target_resolution_done_count_for_week_usecase.dart
@@ -10,8 +10,11 @@ class GetTargetResolutionDoneCountForWeekUsecase {
 
   EitherFuture<int> call({
     required String resolutionId,
+    required DateTime startMonday,
   }) {
-    return _resolutionRepository
-        .getResolutionDoneCountForThisWeek(resolutionId);
+    return _resolutionRepository.getResolutionDoneCountForWeek(
+      resolutionId: resolutionId,
+      startMonday: startMonday,
+    );
   }
 }

--- a/lib/domain/usecases/upload_confirm_post_usecase.dart
+++ b/lib/domain/usecases/upload_confirm_post_usecase.dart
@@ -19,6 +19,7 @@ class UploadConfirmPostUseCase {
     required String content,
     required List<String> localFileUrlList,
     required bool hasRested,
+    required bool isPostingForYesterday,
   }) async {
     try {
       final networkImageUrlList = await Future.wait(
@@ -58,7 +59,8 @@ class UploadConfirmPostUseCase {
         imageUrlList: networkImageUrlList,
         owner: uid,
         recentStrike: 0,
-        createdAt: DateTime.now(),
+        createdAt: DateTime.now()
+            .subtract(Duration(days: isPostingForYesterday ? 1 : 0)),
         updatedAt: DateTime.now(),
         hasRested: hasRested,
       );

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -347,6 +347,7 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                             child: ConfirmPostWidget(
                               confirmPostEntity: viewModel.confirmPostList[
                                   viewModel.selectedDate]![index],
+                              createdDate: viewModel.selectedDate,
                             ),
                           ),
                         ),

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -2,9 +2,8 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:wehavit/common/constants/constants.dart';
-import 'package:wehavit/common/utils/emoji_assets.dart';
-import 'package:wehavit/common/utils/utils.dart';
+import 'package:wehavit/common/common.dart';
+
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
@@ -16,10 +15,12 @@ import 'package:wehavit/presentation/write_post/write_post.dart';
 class ConfirmPostWidget extends ConsumerStatefulWidget {
   const ConfirmPostWidget({
     required this.confirmPostEntity,
+    required this.createdDate,
     super.key,
   });
 
   final ConfirmPostEntity confirmPostEntity;
+  final DateTime createdDate;
 
   @override
   ConsumerState<ConfirmPostWidget> createState() => _ConfirmPostWidgetState();
@@ -27,19 +28,23 @@ class ConfirmPostWidget extends ConsumerStatefulWidget {
 
 class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
     with TickerProviderStateMixin {
-  late Future<int> resolutionDoneCountForThisWeek;
+  late Future<int> resolutionDoneCountForWrittenWeek;
   late EitherFuture<UserDataEntity> futureUserDataEntity;
   late Future<ResolutionEntity?> futureResolutionEntity;
 
   @override
   void initState() {
     super.initState();
+    print(widget.createdDate.getMondayDateTime());
     futureUserDataEntity = ref.read(getUserDataFromIdUsecaseProvider)(
         widget.confirmPostEntity.owner!);
 
-    resolutionDoneCountForThisWeek = ref
+    resolutionDoneCountForWrittenWeek = ref
         .read(getTargetResolutionDoneCountForWeekUsecaseProvider)
-        .call(resolutionId: widget.confirmPostEntity.resolutionId!)
+        .call(
+          resolutionId: widget.confirmPostEntity.resolutionId!,
+          startMonday: widget.createdDate.getMondayDateTime(),
+        )
         .then((result) => result.fold((failure) => -1, (count) => count));
 
     futureResolutionEntity = ref
@@ -151,7 +156,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                         // const SizedBox(height: 12.0),
                         FutureBuilder(
                           future: Future.wait([
-                            resolutionDoneCountForThisWeek,
+                            resolutionDoneCountForWrittenWeek,
                             futureResolutionEntity,
                           ]),
                           builder: (context, snapshot) {

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/constants/constants.dart';
 import 'package:wehavit/common/utils/emoji_assets.dart';
 import 'package:wehavit/common/utils/utils.dart';
@@ -156,7 +155,6 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                             futureResolutionEntity,
                           ]),
                           builder: (context, snapshot) {
-                            print(snapshot);
                             if (snapshot.hasData) {
                               int successCount = snapshot.data![0] as int;
                               ResolutionEntity? resolutionEntity =

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -71,6 +71,7 @@ class ResolutionListViewModelProvider
       content: '',
       localFileUrlList: [],
       hasRested: false,
+      isPostingForYesterday: false,
     );
   }
 }

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -35,6 +35,7 @@ class ResolutionListViewModelProvider
         if (entity.resolutionId != null) {
           successCount = await _getTargetResolutionDoneCountForWeekUsecase(
             resolutionId: entity.resolutionId ?? '',
+            startMonday: DateTime.now().getMondayDateTime(),
           ).then(
             (result) => result.fold(
               (failure) => 0,

--- a/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
@@ -32,6 +32,7 @@ class WritingConfirmPostViewModelProvider
       localFileUrlList:
           state.imageMediaList.map((media) => media.path.toString()).toList(),
       hasRested: hasRested,
+      isPostingForYesterday: state.isWritingYesterdayPost,
     );
   }
 }

--- a/lib/presentation/write_post/view/resolution_list_view_widget.dart
+++ b/lib/presentation/write_post/view/resolution_list_view_widget.dart
@@ -233,7 +233,7 @@ class ResolutionLinearGaugeWidget extends StatelessWidget {
                   ),
                 ),
                 Flexible(
-                  flex: model.entity.actionPerWeek ?? 1 - model.successCount,
+                  flex: (model.entity.actionPerWeek ?? 1) - model.successCount,
                   child: Container(
                     height: 7,
                     color: Colors.transparent,

--- a/lib/presentation/write_post/view/writing_confirm_post_view.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view.dart
@@ -146,6 +146,9 @@ class _WritingConfirmPostViewState
                         color: CustomColors.whPlaceholderGrey.withAlpha(200),
                       ),
                     ),
+                    onChanged: (value) {
+                      viewModel.postContent = value;
+                    },
                   ),
                 ),
                 Visibility(


### PR DESCRIPTION
# 설명
인증글 카드의 달성 게이지 UI가 정상적으로 출력될 수 있도록 개선 + 이를 위해 내부 로직을 일부 수정함

Fixes #
Closes #227
Resolves #

# 작업 내역
- 인증글 카드 달성 게이지가 보여지도록 하기 위해 ConfirmPostEntity 에 데이터 추가
- 인증글 달성 게이지의 비율이 정상적으로 보이도록 View 코드 수정
- 지난 날짜 인증글 남기기 기능 정상적으로 동작
- 인증글 본문이 정상적으로 파이어베이스로 업로드됨


## 작업 결과물

|이미지|GIF|
|---|---|
|<img width="300" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/2610df81-aef9-449b-bd51-d22e08e8aae4">|![Simulator Screen Recording - iPhone 13 Pro - 2024-05-10 at 09 15 56](https://github.com/cau-bootcamp/wehavit/assets/39216546/d518d272-6c67-410b-8250-8ff7cbb2253e)|


## 참고 사항(선택)
주어진 Date에 대해서 해당 Date가 들어있는 주의 월요일날의 00:00:00에 해당하는 DateTime을 만들어내는 함수를 DateTime Extension으로 추가해주었음. 상속 키워드인 extends와 확장 키워드인 extension 가 비슷해서인지 class extend를 검색했을 때 잘 안나와서 extension이 없나? 생각하고 있었는데, 다시 찾아보니 extension 키워드가 있어 적용해주었음. 유틸리티 함수는 좀 더 적극적으로 extension을 사용해서 코드 중복을 줄여나가보자.

작업을 진행하면서 Data Layer 쪽의 코드를 이후에 한 번 정리해야겠다는 생각이 들었음. 기능을 개발하면서 이전에 작성한 함수를 좀 더 일반적인 메서드로 변경해서 적용하게 되는 일이 심심치않게 발생하고 있다. 예를 들면, [이번 일주일 동안의 달성 횟수를 가져오는 메서드 → 과거의 특정한 일주일 동안의 달성 횟수를 가져오는 메서드] 로 변경을 했는데, 어쩌면 [특정 기간동안의 달성 횟수를 가져오는 메서드]로 확장이 필요할 수도 있을 것 같음. 요런 부분은 이후에 리펙토링을 한 번 적용하면서 개선을 적용할 부분인 것 같다.
- 현재 작성되어 있는 코드에서 중복되는 부분들은 Data Layer 내부 메서드로 따로 추출해버리기
- 구체적인 메서드들은 추상화해서 단순화하기 + 구체적인 형태는 Usecase로 분리하면 되니까--계층 분리의 이점을 살려보자

갈 길이 멀다~!

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
