### PR TITLE
[#239] fix: 그룹뷰, 그룹포스트뷰 UI 및 로직 개선

### DIFF
--- a/lib/presentation/common_components/resolution_list_cell_widget.dart
+++ b/lib/presentation/common_components/resolution_list_cell_widget.dart
@@ -22,24 +22,14 @@ class ResolutionListCellWidget extends ConsumerStatefulWidget {
 
 class _MyPageResolutionListCellWidgetState
     extends ConsumerState<ResolutionListCellWidget> {
-  late EitherFuture<List<bool>> futureDoneList =
-      ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
-    resolutionId: widget.resolutionEntity.resolutionId ?? '',
-    startMonday: DateTime.now().getMondayDateTime(),
-  );
-
-  @override
-  void initState() {
-    super.initState();
-    // final EitherFuture<List<bool>> futureDoneList =
-    //     ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
-    //   resolutionId: widget.resolutionEntity.resolutionId ?? '',
-    //   startMonday: DateTime.now().getMondayDateTime(),
-    // );
-  }
-
   @override
   Widget build(BuildContext context) {
+    EitherFuture<List<bool>> futureDoneList =
+        ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
+      resolutionId: widget.resolutionEntity.resolutionId ?? '',
+      startMonday: DateTime.now().getMondayDateTime(),
+    );
+
     final daysSinceFirstDay = DateTime.now()
             .difference(widget.resolutionEntity.startDate ?? DateTime.now())
             .inDays +
@@ -395,6 +385,7 @@ class ResolutionLinearGaugeWidget extends StatelessWidget {
       mainWidgetCallback: (successList) {
         final successCount =
             successList.where((element) => element == true).length;
+
         return Column(
           children: [
             Row(

--- a/lib/presentation/common_components/resolution_list_cell_widget.dart
+++ b/lib/presentation/common_components/resolution_list_cell_widget.dart
@@ -22,13 +22,25 @@ class ResolutionListCellWidget extends ConsumerStatefulWidget {
 
 class _MyPageResolutionListCellWidgetState
     extends ConsumerState<ResolutionListCellWidget> {
+  late EitherFuture<List<bool>> futureDoneList =
+      ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
+    resolutionId: widget.resolutionEntity.resolutionId ?? '',
+    startMonday: DateTime.now().getMondayDateTime(),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    // final EitherFuture<List<bool>> futureDoneList =
+    //     ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
+    //   resolutionId: widget.resolutionEntity.resolutionId ?? '',
+    //   startMonday: DateTime.now().getMondayDateTime(),
+    // );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final EitherFuture<List<bool>> futureDoneList =
-        ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
-      resolutionId: widget.resolutionEntity.resolutionId ?? '',
-      startMonday: DateTime.now().getMondayDateTime(),
-    );
+    print("BUILD");
 
     final daysSinceFirstDay = DateTime.now()
             .difference(widget.resolutionEntity.startDate ?? DateTime.now())
@@ -314,33 +326,26 @@ class ResolutionListWeeklyDoneCellPlaceholderWidget extends StatelessWidget {
   }
 }
 
-class ResolutionLinearGaugeWidget extends ConsumerStatefulWidget {
+class ResolutionLinearGaugeWidget extends StatelessWidget {
   const ResolutionLinearGaugeWidget({
     required this.resolutionEntity,
     required this.futureDoneList,
     super.key,
   });
 
-  final ResolutionEntity resolutionEntity;
+  final ResolutionEntity? resolutionEntity;
   final EitherFuture<List<bool>> futureDoneList;
 
   @override
-  ConsumerState<ResolutionLinearGaugeWidget> createState() =>
-      _ResolutionLinearGaugeWidgetState();
-}
-
-class _ResolutionLinearGaugeWidgetState
-    extends ConsumerState<ResolutionLinearGaugeWidget> {
-  @override
   Widget build(BuildContext context) {
     return EitherFutureBuilder<List<bool>>(
-      target: widget.futureDoneList,
+      target: futureDoneList,
       forWaiting: Column(
         children: [
           Row(
             children: [
               Text(
-                widget.resolutionEntity.actionStatement ?? '',
+                resolutionEntity?.actionStatement ?? '',
                 style: const TextStyle(
                   color: CustomColors.whWhite,
                   fontSize: 14.0,
@@ -354,8 +359,7 @@ class _ResolutionLinearGaugeWidgetState
           ),
           LinearProgressIndicator(
             minHeight: 7,
-            color:
-                PointColors.colorList[widget.resolutionEntity.colorIndex ?? 0],
+            color: PointColors.colorList[resolutionEntity?.colorIndex ?? 0],
             backgroundColor: CustomColors.whDarkBlack,
           ),
         ],
@@ -399,7 +403,7 @@ class _ResolutionLinearGaugeWidgetState
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  widget.resolutionEntity.actionStatement ?? '',
+                  resolutionEntity?.actionStatement ?? '',
                   style: const TextStyle(
                     color: CustomColors.whWhite,
                     fontSize: 14.0,
@@ -408,7 +412,7 @@ class _ResolutionLinearGaugeWidgetState
                 ),
                 Text(
                   // ignore: lines_longer_than_80_chars
-                  '주 ${widget.resolutionEntity.actionPerWeek}회 중 $successCount회 실천',
+                  '주 ${resolutionEntity?.actionPerWeek ?? '-'}회 중 $successCount회 실천',
                   style: const TextStyle(
                     color: CustomColors.whWhite,
                     fontSize: 12.0,
@@ -436,12 +440,12 @@ class _ResolutionLinearGaugeWidgetState
                       child: Container(
                         height: 7,
                         color: PointColors
-                            .colorList[widget.resolutionEntity.colorIndex ?? 0],
+                            .colorList[resolutionEntity?.colorIndex ?? 0],
                       ),
                     ),
                     Flexible(
-                      flex: (widget.resolutionEntity.actionPerWeek ?? 1) -
-                          successCount,
+                      flex:
+                          (resolutionEntity?.actionPerWeek ?? 1) - successCount,
                       child: Container(
                         height: 7,
                         color: Colors.transparent,

--- a/lib/presentation/common_components/resolution_list_cell_widget.dart
+++ b/lib/presentation/common_components/resolution_list_cell_widget.dart
@@ -40,8 +40,6 @@ class _MyPageResolutionListCellWidgetState
 
   @override
   Widget build(BuildContext context) {
-    print("BUILD");
-
     final daysSinceFirstDay = DateTime.now()
             .difference(widget.resolutionEntity.startDate ?? DateTime.now())
             .inDays +

--- a/lib/presentation/effects/camera_quickshot/reaction_camera_widget.dart
+++ b/lib/presentation/effects/camera_quickshot/reaction_camera_widget.dart
@@ -151,8 +151,8 @@ class _ReactionCameraWidgetState extends ConsumerState<ReactionCameraWidget> {
                       textAlign: TextAlign.center,
                       style: const TextStyle(
                         decoration: TextDecoration.none,
-                        color: CustomColors.whWhite,
                         fontSize: 24,
+                        color: CustomColors.whWhite,
                         fontWeight: FontWeight.w400,
                       ),
                     ),
@@ -163,9 +163,11 @@ class _ReactionCameraWidgetState extends ConsumerState<ReactionCameraWidget> {
                     top: _reactionCameraWidgetModel.cameraWidgetPositionY +
                         _reactionCameraWidgetModel.cameraWidgetRadius * 2 +
                         100,
-                    child: const Text(
-                      '취소하려면 지금 손가락을 떼세요',
-                      style: TextStyle(
+                    child: Text(
+                      _reactionCameraWidgetModel.isPosInCapturingArea
+                          ? ''
+                          : '취소하려면 지금 손가락을 떼세요',
+                      style: const TextStyle(
                         decoration: TextDecoration.none,
                         color: CustomColors.whWhite,
                         fontSize: 16.0,

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
@@ -69,6 +68,7 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                 onPressed: () async {
                   await ref.read(logOutUseCaseProvider).call();
                   if (mounted) {
+                    // ignore: use_build_context_synchronously
                     Navigator.pushReplacementNamed(context, '/entrance');
                   }
                 },

--- a/lib/presentation/group/view/group_list_view_cell_widget.dart
+++ b/lib/presentation/group/view/group_list_view_cell_widget.dart
@@ -1,7 +1,9 @@
 import 'package:dotted_border/dotted_border.dart';
 import 'package:flutter/material.dart';
+import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/constants/constants.dart';
 import 'package:wehavit/common/utils/utils.dart';
+import 'package:wehavit/presentation/common_components/common_components.dart';
 import 'package:wehavit/presentation/group/group.dart';
 
 class GroupListViewCellWidget extends StatelessWidget {
@@ -77,15 +79,19 @@ class GroupListViewCellContentWidget extends StatelessWidget {
                   children: [
                     GroupListCellBulletWidget(
                       title: '멤버 수',
-                      number: cellModel.groupEntity.groupMemberUidList.length,
+                      number: Future(
+                        () => right(
+                          cellModel.groupEntity.groupMemberUidList.length,
+                        ),
+                      ),
                     ),
                     const SizedBox(height: 6),
-                    GroupListCellBulletFutureWidget(
+                    GroupListCellBulletWidget(
                       title: '함께 도전중인 목표 수',
                       number: cellModel.sharedResolutionCount,
                     ),
                     const SizedBox(height: 6),
-                    GroupListCellBulletFutureWidget(
+                    GroupListCellBulletWidget(
                       title: '현재까지 올라온 인증글 수',
                       number: cellModel.sharedPostCount,
                     ),
@@ -108,7 +114,7 @@ class GroupListCellBulletWidget extends StatelessWidget {
   });
 
   final String title;
-  final int number;
+  final EitherFuture<int> number;
 
   @override
   Widget build(BuildContext context) {
@@ -126,72 +132,37 @@ class GroupListCellBulletWidget extends StatelessWidget {
         const SizedBox(
           width: 8,
         ),
-        Text(
-          number.toString(),
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 22,
-            fontWeight: FontWeight.w600,
-            height: 0,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class GroupListCellBulletFutureWidget extends StatelessWidget {
-  const GroupListCellBulletFutureWidget({
-    super.key,
-    required this.title,
-    required this.number,
-  });
-
-  final String title;
-  final EitherFuture<int> number;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Text(
-            title,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 16,
-              fontWeight: FontWeight.w300,
+        EitherFutureBuilder<int>(
+          target: number,
+          forFail: Container(),
+          forWaiting: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(4.0),
+              color: CustomColors.whGrey,
+            ),
+            child: const Text(
+              '1234',
+              style: TextStyle(
+                color: Colors.transparent,
+                fontSize: 22,
+                fontWeight: FontWeight.w600,
+                height: 0,
+              ),
             ),
           ),
-          const SizedBox(
-            width: 8,
-          ),
-          FutureBuilder(
-            future: number,
-            builder: (context, snapshot) {
-              if (snapshot.hasData) {
-                return Text(
-                  snapshot.data!.fold((l) => '0', (r) => r.toString()),
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 22,
-                    fontWeight: FontWeight.w600,
-                    height: 0,
-                  ),
-                );
-              } else {
-                // TODO: 나중에 예쁜걸로 수정하기! ******
-                return const SizedBox(
-                  width: 30,
-                  height: 16,
-                  child: LinearProgressIndicator(),
-                );
-              }
-            },
-          ),
-        ],
-      ),
+          mainWidgetCallback: (value) {
+            return Text(
+              value.toString(),
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 22,
+                fontWeight: FontWeight.w600,
+                height: 0,
+              ),
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -149,8 +149,11 @@ class _GroupViewState extends ConsumerState<GroupView>
               ),
               WideColoredButton(
                 buttonTitle: '돌아가기',
-                onPressed: () {},
-                isDiminished: true,
+                backgroundColor: Colors.transparent,
+                foregroundColor: CustomColors.whPlaceholderGrey,
+                onPressed: () {
+                  Navigator.pop(context);
+                },
               ),
             ],
           ),

--- a/lib/presentation/group_post/model/group_post_view_model.dart
+++ b/lib/presentation/group_post/model/group_post_view_model.dart
@@ -4,6 +4,7 @@ import 'package:camera/camera.dart';
 import 'package:carousel_slider/carousel_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/effects/effects.dart';
 
@@ -33,7 +34,7 @@ class GroupPostViewModel {
 
   String get selectedDateString => formatter.format(selectedDate);
 
-  Map<DateTime, List<ConfirmPostEntity>> confirmPostList = {};
+  Map<DateTime, EitherFuture<List<ConfirmPostEntity>>> confirmPostList = {};
 
   Point<double> panPosition = const Point<double>(0, 0);
   List<DateTime> calendartMondayDateList = [

--- a/lib/presentation/group_post/model/group_post_view_model.dart
+++ b/lib/presentation/group_post/model/group_post_view_model.dart
@@ -14,6 +14,8 @@ class GroupPostViewModel {
   ScrollController scrollController = ScrollController();
 
   String groupId = '';
+
+  bool isShowingCalendar = true;
   DateTime selectedDate =
       DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
 

--- a/lib/presentation/group_post/provider/group_post_view_model_provider.dart
+++ b/lib/presentation/group_post/provider/group_post_view_model_provider.dart
@@ -26,15 +26,8 @@ class GroupPostViewModelProvider extends StateNotifier<GroupPostViewModel> {
   }) async {
     final selectedDate = DateTime(dateTime.year, dateTime.month, dateTime.day);
 
-    final fetchResult =
-        await _getGroupConfirmPostListByDateUsecase(state.groupId, selectedDate)
-            .then((result) => result.fold((failure) => null, (list) => list));
-
-    if (fetchResult == null) {
-      return;
-    }
-
-    state.confirmPostList[selectedDate] = fetchResult;
+    state.confirmPostList[selectedDate] =
+        _getGroupConfirmPostListByDateUsecase(state.groupId, selectedDate);
   }
 
   // Reactions

--- a/lib/presentation/group_post/view/confirm_post_photo_view.dart
+++ b/lib/presentation/group_post/view/confirm_post_photo_view.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+import 'package:photo_view/photo_view_gallery.dart';
+import 'package:wehavit/common/constants/app_colors.dart';
+
+class ConfirmPostPhotoView extends StatelessWidget {
+  const ConfirmPostPhotoView({
+    required this.imageProviderList,
+    required this.initPageIndex,
+    super.key,
+  });
+
+  final List<ImageProvider> imageProviderList;
+  final int initPageIndex;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        leading: IconButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          icon: const Icon(
+            Icons.chevron_left,
+            color: CustomColors.whWhite,
+            size: 32.0,
+          ),
+        ),
+      ),
+      body: PhotoViewGallery.builder(
+        scrollPhysics: const ClampingScrollPhysics(),
+        pageController: PageController(initialPage: initPageIndex),
+        backgroundDecoration: const BoxDecoration(color: Colors.black),
+        itemCount: imageProviderList.length,
+        loadingBuilder: (context, event) {
+          return Container(
+            decoration: const BoxDecoration(
+              color: Colors.black,
+            ),
+            child: const Center(
+              child: SizedBox(
+                width: 50,
+                height: 50,
+                child: CircularProgressIndicator(
+                  color: CustomColors.whYellow,
+                ),
+              ),
+            ),
+          );
+        },
+        builder: (context, index) {
+          return PhotoViewGalleryPageOptions(
+            imageProvider: imageProviderList[index],
+            initialScale: PhotoViewComputedScale.contained * 0.9,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/group_post/view/group_member_list_view_widget.dart
+++ b/lib/presentation/group_post/view/group_member_list_view_widget.dart
@@ -127,7 +127,7 @@ class _GroupMemberListBottomSheetState
                               ),
                             ),
                           ),
-                        )
+                        ),
                       ],
                     ),
                   ),
@@ -184,6 +184,7 @@ class _GroupMemberListBottomSheetState
                         //   ],
                         // ),
                         child: Text(
+                          // ignore: lines_longer_than_80_chars
                           '멤버 (${widget.groupEntity.groupMemberUidList.length})',
                           style: const TextStyle(
                             color: CustomColors.whPlaceholderGrey,
@@ -406,7 +407,6 @@ class _GroupMemberListCellWidgetState
               const SizedBox(width: 4.0),
               SmallColoredButtonWidget(
                 buttonLabel: '수락',
-                backgroundColor: CustomColors.whYellow,
                 onPressed: () async {
                   await ref
                       .watch(acceptApplyingForJoiningGroupUsecaseProvider)(

--- a/lib/presentation/group_post/view/group_member_list_view_widget.dart
+++ b/lib/presentation/group_post/view/group_member_list_view_widget.dart
@@ -149,6 +149,7 @@ class _GroupMemberListBottomSheetState
                           padding: const EdgeInsets.only(bottom: 12.0),
                           child: GroupMemberListCellWidget(
                             memberId: appliedUidList[index],
+                            groupManagerUid: widget.groupEntity.groupManagerUid,
                             groupEntity: widget.groupEntity,
                             isManagingMode: isManagingMode,
                             isAppliedUser: true,
@@ -164,23 +165,31 @@ class _GroupMemberListBottomSheetState
                     children: [
                       GestureDetector(
                         onTapUp: (_) {},
-                        child: const Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                              '가나다 순',
-                              style: TextStyle(
-                                color: CustomColors.whPlaceholderGrey,
-                                fontSize: 16.0,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            Icon(
-                              Icons.keyboard_arrow_down,
-                              color: CustomColors.whPlaceholderGrey,
-                              size: 20.0,
-                            ),
-                          ],
+                        // child: const Row(
+                        //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        //   children: [
+                        //     Text(
+                        //       '가나다 순',
+                        //       style: TextStyle(
+                        //         color: CustomColors.whPlaceholderGrey,
+                        //         fontSize: 16.0,
+                        //         fontWeight: FontWeight.w600,
+                        //       ),
+                        //     ),
+                        //     Icon(
+                        //       Icons.keyboard_arrow_down,
+                        //       color: CustomColors.whPlaceholderGrey,
+                        //       size: 20.0,
+                        //     ),
+                        //   ],
+                        // ),
+                        child: Text(
+                          '멤버 (${widget.groupEntity.groupMemberUidList.length})',
+                          style: const TextStyle(
+                            color: CustomColors.whPlaceholderGrey,
+                            fontSize: 16.0,
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
                       ),
                       Text(
@@ -204,6 +213,7 @@ class _GroupMemberListBottomSheetState
                         child: GroupMemberListCellWidget(
                           memberId:
                               widget.groupEntity.groupMemberUidList[index],
+                          groupManagerUid: widget.groupEntity.groupManagerUid,
                           groupEntity: widget.groupEntity,
                           isManagingMode: isManagingMode,
                           isAppliedUser: false,
@@ -238,6 +248,7 @@ class GroupMemberListCellWidget extends ConsumerStatefulWidget {
   const GroupMemberListCellWidget({
     super.key,
     required this.memberId,
+    required this.groupManagerUid,
     required this.groupEntity,
     required this.isManagingMode,
     required this.isAppliedUser,
@@ -247,6 +258,7 @@ class GroupMemberListCellWidget extends ConsumerStatefulWidget {
   final bool isManagingMode;
   final bool isAppliedUser;
   final String memberId;
+  final String groupManagerUid;
   final GroupEntity groupEntity;
   final Function(GroupEntity, String) updateGroupEntity;
 
@@ -339,30 +351,33 @@ class _GroupMemberListCellWidgetState
             ),
             child: Row(
               children: [
-                SmallColoredButtonWidget(
-                  buttonLabel: '내보내기',
-                  backgroundColor: CustomColors.whBrightGrey,
-                  onPressed: () async {
-                    await ref
-                        .watch(withdrawalFromGroupUsecaseProvider)(
-                      groupId: widget.groupEntity.groupId,
-                      targetUserId: widget.memberId,
-                    )
-                        .then((result) {
-                      if (result.isRight()) {
-                        final List<String> uidList = widget
-                            .groupEntity.groupMemberUidList
-                            .where((element) => element != widget.memberId)
-                            .toList();
+                Visibility(
+                  visible: widget.groupManagerUid != widget.memberId,
+                  child: SmallColoredButtonWidget(
+                    buttonLabel: '내보내기',
+                    backgroundColor: CustomColors.whBrightGrey,
+                    onPressed: () async {
+                      await ref
+                          .watch(withdrawalFromGroupUsecaseProvider)(
+                        groupId: widget.groupEntity.groupId,
+                        targetUserId: widget.memberId,
+                      )
+                          .then((result) {
+                        if (result.isRight()) {
+                          final List<String> uidList = widget
+                              .groupEntity.groupMemberUidList
+                              .where((element) => element != widget.memberId)
+                              .toList();
 
-                        widget.updateGroupEntity(
-                          widget.groupEntity
-                              .copyWith(groupMemberUidList: uidList),
-                          widget.memberId,
-                        );
-                      }
-                    });
-                  },
+                          widget.updateGroupEntity(
+                            widget.groupEntity
+                                .copyWith(groupMemberUidList: uidList),
+                            widget.memberId,
+                          );
+                        }
+                      });
+                    },
+                  ),
                 ),
               ],
             ),

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -67,42 +67,55 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                 fontWeight: FontWeight.w600,
               ),
             ),
-            centerTitle: false,
+            leading: IconButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              icon: Icon(
+                Icons.chevron_left,
+                color: CustomColors.whWhite,
+                size: 36.0,
+              ),
+            ),
+            centerTitle: true,
             automaticallyImplyLeading: false,
             actions: [
-              IconButton(
-                onPressed: () async {},
-                icon: const Icon(
-                  Icons.campaign_outlined,
-                  color: CustomColors.whWhite,
-                  size: 30,
-                ),
-              ),
-              IconButton(
-                onPressed: () {},
-                icon: const Icon(
-                  Icons.error_outline,
-                  color: CustomColors.whWhite,
-                  size: 30,
-                ),
-              ),
-              IconButton(
-                onPressed: () async {
-                  showModalBottomSheet(
-                    isScrollControlled: true,
-                    context: context,
-                    builder: (context) {
-                      return GroupMemberListBottomSheet(
-                        updateGroupEntity,
-                        groupEntity: widget.groupEntity,
-                      );
-                    },
-                  );
-                },
-                icon: const Icon(
-                  Icons.people_outline,
-                  color: CustomColors.whWhite,
-                  size: 30,
+              // IconButton(
+              //   onPressed: () async {},
+              //   icon: const Icon(
+              //     Icons.campaign_outlined,
+              //     color: CustomColors.whWhite,
+              //     size: 30,
+              //   ),
+              // ),
+              // IconButton(
+              //   onPressed: () {},
+              //   icon: const Icon(
+              //     Icons.error_outline,
+              //     color: CustomColors.whWhite,
+              //     size: 30,
+              //   ),
+              // ),
+              Container(
+                margin: const EdgeInsets.only(right: 12.0),
+                child: IconButton(
+                  onPressed: () async {
+                    showModalBottomSheet(
+                      isScrollControlled: true,
+                      context: context,
+                      builder: (context) {
+                        return GroupMemberListBottomSheet(
+                          updateGroupEntity,
+                          groupEntity: widget.groupEntity,
+                        );
+                      },
+                    );
+                  },
+                  icon: const Icon(
+                    Icons.people_outline,
+                    color: CustomColors.whWhite,
+                    size: 30,
+                  ),
                 ),
               ),
             ],

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -71,7 +71,7 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
               onPressed: () {
                 Navigator.pop(context);
               },
-              icon: Icon(
+              icon: const Icon(
                 Icons.chevron_left,
                 color: CustomColors.whWhite,
                 size: 36.0,
@@ -139,16 +139,29 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                               fontWeight: FontWeight.w600,
                             ),
                           ),
-                          const Icon(
-                            Icons.keyboard_arrow_down,
-                            color: CustomColors.whWhite,
+                          IconButton(
+                            style: IconButton.styleFrom(
+                              padding: EdgeInsets.all(0),
+                              side: BorderSide.none,
+                            ),
+                            onPressed: () {
+                              setState(() {
+                                viewModel.isShowingCalendar =
+                                    !viewModel.isShowingCalendar;
+                              });
+                            },
+                            icon: const Icon(
+                              Icons.keyboard_arrow_down,
+                              color: CustomColors.whWhite,
+                            ),
                           ),
                         ],
                       ),
-                      Visibility(
-                        visible: true,
-                        child: Container(
-                          padding: const EdgeInsets.only(top: 12),
+                      AnimatedContainer(
+                        duration: const Duration(milliseconds: 250),
+                        curve: Curves.fastOutSlowIn,
+                        height: viewModel.isShowingCalendar ? 64 : 0,
+                        child: ProviderScope(
                           child: CarouselSlider.builder(
                             itemBuilder: (context, index, realIndex) {
                               return Row(
@@ -183,23 +196,22 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                       },
                                       child: Container(
                                         margin: const EdgeInsets.symmetric(
-                                          horizontal: 4,
+                                          horizontal: 4.0,
                                         ),
-                                        height: 64,
                                         clipBehavior: Clip.hardEdge,
                                         decoration: BoxDecoration(
-                                          borderRadius:
-                                              BorderRadius.circular(14.0),
+                                          border: Border.all(
+                                            color: CustomColors.whBlack,
+                                            width: 2,
+                                            strokeAlign:
+                                                BorderSide.strokeAlignOutside,
+                                          ),
+                                          borderRadius: BorderRadius.circular(
+                                            14.0,
+                                          ),
                                         ),
                                         child: Container(
-                                          height: 64,
                                           decoration: BoxDecoration(
-                                            border: Border.all(
-                                              color: CustomColors.whBlack,
-                                              width: 2,
-                                              strokeAlign:
-                                                  BorderSide.strokeAlignOutside,
-                                            ),
                                             boxShadow: [
                                               const BoxShadow(
                                                 blurRadius: 4,
@@ -218,49 +230,62 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                                             .whYellowDark,
                                               ),
                                             ],
-                                            borderRadius:
-                                                BorderRadius.circular(14.0),
                                           ),
                                           child: Column(
                                             mainAxisAlignment:
                                                 MainAxisAlignment.center,
                                             children: [
-                                              Text(
-                                                cellDate.day == 1
-                                                    ? '${cellDate.month}/${cellDate.day}'
-                                                    : cellDate.day.toString(),
-                                                style: TextStyle(
-                                                  fontSize: 16,
-                                                  fontWeight: FontWeight.w500,
-                                                  color: isFuture ||
-                                                          cellDate !=
-                                                              viewModel
-                                                                  .selectedDate
-                                                      ? CustomColors
-                                                          .whPlaceholderGrey
-                                                      : CustomColors.whBlack,
+                                              Flexible(
+                                                child: FittedBox(
+                                                  fit: BoxFit.scaleDown,
+                                                  child: Text(
+                                                    cellDate.day == 1
+                                                        ? '${cellDate.month}/${cellDate.day}'
+                                                        : cellDate.day
+                                                            .toString(),
+                                                    style: TextStyle(
+                                                      fontSize: 16,
+                                                      fontWeight:
+                                                          FontWeight.w500,
+                                                      color: isFuture ||
+                                                              cellDate !=
+                                                                  viewModel
+                                                                      .selectedDate
+                                                          ? CustomColors
+                                                              .whPlaceholderGrey
+                                                          : CustomColors
+                                                              .whBlack,
+                                                    ),
+                                                  ),
                                                 ),
                                               ),
-                                              Text(
-                                                isFuture
-                                                    ? '-'
-                                                    : (viewModel.confirmPostList[
-                                                                cellDate] ??
-                                                            [])
-                                                        .length
-                                                        .toString(),
-                                                style: TextStyle(
-                                                  height: 1.0,
-                                                  fontFamily: 'Giants',
-                                                  fontSize: 24,
-                                                  fontWeight: FontWeight.w700,
-                                                  color: isFuture ||
-                                                          cellDate !=
-                                                              viewModel
-                                                                  .selectedDate
-                                                      ? CustomColors
-                                                          .whPlaceholderGrey
-                                                      : CustomColors.whBlack,
+                                              Flexible(
+                                                child: FittedBox(
+                                                  fit: BoxFit.scaleDown,
+                                                  child: Text(
+                                                    isFuture
+                                                        ? '-'
+                                                        : (viewModel.confirmPostList[
+                                                                    cellDate] ??
+                                                                [])
+                                                            .length
+                                                            .toString(),
+                                                    style: TextStyle(
+                                                      height: 1.0,
+                                                      fontFamily: 'Giants',
+                                                      fontSize: 24,
+                                                      fontWeight:
+                                                          FontWeight.w700,
+                                                      color: isFuture ||
+                                                              cellDate !=
+                                                                  viewModel
+                                                                      .selectedDate
+                                                          ? CustomColors
+                                                              .whPlaceholderGrey
+                                                          : CustomColors
+                                                              .whBlack,
+                                                    ),
+                                                  ),
                                                 ),
                                               ),
                                             ],

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'dart:async';
 
 import 'package:carousel_slider/carousel_slider.dart';
@@ -6,8 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/presentation/effects/effects.dart';
-import 'package:wehavit/presentation/group_post/group_post.dart';
+import 'package:wehavit/presentation/presentation.dart';
 
 class GroupPostView extends ConsumerStatefulWidget {
   GroupPostView({super.key, required this.groupEntity});
@@ -140,10 +141,6 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                             ),
                           ),
                           IconButton(
-                            style: IconButton.styleFrom(
-                              padding: EdgeInsets.all(0),
-                              side: BorderSide.none,
-                            ),
                             onPressed: () {
                               setState(() {
                                 viewModel.isShowingCalendar =
@@ -262,28 +259,62 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                               Flexible(
                                                 child: FittedBox(
                                                   fit: BoxFit.scaleDown,
-                                                  child: Text(
-                                                    isFuture
-                                                        ? '-'
-                                                        : (viewModel.confirmPostList[
-                                                                    cellDate] ??
-                                                                [])
-                                                            .length
+                                                  child: Visibility(
+                                                    visible: !isFuture,
+                                                    replacement: Text(
+                                                      '-',
+                                                      style: TextStyle(
+                                                        height: 1.0,
+                                                        fontFamily: 'Giants',
+                                                        fontSize: 24,
+                                                        fontWeight:
+                                                            FontWeight.w700,
+                                                        color: isFuture ||
+                                                                cellDate !=
+                                                                    viewModel
+                                                                        .selectedDate
+                                                            ? CustomColors
+                                                                .whPlaceholderGrey
+                                                            : CustomColors
+                                                                .whBlack,
+                                                      ),
+                                                    ),
+                                                    child: EitherFutureBuilder<
+                                                        List<
+                                                            ConfirmPostEntity>>(
+                                                      target: viewModel
+                                                              .confirmPostList[
+                                                          cellDate],
+                                                      forWaiting: const Padding(
+                                                        padding:
+                                                            EdgeInsets.all(2.0),
+                                                        child:
+                                                            CircularProgressIndicator(
+                                                          color: CustomColors
+                                                              .whBrightGrey,
+                                                        ),
+                                                      ),
+                                                      forFail: const Text('-'),
+                                                      mainWidgetCallback:
+                                                          (entityList) => Text(
+                                                        entityList.length
                                                             .toString(),
-                                                    style: TextStyle(
-                                                      height: 1.0,
-                                                      fontFamily: 'Giants',
-                                                      fontSize: 24,
-                                                      fontWeight:
-                                                          FontWeight.w700,
-                                                      color: isFuture ||
-                                                              cellDate !=
-                                                                  viewModel
-                                                                      .selectedDate
-                                                          ? CustomColors
-                                                              .whPlaceholderGrey
-                                                          : CustomColors
-                                                              .whBlack,
+                                                        style: TextStyle(
+                                                          height: 1.0,
+                                                          fontFamily: 'Giants',
+                                                          fontSize: 24,
+                                                          fontWeight:
+                                                              FontWeight.w700,
+                                                          color: isFuture ||
+                                                                  cellDate !=
+                                                                      viewModel
+                                                                          .selectedDate
+                                                              ? CustomColors
+                                                                  .whPlaceholderGrey
+                                                              : CustomColors
+                                                                  .whBlack,
+                                                        ),
+                                                      ),
                                                     ),
                                                   ),
                                                 ),
@@ -334,13 +365,18 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                   ),
                 ),
                 Expanded(
-                  child: Visibility(
-                    visible:
-                        viewModel.confirmPostList[viewModel.selectedDate] !=
-                                null &&
-                            viewModel.confirmPostList[viewModel.selectedDate]!
-                                .isNotEmpty,
-                    replacement: const Center(
+                  child: EitherFutureBuilder<List<ConfirmPostEntity>>(
+                    target: viewModel.confirmPostList[viewModel.selectedDate],
+                    forWaiting: const Center(
+                      child: SizedBox(
+                        height: 50,
+                        width: 50,
+                        child: CircularProgressIndicator(
+                          color: CustomColors.whBrightGrey,
+                        ),
+                      ),
+                    ),
+                    forFail: const Center(
                       child: Column(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
@@ -368,27 +404,57 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                         ],
                       ),
                     ),
-                    child: SingleChildScrollView(
-                      padding: const EdgeInsets.only(bottom: 20.0),
-                      physics: reactionCameraViewModel.isFocusingMode
-                          ? const NeverScrollableScrollPhysics()
-                          : const AlwaysScrollableScrollPhysics(),
-                      child: Column(
-                        children: List<Widget>.generate(
-                          viewModel.confirmPostList[viewModel.selectedDate]
-                                  ?.length ??
-                              0,
-                          (index) => Padding(
-                            padding: const EdgeInsets.only(bottom: 12.0),
-                            child: ConfirmPostWidget(
-                              confirmPostEntity: viewModel.confirmPostList[
-                                  viewModel.selectedDate]![index],
-                              createdDate: viewModel.selectedDate,
+                    mainWidgetCallback: (entityList) {
+                      return Visibility(
+                        visible: entityList.isNotEmpty,
+                        replacement: const Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                '아무도 인증글을 남기지 않은\n조용한 날이네요',
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  fontSize: 20,
+                                  fontWeight: FontWeight.bold,
+                                  color: CustomColors.whWhite,
+                                ),
+                              ),
+                              Text(
+                                '🤫',
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  fontSize: 40,
+                                  fontWeight: FontWeight.bold,
+                                  color: CustomColors.whWhite,
+                                ),
+                              ),
+                              SizedBox(
+                                height: 60,
+                              ),
+                            ],
+                          ),
+                        ),
+                        child: SingleChildScrollView(
+                          padding: const EdgeInsets.only(bottom: 20.0),
+                          physics: reactionCameraViewModel.isFocusingMode
+                              ? const NeverScrollableScrollPhysics()
+                              : const AlwaysScrollableScrollPhysics(),
+                          child: Column(
+                            children: List<Widget>.generate(
+                              entityList.length,
+                              (index) => Padding(
+                                padding: const EdgeInsets.only(bottom: 12.0),
+                                child: ConfirmPostWidget(
+                                  confirmPostEntity: entityList[index],
+                                  createdDate: viewModel.selectedDate,
+                                ),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ),
+                      );
+                    },
                   ),
                 ),
               ],

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path/path.dart';
 import 'package:wehavit/common/common.dart';
 
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
@@ -12,6 +11,7 @@ import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 import 'package:wehavit/presentation/effects/effects.dart';
 import 'package:wehavit/presentation/group_post/group_post.dart';
+import 'package:wehavit/presentation/group_post/view/confirm_post_photo_view.dart';
 
 class ConfirmPostWidget extends ConsumerStatefulWidget {
   const ConfirmPostWidget({
@@ -232,9 +232,6 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                         top: 4.0,
                         bottom: 12.0,
                       ),
-
-                      // height: 200,
-
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -682,7 +679,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
   }
 }
 
-class ConfirmPostContentWidget extends StatelessWidget {
+class ConfirmPostContentWidget extends StatefulWidget {
   const ConfirmPostContentWidget({
     super.key,
     required this.confirmPostEntity,
@@ -690,8 +687,26 @@ class ConfirmPostContentWidget extends StatelessWidget {
   final ConfirmPostEntity confirmPostEntity;
 
   @override
+  State<ConfirmPostContentWidget> createState() =>
+      _ConfirmPostContentWidgetState();
+}
+
+class _ConfirmPostContentWidgetState extends State<ConfirmPostContentWidget> {
+  late List<ImageProvider> imageList;
+
+  @override
+  void initState() {
+    super.initState();
+    imageList = widget.confirmPostEntity.imageUrlList?.map((imageUrl) {
+          return NetworkImage(imageUrl);
+        }).toList() ??
+        [];
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (confirmPostEntity.content != null && confirmPostEntity.content != '') {
+    if (widget.confirmPostEntity.content != null &&
+        widget.confirmPostEntity.content != '') {
       return Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -701,7 +716,7 @@ class ConfirmPostContentWidget extends StatelessWidget {
                 minHeight: 100,
               ),
               child: Text(
-                confirmPostEntity.content!,
+                widget.confirmPostEntity.content!,
                 textAlign: TextAlign.start,
                 style: const TextStyle(
                   color: CustomColors.whWhite,
@@ -712,220 +727,177 @@ class ConfirmPostContentWidget extends StatelessWidget {
           const SizedBox(
             width: 4.0,
           ),
-          if (confirmPostEntity.imageUrlList!.isNotEmpty)
-            Stack(
-              alignment: Alignment.bottomRight,
-              children: [
-                Container(
-                  decoration: BoxDecoration(
-                    borderRadius: const BorderRadius.all(
-                      Radius.circular(20.0),
+          if (widget.confirmPostEntity.imageUrlList!.isNotEmpty)
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.all(0),
+                backgroundColor: CustomColors.whDarkBlack,
+              ),
+              onPressed: () async {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ConfirmPostPhotoView(
+                      imageProviderList: imageList,
+                      initPageIndex: 0,
                     ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withAlpha(64),
-                        offset: const Offset(0, 4),
-                        blurRadius: 4,
-                      ),
-                    ],
                   ),
-                  clipBehavior: Clip.hardEdge,
-                  child: Image(
-                    loadingBuilder: (context, child, loadingProgress) {
-                      if (loadingProgress == null) {
-                        return Stack(
-                          children: [
-                            child,
-                            if (confirmPostEntity.imageUrlList!.length > 1)
-                              Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Text(
-                                  // ignore: lines_longer_than_80_chars
-                                  '+${confirmPostEntity.imageUrlList!.length - 1}',
-                                  style: const TextStyle(
-                                    color: CustomColors.whWhite,
-                                    fontSize: 16.0,
-                                    fontWeight: FontWeight.w700,
+                );
+              },
+              child: Stack(
+                alignment: Alignment.bottomRight,
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      color: CustomColors.whDarkBlack,
+                      borderRadius: const BorderRadius.all(
+                        Radius.circular(20.0),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withAlpha(64),
+                          offset: const Offset(0, 4),
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                    clipBehavior: Clip.hardEdge,
+                    child: Image(
+                      loadingBuilder: (context, child, loadingProgress) {
+                        if (loadingProgress == null) {
+                          return Stack(
+                            children: [
+                              child,
+                              if (widget
+                                      .confirmPostEntity.imageUrlList!.length >
+                                  1)
+                                Padding(
+                                  padding: const EdgeInsets.all(8.0),
+                                  child: Text(
+                                    // ignore: lines_longer_than_80_chars
+                                    '+${widget.confirmPostEntity.imageUrlList!.length - 1}',
+                                    style: const TextStyle(
+                                      color: CustomColors.whWhite,
+                                      fontSize: 16.0,
+                                      fontWeight: FontWeight.w700,
+                                    ),
                                   ),
                                 ),
-                              ),
-                          ],
-                        );
-                      } else {
-                        return Container(
-                          color: CustomColors.whBlack,
-                          child: const Center(
-                            child: SizedBox(
-                              width: 30,
-                              height: 30,
-                              child: CircularProgressIndicator(
-                                color: CustomColors.whYellow,
+                            ],
+                          );
+                        } else {
+                          return const SizedBox(
+                            width: 150,
+                            height: 100,
+                            child: Center(
+                              child: SizedBox(
+                                width: 40,
+                                height: 40,
+                                child: CircularProgressIndicator(
+                                  color: CustomColors.whYellow,
+                                ),
                               ),
                             ),
-                          ),
-                        );
-                      }
-                    },
-                    fit: BoxFit.cover,
-                    width: 150,
-                    height: 100,
-                    image: NetworkImage(
-                      confirmPostEntity.imageUrlList!.first,
+                          );
+                        }
+                      },
+                      fit: BoxFit.cover,
+                      width: 150,
+                      height: 100,
+                      image: NetworkImage(
+                        widget.confirmPostEntity.imageUrlList!.first,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
         ],
       );
     } else {
-      if (confirmPostEntity.imageUrlList!.length == 1) {
+      if (widget.confirmPostEntity.imageUrlList!.length == 1) {
+        return ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            padding: const EdgeInsets.all(0),
+            backgroundColor: CustomColors.whDarkBlack,
+          ),
+          onPressed: () async {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => ConfirmPostPhotoView(
+                  imageProviderList: imageList,
+                  initPageIndex: 0,
+                ),
+              ),
+            );
+          },
+          child: AspectRatio(
+            aspectRatio: 1.5,
+            child: Container(
+              decoration: BoxDecoration(
+                color: CustomColors.whDarkBlack,
+                borderRadius: const BorderRadius.all(
+                  Radius.circular(20.0),
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withAlpha(64),
+                    offset: const Offset(0, 4),
+                    blurRadius: 4,
+                  ),
+                ],
+              ),
+              clipBehavior: Clip.hardEdge,
+              child: Image(
+                loadingBuilder: (context, child, loadingProgress) {
+                  if (loadingProgress == null) {
+                    return child;
+                  } else {
+                    return Container(
+                      color: CustomColors.whBlack,
+                      child: const Center(
+                        child: SizedBox(
+                          width: 30,
+                          height: 30,
+                          child: CircularProgressIndicator(
+                            color: CustomColors.whYellow,
+                          ),
+                        ),
+                      ),
+                    );
+                  }
+                },
+                fit: BoxFit.cover,
+                image: NetworkImage(widget.confirmPostEntity.imageUrlList![0]),
+              ),
+            ),
+          ),
+        );
+      } else if (widget.confirmPostEntity.imageUrlList!.length == 2) {
         return Column(
           children: [
-            AspectRatio(
-              aspectRatio: 1.5,
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: const BorderRadius.all(
-                    Radius.circular(20.0),
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withAlpha(64),
-                      offset: const Offset(0, 4),
-                      blurRadius: 4,
-                    ),
-                  ],
-                ),
-                clipBehavior: Clip.hardEdge,
-                child: Image(
-                  loadingBuilder: (context, child, loadingProgress) {
-                    if (loadingProgress == null) {
-                      return child;
-                    } else {
-                      return Container(
-                        color: CustomColors.whBlack,
-                        child: const Center(
-                          child: SizedBox(
-                            width: 30,
-                            height: 30,
-                            child: CircularProgressIndicator(
-                              color: CustomColors.whYellow,
-                            ),
-                          ),
-                        ),
-                      );
-                    }
-                  },
-                  fit: BoxFit.cover,
-                  image: NetworkImage(
-                    confirmPostEntity.imageUrlList![0],
-                  ),
-                ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.all(0),
+                backgroundColor: CustomColors.whDarkBlack,
               ),
-            ),
-          ],
-        );
-      } else if (confirmPostEntity.imageUrlList!.length == 2) {
-        return Column(
-          children: [
-            AspectRatio(
-              aspectRatio: 1.5,
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: const BorderRadius.all(
-                    Radius.circular(20.0),
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withAlpha(64),
-                      offset: const Offset(0, 4),
-                      blurRadius: 4,
+              onPressed: () async {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ConfirmPostPhotoView(
+                      imageProviderList: imageList,
+                      initPageIndex: 0,
                     ),
-                  ],
-                ),
-                clipBehavior: Clip.hardEdge,
-                child: Image(
-                  loadingBuilder: (context, child, loadingProgress) {
-                    if (loadingProgress == null) {
-                      return child;
-                    } else {
-                      return Container(
-                        color: CustomColors.whBlack,
-                        child: const Center(
-                          child: SizedBox(
-                            width: 30,
-                            height: 30,
-                            child: CircularProgressIndicator(
-                              color: CustomColors.whYellow,
-                            ),
-                          ),
-                        ),
-                      );
-                    }
-                  },
-                  fit: BoxFit.cover,
-                  image: NetworkImage(
-                    confirmPostEntity.imageUrlList![0],
                   ),
-                ),
-              ),
-            ),
-            const SizedBox(
-              height: 8.0,
-            ),
-            AspectRatio(
-              aspectRatio: 1.5,
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: const BorderRadius.all(
-                    Radius.circular(20.0),
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withAlpha(64),
-                      offset: const Offset(0, 4),
-                      blurRadius: 4,
-                    ),
-                  ],
-                ),
-                clipBehavior: Clip.hardEdge,
-                child: Image(
-                  loadingBuilder: (context, child, loadingProgress) {
-                    if (loadingProgress == null) {
-                      return child;
-                    } else {
-                      return Container(
-                        color: CustomColors.whBlack,
-                        child: const Center(
-                          child: SizedBox(
-                            width: 30,
-                            height: 30,
-                            child: CircularProgressIndicator(
-                              color: CustomColors.whYellow,
-                            ),
-                          ),
-                        ),
-                      );
-                    }
-                  },
-                  fit: BoxFit.cover,
-                  image: NetworkImage(
-                    confirmPostEntity.imageUrlList![1],
-                  ),
-                ),
-              ),
-            ),
-          ],
-        );
-      } else if (confirmPostEntity.imageUrlList!.length == 3) {
-        return IntrinsicHeight(
-          child: Row(
-            children: [
-              Expanded(
+                );
+              },
+              child: AspectRatio(
+                aspectRatio: 1.5,
                 child: Container(
-                  height: double.infinity,
                   decoration: BoxDecoration(
+                    color: CustomColors.whDarkBlack,
                     borderRadius: const BorderRadius.all(
                       Radius.circular(20.0),
                     ),
@@ -959,7 +931,140 @@ class ConfirmPostContentWidget extends StatelessWidget {
                     },
                     fit: BoxFit.cover,
                     image: NetworkImage(
-                      confirmPostEntity.imageUrlList![0],
+                      widget.confirmPostEntity.imageUrlList![0],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(
+              height: 8.0,
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.all(0),
+                backgroundColor: CustomColors.whDarkBlack,
+              ),
+              onPressed: () async {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ConfirmPostPhotoView(
+                      imageProviderList: imageList,
+                      initPageIndex: 1,
+                    ),
+                  ),
+                );
+              },
+              child: AspectRatio(
+                aspectRatio: 1.5,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: CustomColors.whDarkBlack,
+                    borderRadius: const BorderRadius.all(
+                      Radius.circular(20.0),
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withAlpha(64),
+                        offset: const Offset(0, 4),
+                        blurRadius: 4,
+                      ),
+                    ],
+                  ),
+                  clipBehavior: Clip.hardEdge,
+                  child: Image(
+                    loadingBuilder: (context, child, loadingProgress) {
+                      if (loadingProgress == null) {
+                        return child;
+                      } else {
+                        return Container(
+                          color: CustomColors.whBlack,
+                          child: const Center(
+                            child: SizedBox(
+                              width: 30,
+                              height: 30,
+                              child: CircularProgressIndicator(
+                                color: CustomColors.whYellow,
+                              ),
+                            ),
+                          ),
+                        );
+                      }
+                    },
+                    fit: BoxFit.cover,
+                    image: NetworkImage(
+                      widget.confirmPostEntity.imageUrlList![1],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      } else if (widget.confirmPostEntity.imageUrlList!.length == 3) {
+        return IntrinsicHeight(
+          child: Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20.0),
+                    ),
+                    padding: const EdgeInsets.all(0),
+                    backgroundColor: CustomColors.whDarkBlack,
+                  ),
+                  onPressed: () async {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ConfirmPostPhotoView(
+                          imageProviderList: imageList,
+                          initPageIndex: 0,
+                        ),
+                      ),
+                    );
+                  },
+                  child: Container(
+                    height: double.infinity,
+                    decoration: BoxDecoration(
+                      color: CustomColors.whDarkBlack,
+                      borderRadius: const BorderRadius.all(
+                        Radius.circular(20.0),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withAlpha(64),
+                          offset: const Offset(0, 4),
+                          blurRadius: 4,
+                        ),
+                      ],
+                    ),
+                    clipBehavior: Clip.hardEdge,
+                    child: Image(
+                      loadingBuilder: (context, child, loadingProgress) {
+                        if (loadingProgress == null) {
+                          return child;
+                        } else {
+                          return Container(
+                            color: CustomColors.whBlack,
+                            child: const Center(
+                              child: SizedBox(
+                                width: 30,
+                                height: 30,
+                                child: CircularProgressIndicator(
+                                  color: CustomColors.whYellow,
+                                ),
+                              ),
+                            ),
+                          );
+                        }
+                      },
+                      fit: BoxFit.cover,
+                      image: NetworkImage(
+                        widget.confirmPostEntity.imageUrlList![0],
+                      ),
                     ),
                   ),
                 ),
@@ -970,44 +1075,62 @@ class ConfirmPostContentWidget extends StatelessWidget {
               Expanded(
                 child: Column(
                   children: [
-                    AspectRatio(
-                      aspectRatio: 1.5,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(20.0),
-                          ),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black.withAlpha(64),
-                              offset: const Offset(0, 4),
-                              blurRadius: 4,
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.all(0),
+                        backgroundColor: CustomColors.whDarkBlack,
+                      ),
+                      onPressed: () async {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => ConfirmPostPhotoView(
+                              imageProviderList: imageList,
+                              initPageIndex: 1,
                             ),
-                          ],
-                        ),
-                        clipBehavior: Clip.hardEdge,
-                        child: Image(
-                          loadingBuilder: (context, child, loadingProgress) {
-                            if (loadingProgress == null) {
-                              return child;
-                            } else {
-                              return Container(
-                                color: CustomColors.whBlack,
-                                child: const Center(
-                                  child: SizedBox(
-                                    width: 30,
-                                    height: 30,
-                                    child: CircularProgressIndicator(
-                                      color: CustomColors.whYellow,
+                          ),
+                        );
+                      },
+                      child: AspectRatio(
+                        aspectRatio: 1.5,
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: CustomColors.whDarkBlack,
+                            borderRadius: const BorderRadius.all(
+                              Radius.circular(20.0),
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withAlpha(64),
+                                offset: const Offset(0, 4),
+                                blurRadius: 4,
+                              ),
+                            ],
+                          ),
+                          clipBehavior: Clip.hardEdge,
+                          child: Image(
+                            loadingBuilder: (context, child, loadingProgress) {
+                              if (loadingProgress == null) {
+                                return child;
+                              } else {
+                                return Container(
+                                  color: CustomColors.whBlack,
+                                  child: const Center(
+                                    child: SizedBox(
+                                      width: 30,
+                                      height: 30,
+                                      child: CircularProgressIndicator(
+                                        color: CustomColors.whYellow,
+                                      ),
                                     ),
                                   ),
-                                ),
-                              );
-                            }
-                          },
-                          fit: BoxFit.cover,
-                          image: NetworkImage(
-                            confirmPostEntity.imageUrlList![1],
+                                );
+                              }
+                            },
+                            fit: BoxFit.cover,
+                            image: NetworkImage(
+                              widget.confirmPostEntity.imageUrlList![1],
+                            ),
                           ),
                         ),
                       ),
@@ -1015,44 +1138,62 @@ class ConfirmPostContentWidget extends StatelessWidget {
                     const SizedBox(
                       height: 8.0,
                     ),
-                    AspectRatio(
-                      aspectRatio: 1.5,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          borderRadius: const BorderRadius.all(
-                            Radius.circular(20.0),
-                          ),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.black.withAlpha(64),
-                              offset: const Offset(0, 4),
-                              blurRadius: 4,
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.all(0),
+                        backgroundColor: CustomColors.whDarkBlack,
+                      ),
+                      onPressed: () async {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => ConfirmPostPhotoView(
+                              imageProviderList: imageList,
+                              initPageIndex: 2,
                             ),
-                          ],
-                        ),
-                        clipBehavior: Clip.hardEdge,
-                        child: Image(
-                          loadingBuilder: (context, child, loadingProgress) {
-                            if (loadingProgress == null) {
-                              return child;
-                            } else {
-                              return Container(
-                                color: CustomColors.whBlack,
-                                child: const Center(
-                                  child: SizedBox(
-                                    width: 30,
-                                    height: 30,
-                                    child: CircularProgressIndicator(
-                                      color: CustomColors.whYellow,
+                          ),
+                        );
+                      },
+                      child: AspectRatio(
+                        aspectRatio: 1.5,
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: CustomColors.whDarkBlack,
+                            borderRadius: const BorderRadius.all(
+                              Radius.circular(20.0),
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withAlpha(64),
+                                offset: const Offset(0, 4),
+                                blurRadius: 4,
+                              ),
+                            ],
+                          ),
+                          clipBehavior: Clip.hardEdge,
+                          child: Image(
+                            loadingBuilder: (context, child, loadingProgress) {
+                              if (loadingProgress == null) {
+                                return child;
+                              } else {
+                                return Container(
+                                  color: CustomColors.whBlack,
+                                  child: const Center(
+                                    child: SizedBox(
+                                      width: 30,
+                                      height: 30,
+                                      child: CircularProgressIndicator(
+                                        color: CustomColors.whYellow,
+                                      ),
                                     ),
                                   ),
-                                ),
-                              );
-                            }
-                          },
-                          fit: BoxFit.cover,
-                          image: NetworkImage(
-                            confirmPostEntity.imageUrlList![2],
+                                );
+                              }
+                            },
+                            fit: BoxFit.cover,
+                            image: NetworkImage(
+                              widget.confirmPostEntity.imageUrlList![2],
+                            ),
                           ),
                         ),
                       ),

--- a/lib/presentation/write_post/model/resolution_list_view_model.dart
+++ b/lib/presentation/write_post/model/resolution_list_view_model.dart
@@ -2,9 +2,25 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/presentation/write_post/write_post.dart';
 
 class ResolutionListViewModel {
+  ResolutionListViewModel({
+    this.resolutionModelList,
+    this.futureDoneCount,
+    this.futureDoneRatio,
+  });
+
   List<ResolutionListCellWidgetModel>? resolutionModelList;
   EitherFuture<int>? futureDoneCount;
   EitherFuture<int>? futureDoneRatio;
 
   bool isLoadingView = true;
+
+  ResolutionListViewModel copyWith({
+    List<ResolutionListCellWidgetModel>? newResolutionModelList,
+  }) {
+    return ResolutionListViewModel(
+      resolutionModelList: newResolutionModelList,
+      futureDoneCount: futureDoneCount,
+      futureDoneRatio: futureDoneRatio,
+    );
+  }
 }

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -45,7 +45,7 @@ class ResolutionListViewModelProvider
       }).toList(),
     );
 
-    state.resolutionModelList = modelList;
+    state = state.copyWith(newResolutionModelList: modelList);
 
     int tempTotalCount = 0;
     state.futureDoneCount = Future(() async {

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -19,6 +19,7 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
   @override
   void initState() {
     super.initState();
+
     unawaited(
       ref
           .read(resolutionListViewModelProvider.notifier)

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -47,9 +47,12 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
         minimum: const EdgeInsets.symmetric(horizontal: 16.0),
         child: RefreshIndicator(
           onRefresh: () async {
-            provider
-                .loadResolutionModelList()
-                .whenComplete(() => setState(() {}));
+            provider.loadResolutionModelList().whenComplete(() {
+              setState(() {
+                ref.watch(resolutionListViewModelProvider).isLoadingView =
+                    false;
+              });
+            });
           },
           child: ListView(
             children: [
@@ -93,10 +96,16 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                               index: index,
                             );
                           },
-                        ).whenComplete(() {
-                          provider
+                        ).whenComplete(() async {
+                          await provider
                               .loadResolutionModelList()
-                              .whenComplete(() => setState(() {}));
+                              .whenComplete(() {
+                            setState(() {
+                              ref
+                                  .watch(resolutionListViewModelProvider)
+                                  .isLoadingView = false;
+                            });
+                          });
                         });
                       },
                     ),
@@ -153,7 +162,9 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
                 viewModel.resolutionModelList![index].entity.goalStatement ??
                     '',
                 style: TextStyle(
-                  color: PointColors.colorList[0],
+                  color: PointColors.colorList[
+                      viewModel.resolutionModelList![index].entity.colorIndex ??
+                          0],
                   fontSize: 18.0,
                   fontWeight: FontWeight.w600,
                 ),
@@ -272,7 +283,8 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
           ),
           WideColoredButton(
             buttonTitle: '돌아가기',
-            isDiminished: true,
+            backgroundColor: Colors.transparent,
+            foregroundColor: CustomColors.whPlaceholderGrey,
             onPressed: () {
               Navigator.pop(context);
             },

--- a/lib/presentation/write_post/view/writing_confirm_post_view.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view.dart
@@ -39,10 +39,10 @@ class _WritingConfirmPostViewState
           backgroundColor: CustomColors.whDarkBlack,
           appBar: WehavitAppBar(
             title: widget.hasRested ? '반성글 남기기' : '인증 남기기',
-            leadingTitle: '목표 선택',
+            leadingTitle: '',
             leadingIcon: Icons.chevron_left,
             leadingAction: () {
-              Navigator.pop(context);
+              Navigator.of(context).pop(false);
             },
             trailingTitle: '공유 대상',
             trailingIcon: Icons.cloud_upload_outlined,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   cp949_dart: ^1.0.0+1
   loading_animation_widget: ^1.2.1
   visibility_detector: ^0.4.0+2
+  photo_view: ^0.15.0
 
 
 dev_dependencies:


### PR DESCRIPTION
# 설명
그룹뷰, 그룹포스트뷰의 UI와 관련해 필요한 부분들의 개선을 진행 및 미구현된 기능 구현

Fixes #
Closes #239 
Resolves #

# 작업 내역
- 그룹포스트뷰 뒤로가기 버튼 추가 및 미구현 버튼 주석처리
- 캘린더 접기/펼치기 구현
- 그룹포스트 데이터 로드 및 비동기 UI 로직 개선
- 포스트 사진 갤러리뷰 기능 구현

## 작업 결과물
|그룹포스트뷰 UI 개선|캘린더 접고펼치기|
|---|---|
|![Simulator Screen Recording - 13 Pro simulator - 2024-06-10 at 16 04 09](https://github.com/cau-bootcamp/wehavit/assets/39216546/01d4d791-d22e-4032-804d-818259687866)|![Simulator Screen Recording - 13 Pro simulator - 2024-06-10 at 16 06 31](https://github.com/cau-bootcamp/wehavit/assets/39216546/d909f455-df5c-424b-953d-5714c1d351d1)|


## 참고 사항
실수로 #240의 기능 하나를 여기에서 개선하여 적용하였음! 

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
