### PR TITLE
[#257] fix: 출시 전 개선이 필요한 UI, 로직, UX라이팅을 수정

### DIFF
--- a/lib/common/routers/route_provider.dart
+++ b/lib/common/routers/route_provider.dart
@@ -104,17 +104,17 @@ class AuthRoute extends GoRouteData {
   }
 }
 
-@TypedGoRoute<MyPageRoute>(path: MyPageRoute.path)
-class MyPageRoute extends GoRouteData {
-  const MyPageRoute();
+// @TypedGoRoute<MyPageRoute>(path: MyPageRoute.path)
+// class MyPageRoute extends GoRouteData {
+//   const MyPageRoute();
 
-  static const path = RouteLocation.myPage;
+//   static const path = RouteLocation.myPage;
 
-  @override
-  Widget build(BuildContext context, GoRouterState state) {
-    return const MyPageView();
-  }
-}
+//   @override
+//   Widget build(BuildContext context, GoRouterState state) {
+//     return const MyPageView();
+//   }
+// }
 
 @TypedGoRoute<TestPageRoute>(path: TestPageRoute.path)
 class TestPageRoute extends GoRouteData {
@@ -140,17 +140,17 @@ class AddResolutionRoute extends GoRouteData {
   }
 }
 
-@TypedGoRoute<FriendListRoute>(path: FriendListRoute.path)
-class FriendListRoute extends GoRouteData {
-  const FriendListRoute();
+// @TypedGoRoute<FriendListRoute>(path: FriendListRoute.path)
+// class FriendListRoute extends GoRouteData {
+//   const FriendListRoute();
 
-  static const path = RouteLocation.friendList;
+//   static const path = RouteLocation.friendList;
 
-  @override
-  Widget build(BuildContext context, GoRouterState state) {
-    return const FriendListView();
-  }
-}
+//   @override
+//   Widget build(BuildContext context, GoRouterState state) {
+//     return const FriendListView();
+//   }
+// }
 
 @TypedGoRoute<AnimationSampleViewRoute>(path: AnimationSampleViewRoute.path)
 class AnimationSampleViewRoute extends GoRouteData {
@@ -188,17 +188,17 @@ class GroupSampleViewRoute extends GoRouteData {
   }
 }
 
-@TypedGoRoute<GroupViewRoute>(path: GroupViewRoute.path)
-class GroupViewRoute extends GoRouteData {
-  const GroupViewRoute();
+// @TypedGoRoute<GroupViewRoute>(path: GroupViewRoute.path)
+// class GroupViewRoute extends GoRouteData {
+//   const GroupViewRoute();
 
-  static const path = RouteLocation.groupView;
+//   static const path = RouteLocation.groupView;
 
-  @override
-  Widget build(BuildContext context, GoRouterState state) {
-    return const GroupView();
-  }
-}
+//   @override
+//   Widget build(BuildContext context, GoRouterState state) {
+//     return const GroupView();
+//   }
+// }
 
 class GoNavigatorObserver extends NavigatorObserver {
   @override

--- a/lib/common/routers/route_provider.dart
+++ b/lib/common/routers/route_provider.dart
@@ -5,14 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
-import 'package:wehavit/presentation/effects/effects.dart';
-import 'package:wehavit/presentation/entrance/auth.dart';
-import 'package:wehavit/presentation/friend_list/friend_list.dart';
-import 'package:wehavit/presentation/group/view/group_view.dart';
-import 'package:wehavit/presentation/main/view/main_view.dart';
-import 'package:wehavit/presentation/my_page/my_page.dart';
-import 'package:wehavit/presentation/splash/splash.dart';
-import 'package:wehavit/presentation/test_view/test_view.dart';
+import 'package:wehavit/presentation/presentation.dart';
 
 part 'route_provider.g.dart';
 

--- a/lib/common/routers/route_provider.g.dart
+++ b/lib/common/routers/route_provider.g.dart
@@ -10,14 +10,11 @@ List<RouteBase> get $appRoutes => [
       $homeRoute,
       $splashRoute,
       $authRoute,
-      $myPageRoute,
       $testPageRoute,
       $addResolutionRoute,
-      $friendListRoute,
       $animationSampleViewRoute,
       $reactionSampleViewRoute,
       $groupSampleViewRoute,
-      $groupViewRoute,
     ];
 
 RouteBase get $homeRoute => GoRouteData.$route(
@@ -86,28 +83,6 @@ extension $AuthRouteExtension on AuthRoute {
   void replace(BuildContext context) => context.replace(location);
 }
 
-RouteBase get $myPageRoute => GoRouteData.$route(
-      path: '/myPage',
-      factory: $MyPageRouteExtension._fromState,
-    );
-
-extension $MyPageRouteExtension on MyPageRoute {
-  static MyPageRoute _fromState(GoRouterState state) => const MyPageRoute();
-
-  String get location => GoRouteData.$location(
-        '/myPage',
-      );
-
-  void go(BuildContext context) => context.go(location);
-
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
-
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
-
-  void replace(BuildContext context) => context.replace(location);
-}
-
 RouteBase get $testPageRoute => GoRouteData.$route(
       path: '/testPage',
       factory: $TestPageRouteExtension._fromState,
@@ -141,29 +116,6 @@ extension $AddResolutionRouteExtension on AddResolutionRoute {
 
   String get location => GoRouteData.$location(
         '/addResolution',
-      );
-
-  void go(BuildContext context) => context.go(location);
-
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
-
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
-
-  void replace(BuildContext context) => context.replace(location);
-}
-
-RouteBase get $friendListRoute => GoRouteData.$route(
-      path: '/friendList',
-      factory: $FriendListRouteExtension._fromState,
-    );
-
-extension $FriendListRouteExtension on FriendListRoute {
-  static FriendListRoute _fromState(GoRouterState state) =>
-      const FriendListRoute();
-
-  String get location => GoRouteData.$location(
-        '/friendList',
       );
 
   void go(BuildContext context) => context.go(location);
@@ -233,29 +185,6 @@ extension $GroupSampleViewRouteExtension on GroupSampleViewRoute {
 
   String get location => GoRouteData.$location(
         '/groupSampleView',
-      );
-
-  void go(BuildContext context) => context.go(location);
-
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
-
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
-
-  void replace(BuildContext context) => context.replace(location);
-}
-
-RouteBase get $groupViewRoute => GoRouteData.$route(
-      path: '/groupView',
-      factory: $GroupViewRouteExtension._fromState,
-    );
-
-extension $GroupViewRouteExtension on GroupViewRoute {
-  static GroupViewRoute _fromState(GoRouterState state) =>
-      const GroupViewRoute();
-
-  String get location => GoRouteData.$location(
-        '/groupView',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/lib/common/routers/test_page.dart
+++ b/lib/common/routers/test_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
-import '../../presentation/write_post/write_post.dart';
 
 class TestPage extends ConsumerWidget {
   const TestPage({super.key});
@@ -95,18 +94,18 @@ class TestPage extends ConsumerWidget {
               },
               buttonText: 'Go to Error View',
             ),
-            MoveButton(
-              onPressCallback: () async {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    fullscreenDialog: true,
-                    builder: (context) => const ResolutionListView(),
-                  ),
-                );
-              },
-              buttonText: 'Resolution List View',
-            ),
+            // MoveButton(
+            //   onPressCallback: () async {
+            //     Navigator.push(
+            //       context,
+            //       MaterialPageRoute(
+            //         fullscreenDialog: true,
+            //         builder: (context) => const ResolutionListView(),
+            //       ),
+            //     );
+            //   },
+            //   buttonText: 'Resolution List View',
+            // ),
           ],
         ),
       ),

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -332,6 +332,7 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
     try {
       final reactionModel =
           FirebaseReactionModel.fromReactionEntity(reactionEntity);
+
       await firestore
           .collection(
             FirebaseCollectionName.getConfirmPostReactionCollectionName(
@@ -389,7 +390,7 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
                     .toList();
 
                 final shareGroupEntityList = (await Future.wait(
-                  model.shareGroupIdList!.map((groupId) async {
+                  (model.shareGroupIdList ?? []).map((groupId) async {
                     final entity = (await fetchGroupEntityByGroupId(groupId))
                         .fold((failure) => null, (entity) => entity);
 

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -178,4 +178,8 @@ abstract class WehavitDatasource {
   EitherFuture<List<EitherFuture<GroupEntity>>> getGroupEntityListByGroupName({
     required String keyword,
   });
+
+  EitherFuture<List<EitherFuture<UserDataEntity>>> getUserDataListByHandle({
+    required String handle,
+  });
 }

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -174,4 +174,8 @@ abstract class WehavitDatasource {
   });
 
   EitherFuture<GroupEntity> getGroupEntityByName({required String groupName});
+
+  EitherFuture<List<EitherFuture<GroupEntity>>> getGroupEntityListByGroupName({
+    required String keyword,
+  });
 }

--- a/lib/data/repositories/group_repository_impl.dart
+++ b/lib/data/repositories/group_repository_impl.dart
@@ -168,4 +168,11 @@ class GroupRepositoryImpl implements GroupRepository {
   }) {
     return _wehavitDatasource.getGroupEntityByName(groupName: groupName);
   }
+
+  @override
+  EitherFuture<List<EitherFuture<GroupEntity>>> getGroupEntityListByGroupName({
+    required String keyword,
+  }) {
+    return _wehavitDatasource.getGroupEntityListByGroupName(keyword: keyword);
+  }
 }

--- a/lib/data/repositories/user_model_repository_impl.dart
+++ b/lib/data/repositories/user_model_repository_impl.dart
@@ -75,6 +75,13 @@ class UserModelRepositoryImpl implements UserModelRepository {
   }
 
   @override
+  EitherFuture<List<EitherFuture<UserDataEntity>>> getUserDataListByHandle({
+    required String handle,
+  }) async {
+    return _wehavitDatasource.getUserDataListByHandle(handle: handle);
+  }
+
+  @override
   EitherFuture<void> registerUserData({
     required String uid,
     required String name,

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -304,6 +304,13 @@ final searchUserDataListByNicknameUsecaseProvider =
   final userModelRepository = ref.watch(userModelRepositoryProvider);
   return SearchUserDataListByNicknameUsecase(userModelRepository);
 });
+
+final searchUserDataListByHandleUsecaseProvider =
+    Provider<SearchUserDataListByHandleUsecase>((ref) {
+  final userModelRepository = ref.watch(userModelRepositoryProvider);
+  return SearchUserDataListByHandleUsecase(userModelRepository);
+});
+
 final acceptApplyingForFriendUsecaseProvider =
     Provider<AcceptApplyingForFriendUsecase>((ref) {
   final userModelRepository = ref.watch(userModelRepositoryProvider);

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -358,3 +358,9 @@ final unshareResolutionToFriendUsecaseProvider =
   final resolutionRepository = ref.watch(resolutionRepositoryProvider);
   return UnshareResolutionToFriendUsecase(resolutionRepository);
 });
+
+final searchGroupEntityListByGroupNameUsecaseProvider =
+    Provider<SearchGroupEntityListByGroupNameUsecase>((ref) {
+  final groupRepository = ref.watch(groupRepositoryProvider);
+  return SearchGroupEntityListByGroupNameUsecase(groupRepository);
+});

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -258,7 +258,11 @@ final checkWeatherUserIsMnagerOfGroupEntityUsecaseProvider =
 final getAppliedUserListForGroupEntityUsecaseProvider =
     Provider<GetAppliedUserListForGroupEntityUsecase>((ref) {
   final groupRepository = ref.watch(groupRepositoryProvider);
-  return GetAppliedUserListForGroupEntityUsecase(groupRepository);
+  final userModelRepository = ref.watch(userModelRepositoryProvider);
+  return GetAppliedUserListForGroupEntityUsecase(
+    userModelRepository,
+    groupRepository,
+  );
 });
 
 final getAchievementPercentageForGroupMemberUsecaseProvider =

--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -146,11 +146,14 @@ final groupPostViewModelProvider = StateNotifierProvider.autoDispose<
       ref.watch(sendQuickShotReactionToConfirmPostUsecaseProvider);
   final sendCommentReactionToConfirmPostUsecase =
       ref.watch(sendCommentReactionToConfirmPostUsecaseProvider);
+  final getAppliedUserListForGroupEntityUsecase =
+      ref.watch(getAppliedUserListForGroupEntityUsecaseProvider);
   return GroupPostViewModelProvider(
     getGroupConfirmPostListByDateUsecase,
     sendEmojiReactionToConfirmPostUsecase,
     sendQuickShotReactionToConfirmPostUsecase,
     sendCommentReactionToConfirmPostUsecase,
+    getAppliedUserListForGroupEntityUsecase,
   );
 });
 

--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -46,8 +46,8 @@ final friendListViewModelProvider =
     StateNotifierProvider<FriendListViewModelProvider, FriendListViewModel>(
         (ref) {
   final getFriendListUsecase = ref.read(getFriendListUseCaseProvider);
-  final searchUserDataListByNicknameUsecase =
-      ref.read(searchUserDataListByNicknameUsecaseProvider);
+  final searchUserDataListByHandleUsecase =
+      ref.read(searchUserDataListByHandleUsecaseProvider);
   final getMyUserDataUsecase = ref.read(getMyUserDataUsecaseProvider);
   final getAppliedUserListForFriendUsecase =
       ref.read(getAppliedUserListForFriendUsecaseProvider);
@@ -63,7 +63,7 @@ final friendListViewModelProvider =
       ref.read(getUserDataFromIdUsecaseProvider);
   return FriendListViewModelProvider(
     getFriendListUsecase,
-    searchUserDataListByNicknameUsecase,
+    searchUserDataListByHandleUsecase,
     getMyUserDataUsecase,
     getAppliedUserListForFriendUsecase,
     acceptApplyingForFriendUsecase,

--- a/lib/domain/repositories/group_repository.dart
+++ b/lib/domain/repositories/group_repository.dart
@@ -69,4 +69,8 @@ abstract class GroupRepository {
     required String groupId,
     required String userId,
   });
+
+  EitherFuture<List<EitherFuture<GroupEntity>>> getGroupEntityListByGroupName({
+    required String keyword,
+  });
 }

--- a/lib/domain/repositories/user_model_repository.dart
+++ b/lib/domain/repositories/user_model_repository.dart
@@ -29,6 +29,10 @@ abstract class UserModelRepository {
 
   EitherFuture<void> removeFriend({required String targetUid});
 
+  EitherFuture<List<EitherFuture<UserDataEntity>>> getUserDataListByHandle({
+    required String handle,
+  });
+
   EitherFuture<List<EitherFuture<UserDataEntity>>> getUserDataListByNickname({
     required String nickname,
   });

--- a/lib/domain/usecases/get_applied_user_list_for_group_entity_usecase.dart
+++ b/lib/domain/usecases/get_applied_user_list_for_group_entity_usecase.dart
@@ -1,14 +1,33 @@
+import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/domain/repositories/group_repository.dart';
+import 'package:wehavit/domain/repositories/repositories.dart';
 
 class GetAppliedUserListForGroupEntityUsecase {
-  GetAppliedUserListForGroupEntityUsecase(this._groupRepository);
+  GetAppliedUserListForGroupEntityUsecase(
+    this._userModelRepository,
+    this._groupRepository,
+  );
 
+  final UserModelRepository _userModelRepository;
   final GroupRepository _groupRepository;
 
   EitherFuture<List<String>> call(GroupEntity groupEntity) async {
-    return _groupRepository.getGroupAppliedUserIdList(
-        groupId: groupEntity.groupId);
+    final myUid = await _userModelRepository
+        .getMyUserId()
+        .then((result) => result.fold((failure) => null, (uid) => uid));
+    if (myUid == null) {
+      return Future(() => left(const Failure('fail to get my uid')));
+    }
+
+    if (groupEntity.groupManagerUid.compareTo(myUid) == 0) {
+      return _groupRepository.getGroupAppliedUserIdList(
+        groupId: groupEntity.groupId,
+      );
+    } else {
+      return Future(
+        () => left(const Failure('current user is not manager of this group')),
+      );
+    }
   }
 }

--- a/lib/domain/usecases/get_my_resolution_list_usecase.dart
+++ b/lib/domain/usecases/get_my_resolution_list_usecase.dart
@@ -29,6 +29,7 @@ class GetMyResolutionListUsecase {
           ),
         );
       }
+
       return _resolutionRepository.getActiveResolutionEntityList(fetchResult);
     });
   }

--- a/lib/domain/usecases/search_group_entity_list_by_group_name_usecase.dart
+++ b/lib/domain/usecases/search_group_entity_list_by_group_name_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/repositories/repositories.dart';
+
+class SearchGroupEntityListByGroupNameUsecase {
+  SearchGroupEntityListByGroupNameUsecase(this._groupRepository);
+
+  final GroupRepository _groupRepository;
+
+  EitherFuture<List<EitherFuture<GroupEntity>>> call({
+    required String searchKeyword,
+  }) async {
+    return _groupRepository.getGroupEntityListByGroupName(
+      keyword: searchKeyword,
+    );
+  }
+}

--- a/lib/domain/usecases/search_user_data_list_by_handle_usecase.dart
+++ b/lib/domain/usecases/search_user_data_list_by_handle_usecase.dart
@@ -1,0 +1,15 @@
+import 'package:wehavit/common/utils/custom_types.dart';
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/repositories/repositories.dart';
+
+class SearchUserDataListByHandleUsecase {
+  SearchUserDataListByHandleUsecase(this._userModelRepository);
+
+  final UserModelRepository _userModelRepository;
+
+  EitherFuture<List<EitherFuture<UserDataEntity>>> call({
+    required String handle,
+  }) async {
+    return _userModelRepository.getUserDataListByHandle(handle: handle);
+  }
+}

--- a/lib/domain/usecases/usecases.dart
+++ b/lib/domain/usecases/usecases.dart
@@ -36,6 +36,7 @@ export 'reject_applying_for_friend_usecase.dart';
 export 'reject_applying_for_joining_group_usecase.dart';
 export 'remove_friend_usecase.dart';
 export 'remove_user_data_usecase.dart';
+export 'search_group_entity_list_by_group_name_usecase.dart';
 export 'search_user_data_list_by_nickname_usecase.dart';
 export 'send_comment_reaction_to_confirm_post_usecase.dart';
 export 'send_emoji_reaction_to_confirm_post_usercase.dart';

--- a/lib/domain/usecases/usecases.dart
+++ b/lib/domain/usecases/usecases.dart
@@ -37,6 +37,7 @@ export 'reject_applying_for_joining_group_usecase.dart';
 export 'remove_friend_usecase.dart';
 export 'remove_user_data_usecase.dart';
 export 'search_group_entity_list_by_group_name_usecase.dart';
+export 'search_user_data_list_by_handle_usecase.dart';
 export 'search_user_data_list_by_nickname_usecase.dart';
 export 'send_comment_reaction_to_confirm_post_usecase.dart';
 export 'send_emoji_reaction_to_confirm_post_usercase.dart';

--- a/lib/presentation/common_components/resolution_list_cell_widget.dart
+++ b/lib/presentation/common_components/resolution_list_cell_widget.dart
@@ -144,6 +144,7 @@ class ResolutionListCellHeadWidget extends StatelessWidget {
                   fontSize: 16.0,
                   fontWeight: FontWeight.w600,
                   height: 1.2,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
               Visibility(
@@ -155,6 +156,7 @@ class ResolutionListCellHeadWidget extends StatelessWidget {
                     fontSize: 14.0,
                     fontWeight: FontWeight.w500,
                     height: 1.2,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ),
@@ -252,6 +254,7 @@ class ResolutionListWeeklyDoneCellWidget extends StatelessWidget {
             width: 2,
           ),
         ),
+        padding: const EdgeInsets.only(top: 2),
         width: 25,
         height: 25,
         alignment: Alignment.center,
@@ -338,6 +341,7 @@ class ResolutionLinearGaugeWidget extends StatelessWidget {
                   color: CustomColors.whWhite,
                   fontSize: 14.0,
                   fontWeight: FontWeight.w500,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
             ],
@@ -349,6 +353,7 @@ class ResolutionLinearGaugeWidget extends StatelessWidget {
             minHeight: 7,
             color: PointColors.colorList[resolutionEntity?.colorIndex ?? 0],
             backgroundColor: CustomColors.whDarkBlack,
+            borderRadius: BorderRadius.circular(4.0),
           ),
         ],
       ),
@@ -391,13 +396,19 @@ class ResolutionLinearGaugeWidget extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  resolutionEntity?.actionStatement ?? '',
-                  style: const TextStyle(
-                    color: CustomColors.whWhite,
-                    fontSize: 14.0,
-                    fontWeight: FontWeight.w500,
+                Expanded(
+                  child: Text(
+                    resolutionEntity?.actionStatement ?? '',
+                    style: const TextStyle(
+                      color: CustomColors.whWhite,
+                      fontSize: 14.0,
+                      fontWeight: FontWeight.w500,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
+                ),
+                Container(
+                  width: 4.0,
                 ),
                 Text(
                   // ignore: lines_longer_than_80_chars
@@ -413,36 +424,42 @@ class ResolutionLinearGaugeWidget extends StatelessWidget {
             const SizedBox(
               height: 4,
             ),
-            Stack(
-              alignment: Alignment.centerLeft,
-              children: [
-                Container(
-                  height: 7,
-                  width: double.infinity,
-                  color: CustomColors.whDarkBlack,
-                ),
-                Flex(
-                  direction: Axis.horizontal,
-                  children: [
-                    Flexible(
-                      flex: successCount,
-                      child: Container(
-                        height: 7,
-                        color: PointColors
-                            .colorList[resolutionEntity?.colorIndex ?? 0],
+            Container(
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(4.0),
+              ),
+              child: Stack(
+                alignment: Alignment.centerLeft,
+                children: [
+                  Container(
+                    height: 7,
+                    width: double.infinity,
+                    color: CustomColors.whDarkBlack,
+                  ),
+                  Flex(
+                    direction: Axis.horizontal,
+                    children: [
+                      Flexible(
+                        flex: successCount,
+                        child: Container(
+                          height: 7,
+                          color: PointColors
+                              .colorList[resolutionEntity?.colorIndex ?? 0],
+                        ),
                       ),
-                    ),
-                    Flexible(
-                      flex:
-                          (resolutionEntity?.actionPerWeek ?? 1) - successCount,
-                      child: Container(
-                        height: 7,
-                        color: Colors.transparent,
+                      Flexible(
+                        flex: (resolutionEntity?.actionPerWeek ?? 1) -
+                            successCount,
+                        child: Container(
+                          height: 7,
+                          color: Colors.transparent,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-              ],
+                    ],
+                  ),
+                ],
+              ),
             ),
           ],
         );

--- a/lib/presentation/effects/camera_quickshot/reaction_camera_widget_model_provider.dart
+++ b/lib/presentation/effects/camera_quickshot/reaction_camera_widget_model_provider.dart
@@ -78,6 +78,7 @@ class ReactionCameraWidgetModelProvider
         currentButtonPosition: position,
         isPosInCapturingArea: true,
       );
+
       return;
     }
 

--- a/lib/presentation/entrance/auth.dart
+++ b/lib/presentation/entrance/auth.dart
@@ -1,1 +1,1 @@
-export 'view/view.dart';
+// TODO Implement this library.

--- a/lib/presentation/entrance/authentication.dart
+++ b/lib/presentation/entrance/authentication.dart
@@ -1,5 +1,0 @@
-export 'auth.dart';
-export 'provider/auth_notifier.dart';
-export 'provider/auth_state.dart';
-export 'view/entrance_view.dart';
-export 'view/view.dart';

--- a/lib/presentation/entrance/entrance.dart
+++ b/lib/presentation/entrance/entrance.dart
@@ -1,5 +1,3 @@
-export 'auth.dart';
-export 'authentication.dart';
 export 'model/model.dart';
 export 'provider/provider.dart';
 export 'view/view.dart';

--- a/lib/presentation/entrance/model/log_in_view_model.dart
+++ b/lib/presentation/entrance/model/log_in_view_model.dart
@@ -3,4 +3,6 @@ import 'package:flutter/material.dart';
 class LogInViewModel {
   TextEditingController emailEditingController = TextEditingController();
   TextEditingController passwordEditingController = TextEditingController();
+
+  bool isProcessing = false;
 }

--- a/lib/presentation/entrance/view/entrance_view.dart
+++ b/lib/presentation/entrance/view/entrance_view.dart
@@ -11,7 +11,7 @@ import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 import 'package:wehavit/presentation/effects/effects.dart';
-import 'package:wehavit/presentation/entrance/auth.dart';
+import 'package:wehavit/presentation/entrance/entrance.dart';
 
 class EntranceView extends StatefulHookConsumerWidget {
   const EntranceView({super.key});

--- a/lib/presentation/entrance/view/log_in_view.dart
+++ b/lib/presentation/entrance/view/log_in_view.dart
@@ -6,7 +6,7 @@ import 'package:wehavit/dependency/data/repository_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
-import 'package:wehavit/presentation/entrance/auth.dart';
+import 'package:wehavit/presentation/entrance/entrance.dart';
 import 'package:wehavit/presentation/main/view/main_view.dart';
 
 class LogInView extends ConsumerStatefulWidget {

--- a/lib/presentation/entrance/view/log_in_view.dart
+++ b/lib/presentation/entrance/view/log_in_view.dart
@@ -67,6 +67,7 @@ class _LogInViewState extends ConsumerState<LogInView> {
                       height: 16.0,
                     ),
                     TextFormField(
+                      keyboardType: TextInputType.emailAddress,
                       controller: viewmodel.emailEditingController,
                       cursorColor: CustomColors.whWhite,
                       textAlignVertical: TextAlignVertical.center,
@@ -138,6 +139,10 @@ class _LogInViewState extends ConsumerState<LogInView> {
                 ),
                 WideColoredButton(
                   onPressed: () async {
+                    setState(() {
+                      viewmodel.isProcessing = true;
+                    });
+
                     provider.logIn().then((result) {
                       result.fold(
                         (failure) {
@@ -180,9 +185,14 @@ class _LogInViewState extends ConsumerState<LogInView> {
                           ),
                         ),
                       );
+                    }).whenComplete(() {
+                      setState(() {
+                        viewmodel.isProcessing = false;
+                      });
                     });
                   },
-                  buttonTitle: '로그인하기',
+                  buttonTitle: viewmodel.isProcessing ? '처리중' : '로그인하기',
+                  isDiminished: viewmodel.isProcessing,
                   backgroundColor: CustomColors.whYellow,
                   foregroundColor: CustomColors.whBlack,
                 ),

--- a/lib/presentation/entrance/view/sign_up_view.dart
+++ b/lib/presentation/entrance/view/sign_up_view.dart
@@ -45,288 +45,309 @@ class _SignUpAuthDataViewState extends ConsumerState<SignUpAuthDataView> {
           Navigator.pop(context);
         },
       ),
-      body: SafeArea(
-        minimum: const EdgeInsets.all(16.0),
-        maintainBottomViewPadding: true,
-        child: Column(
-          children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+      body: Stack(
+        children: [
+          SafeArea(
+            minimum: const EdgeInsets.all(16.0),
+            maintainBottomViewPadding: true,
+            child: Column(
               children: [
-                const Text(
-                  '이메일',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
-                    color: CustomColors.whWhite,
-                    fontSize: 20,
-                  ),
-                ),
-                Container(
-                  height: 8.0,
-                ),
-                TextFormField(
-                  controller: viewmodel.emailInputController,
-                  onChanged: (value) {
-                    provider.checkEmailEntered();
-                  },
-                  cursorColor: CustomColors.whWhite,
-                  textAlignVertical: TextAlignVertical.center,
-                  style: const TextStyle(
-                    color: CustomColors.whWhite,
-                    fontSize: 16.0,
-                  ),
-                  decoration: InputDecoration(
-                    hintText: '이메일',
-                    hintStyle: const TextStyle(
-                      fontSize: 16,
-                      color: CustomColors.whPlaceholderGrey,
-                    ),
-                    filled: true,
-                    fillColor: CustomColors.whGrey,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: const BorderSide(
-                        width: 0,
-                        style: BorderStyle.none,
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '이메일',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        color: CustomColors.whWhite,
+                        fontSize: 20,
                       ),
                     ),
-                    isCollapsed: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                      vertical: 12.0,
-                      horizontal: 16.0,
+                    Container(
+                      height: 8.0,
                     ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(
-              height: 24,
-            ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  '비밀번호',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
-                    color: CustomColors.whWhite,
-                    fontSize: 20,
-                  ),
-                ),
-                Container(
-                  height: 8.0,
-                ),
-                TextFormField(
-                  controller: viewmodel.passwordInputController,
-                  obscureText: true,
-                  obscuringCharacter: '*',
-                  inputFormatters: <TextInputFormatter>[
-                    FilteringTextInputFormatter.allow(
-                      RegExp(r'[0-9a-zA-Z!@#$%^&*(),.?":{}|<>]'),
+                    TextFormField(
+                      controller: viewmodel.emailInputController,
+                      onChanged: (value) {
+                        provider.checkEmailEntered();
+                      },
+                      cursorColor: CustomColors.whWhite,
+                      textAlignVertical: TextAlignVertical.center,
+                      style: const TextStyle(
+                        color: CustomColors.whWhite,
+                        fontSize: 16.0,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: '이메일',
+                        hintStyle: const TextStyle(
+                          fontSize: 16,
+                          color: CustomColors.whPlaceholderGrey,
+                        ),
+                        filled: true,
+                        fillColor: CustomColors.whGrey,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(10),
+                          borderSide: const BorderSide(
+                            width: 0,
+                            style: BorderStyle.none,
+                          ),
+                        ),
+                        isCollapsed: true,
+                        contentPadding: const EdgeInsets.symmetric(
+                          vertical: 12.0,
+                          horizontal: 16.0,
+                        ),
+                      ),
                     ),
                   ],
-                  onChanged: (value) {
-                    setState(() {
-                      provider.checkPasswordValidity();
-                    });
-                  },
-                  cursorColor: CustomColors.whWhite,
-                  textAlignVertical: TextAlignVertical.center,
-                  style: const TextStyle(
-                    color: CustomColors.whWhite,
-                    fontSize: 16.0,
-                  ),
-                  decoration: InputDecoration(
-                    hintText: '비밀번호',
-                    hintStyle: const TextStyle(
-                      fontSize: 16,
-                      color: CustomColors.whPlaceholderGrey,
-                    ),
-                    filled: true,
-                    fillColor: CustomColors.whGrey,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: const BorderSide(
-                        width: 0,
-                        style: BorderStyle.none,
+                ),
+                const SizedBox(
+                  height: 24,
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '비밀번호',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        color: CustomColors.whWhite,
+                        fontSize: 20,
                       ),
                     ),
-                    isCollapsed: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                      vertical: 12.0,
-                      horizontal: 16.0,
+                    Container(
+                      height: 8.0,
                     ),
-                  ),
-                ),
-                Container(
-                  height: 8.0,
-                ),
-                Container(
-                  padding: const EdgeInsets.only(left: 8),
-                  child: Text(
-                    '6자리 이상의 알파벳, 숫자, 특수문자로 구성',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w400,
-                      color: viewmodel.isPasswordValid != null
-                          ? (viewmodel.isPasswordValid!
-                              ? PointColors.green
-                              : PointColors.red)
-                          : CustomColors.whPlaceholderGrey,
-                      fontSize: 14,
+                    TextFormField(
+                      controller: viewmodel.passwordInputController,
+                      obscureText: true,
+                      obscuringCharacter: '*',
+                      inputFormatters: <TextInputFormatter>[
+                        FilteringTextInputFormatter.allow(
+                          RegExp(r'[0-9a-zA-Z!@#$%^&*(),.?":{}|<>]'),
+                        ),
+                      ],
+                      onChanged: (value) {
+                        setState(() {
+                          provider.checkPasswordValidity();
+                        });
+                      },
+                      cursorColor: CustomColors.whWhite,
+                      textAlignVertical: TextAlignVertical.center,
+                      style: const TextStyle(
+                        color: CustomColors.whWhite,
+                        fontSize: 16.0,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: '비밀번호',
+                        hintStyle: const TextStyle(
+                          fontSize: 16,
+                          color: CustomColors.whPlaceholderGrey,
+                        ),
+                        filled: true,
+                        fillColor: CustomColors.whGrey,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(10),
+                          borderSide: const BorderSide(
+                            width: 0,
+                            style: BorderStyle.none,
+                          ),
+                        ),
+                        isCollapsed: true,
+                        contentPadding: const EdgeInsets.symmetric(
+                          vertical: 12.0,
+                          horizontal: 16.0,
+                        ),
+                      ),
                     ),
-                  ),
+                    Container(
+                      height: 8.0,
+                    ),
+                    Container(
+                      padding: const EdgeInsets.only(left: 8),
+                      child: Text(
+                        '6자리 이상의 알파벳, 숫자, 특수문자로 구성',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w400,
+                          color: viewmodel.isPasswordValid != null
+                              ? (viewmodel.isPasswordValid!
+                                  ? PointColors.green
+                                  : PointColors.red)
+                              : CustomColors.whPlaceholderGrey,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 24,
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '비밀번호 확인',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        color: CustomColors.whWhite,
+                        fontSize: 20,
+                      ),
+                    ),
+                    Container(
+                      height: 8.0,
+                    ),
+                    TextFormField(
+                      controller: viewmodel.passwordValidatorInputController,
+                      obscureText: true,
+                      obscuringCharacter: '*',
+                      onChanged: (value) {
+                        setState(() {
+                          provider.matchPasswordAndValidator();
+                        });
+                      },
+                      cursorColor: CustomColors.whWhite,
+                      textAlignVertical: TextAlignVertical.center,
+                      style: const TextStyle(
+                        color: CustomColors.whWhite,
+                        fontSize: 16.0,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: '비밀번호 확인',
+                        hintStyle: const TextStyle(
+                          fontSize: 16,
+                          color: CustomColors.whPlaceholderGrey,
+                        ),
+                        filled: true,
+                        fillColor: CustomColors.whGrey,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(10),
+                          borderSide: const BorderSide(
+                            width: 0,
+                            style: BorderStyle.none,
+                          ),
+                        ),
+                        isCollapsed: true,
+                        contentPadding: const EdgeInsets.symmetric(
+                          vertical: 12.0,
+                          horizontal: 16.0,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      height: 8.0,
+                    ),
+                    Container(
+                      padding: const EdgeInsets.only(left: 8),
+                      child: Visibility(
+                        visible: viewmodel
+                            .passwordValidatorInputController.text.isNotEmpty,
+                        child: Text(
+                          viewmodel.isPasswordMatched
+                              ? '일치합니다'
+                              : '비밀번호와 일치하지 않습니다',
+                          style: TextStyle(
+                            fontWeight: FontWeight.w400,
+                            color: viewmodel.isPasswordMatched
+                                ? PointColors.green
+                                : PointColors.red,
+                            fontSize: 14,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                Expanded(child: Container()),
+                WideColoredButton(
+                  isDiminished: !(viewmodel.isEmailEntered &
+                          (viewmodel.isPasswordValid ?? false) &
+                          viewmodel.isPasswordMatched) |
+                      viewmodel.isProcessing,
+                  buttonTitle: viewmodel.isProcessing ? '처리 중' : '다음',
+                  backgroundColor: CustomColors.whYellow,
+                  foregroundColor: CustomColors.whBlack,
+                  onPressed: () async {
+                    setState(() {
+                      viewmodel.isProcessing = true;
+                    });
+
+                    ref
+                        .read(signUpWithEmailAndPasswordUsecaseProvider)
+                        .call(
+                          viewmodel.emailInputController.text,
+                          viewmodel.passwordInputController.text,
+                        )
+                        .then((result) {
+                      setState(() {
+                        viewmodel.isProcessing = false;
+                      });
+
+                      return result.fold((failure) {
+                        viewmodel.registerFailReason =
+                            RegisterFailReasonConverter.fromExceptionCode(
+                          failure.message,
+                        );
+
+                        String alertMessage;
+
+                        switch (viewmodel.registerFailReason) {
+                          case RegisterFailReason.emailFormatIsInvalid:
+                            alertMessage = '이메일의 형식이 올바르지 않아요';
+                          case RegisterFailReason.passwordIsWeak:
+                            alertMessage = '비밀번호가 올바르지 않아요';
+                          case RegisterFailReason.emailIsAlreadyTaken:
+                            alertMessage = '이미 사용 중인 이메일이예요';
+                          default:
+                            alertMessage = '잠시 후 다시 시도해주세요';
+                        }
+
+                        showToastMessage(
+                          context,
+                          text: alertMessage,
+                          icon: const Icon(
+                            Icons.warning,
+                            color: CustomColors.whYellow,
+                          ),
+                        );
+
+                        return false;
+                      }, (result) {
+                        if (result == AuthResult.success) {
+                          return true;
+                        }
+
+                        return false;
+                      });
+                    }).then((canMoveToNextStep) {
+                      if (canMoveToNextStep) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) {
+                              return const SignUpUserDetailView();
+                            },
+                          ),
+                        );
+                      }
+                    });
+                  },
                 ),
               ],
             ),
-            const SizedBox(
-              height: 24,
+          ),
+          Visibility(
+            visible: viewmodel.isProcessing,
+            child: Container(
+              constraints: const BoxConstraints.expand(),
+              alignment: Alignment.center,
+              color: CustomColors.whDarkBlack.withAlpha(130),
+              child: const CircularProgressIndicator(
+                color: CustomColors.whYellow,
+              ),
             ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  '비밀번호 확인',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
-                    color: CustomColors.whWhite,
-                    fontSize: 20,
-                  ),
-                ),
-                Container(
-                  height: 8.0,
-                ),
-                TextFormField(
-                  controller: viewmodel.passwordValidatorInputController,
-                  obscureText: true,
-                  obscuringCharacter: '*',
-                  onChanged: (value) {
-                    setState(() {
-                      provider.matchPasswordAndValidator();
-                    });
-                  },
-                  cursorColor: CustomColors.whWhite,
-                  textAlignVertical: TextAlignVertical.center,
-                  style: const TextStyle(
-                    color: CustomColors.whWhite,
-                    fontSize: 16.0,
-                  ),
-                  decoration: InputDecoration(
-                    hintText: '비밀번호 확인',
-                    hintStyle: const TextStyle(
-                      fontSize: 16,
-                      color: CustomColors.whPlaceholderGrey,
-                    ),
-                    filled: true,
-                    fillColor: CustomColors.whGrey,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: const BorderSide(
-                        width: 0,
-                        style: BorderStyle.none,
-                      ),
-                    ),
-                    isCollapsed: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                      vertical: 12.0,
-                      horizontal: 16.0,
-                    ),
-                  ),
-                ),
-                Container(
-                  height: 8.0,
-                ),
-                Container(
-                  padding: const EdgeInsets.only(left: 8),
-                  child: Text(
-                    viewmodel.isPasswordMatched ? '일치합니다' : '비밀번호와 일치하지 않습니다',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w400,
-                      color: viewmodel.isPasswordMatched
-                          ? PointColors.green
-                          : PointColors.red,
-                      fontSize: 14,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            Expanded(child: Container()),
-            WideColoredButton(
-              isDiminished: !(viewmodel.isEmailEntered &
-                      (viewmodel.isPasswordValid ?? false) &
-                      viewmodel.isPasswordMatched) |
-                  viewmodel.isProcessing,
-              buttonTitle: viewmodel.isProcessing ? '처리 중' : '다음',
-              backgroundColor: CustomColors.whYellow,
-              foregroundColor: CustomColors.whBlack,
-              onPressed: () async {
-                setState(() {
-                  viewmodel.isProcessing = true;
-                });
-
-                ref
-                    .read(signUpWithEmailAndPasswordUsecaseProvider)
-                    .call(
-                      viewmodel.emailInputController.text,
-                      viewmodel.passwordInputController.text,
-                    )
-                    .then((result) {
-                  setState(() {
-                    viewmodel.isProcessing = false;
-                  });
-
-                  return result.fold((failure) {
-                    viewmodel.registerFailReason =
-                        RegisterFailReasonConverter.fromExceptionCode(
-                      failure.message,
-                    );
-
-                    String alertMessage;
-
-                    switch (viewmodel.registerFailReason) {
-                      case RegisterFailReason.emailFormatIsInvalid:
-                        alertMessage = '이메일의 형식이 올바르지 않아요';
-                      case RegisterFailReason.passwordIsWeak:
-                        alertMessage = '비밀번호가 올바르지 않아요';
-                      case RegisterFailReason.emailIsAlreadyTaken:
-                        alertMessage = '이미 사용 중인 이메일이예요';
-                      default:
-                        alertMessage = '잠시 후 다시 시도해주세요';
-                    }
-
-                    showToastMessage(
-                      context,
-                      text: alertMessage,
-                      icon: const Icon(
-                        Icons.warning,
-                        color: CustomColors.whYellow,
-                      ),
-                    );
-
-                    return false;
-                  }, (result) {
-                    if (result == AuthResult.success) {
-                      return true;
-                    }
-
-                    return false;
-                  });
-                }).then((canMoveToNextStep) {
-                  if (canMoveToNextStep) {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) {
-                          return const SignUpUserDetailView();
-                        },
-                      ),
-                    );
-                  }
-                });
-              },
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -349,15 +370,21 @@ class _SignUpUserDetailViewState extends ConsumerState<SignUpUserDetailView> {
     return Stack(
       children: [
         Scaffold(
-          resizeToAvoidBottomInset: false,
+          resizeToAvoidBottomInset: true,
           backgroundColor: CustomColors.whDarkBlack,
           appBar: WehavitAppBar(
             title: '회원가입',
             leadingTitle: '',
             leadingIcon: Icons.chevron_left,
             leadingAction: () async {
-              await provider.removeUserData();
-              await provider.logOut();
+              try {
+                await provider.removeUserData();
+                await provider.logOut();
+              } on Exception catch (e) {
+                // ignore: avoid_print
+                print('DEBUG: ${e.toString()}');
+              }
+
               // ignore: use_build_context_synchronously
               Navigator.pop(context);
             },
@@ -367,215 +394,225 @@ class _SignUpUserDetailViewState extends ConsumerState<SignUpUserDetailView> {
             maintainBottomViewPadding: true,
             child: Column(
               children: [
-                TextButton(
-                  style: TextButton.styleFrom(
-                    overlayColor: CustomColors.whYellow,
-                  ),
-                  onPressed: () async {
-                    provider.pickProfileImage().whenComplete(
-                          () => setState(() {}),
-                        );
-                  },
-                  child: Stack(
-                    clipBehavior: Clip.none,
+                Expanded(
+                  child: ListView(
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.only(bottom: 32.0),
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
                     children: [
-                      Container(
-                        width: 85,
-                        height: 85,
-                        decoration: const BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: CustomColors.whGrey,
+                      TextButton(
+                        style: TextButton.styleFrom(
+                          overlayColor: CustomColors.whYellow,
                         ),
-                        clipBehavior: Clip.hardEdge,
-                        child: viewmodel.profileImageFile != null
-                            ? Image.file(
-                                viewmodel.profileImageFile!,
-                                fit: BoxFit.cover,
-                              )
-                            : Container(),
-                      ),
-                      Positioned(
-                        bottom: 0,
-                        right: -5,
-                        child: Container(
-                          width: 25,
-                          height: 25,
-                          decoration: const BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: CustomColors.whWhite,
-                          ),
-                          child: const Icon(
-                            Icons.photo_camera,
-                            color: CustomColors.whBlack,
-                            size: 18.0,
-                          ),
+                        onPressed: () async {
+                          provider.pickProfileImage().whenComplete(
+                                () => setState(() {}),
+                              );
+                        },
+                        child: Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            Container(
+                              width: 85,
+                              height: 85,
+                              decoration: const BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: CustomColors.whGrey,
+                              ),
+                              clipBehavior: Clip.hardEdge,
+                              child: viewmodel.profileImageFile != null
+                                  ? Image.file(
+                                      viewmodel.profileImageFile!,
+                                      fit: BoxFit.cover,
+                                    )
+                                  : Container(),
+                            ),
+                            Positioned(
+                              bottom: 0,
+                              right: -5,
+                              child: Container(
+                                width: 25,
+                                height: 25,
+                                decoration: const BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: CustomColors.whWhite,
+                                ),
+                                child: const Icon(
+                                  Icons.photo_camera,
+                                  color: CustomColors.whBlack,
+                                  size: 18.0,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
+                      const SizedBox(
+                        height: 24,
+                      ),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            '이름',
+                            style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              color: CustomColors.whWhite,
+                              fontSize: 20,
+                            ),
+                          ),
+                          Container(
+                            height: 8.0,
+                          ),
+                          TextFormField(
+                            onChanged: (value) {
+                              provider.setName(value);
+                              setState(() {});
+                            },
+                            cursorColor: CustomColors.whWhite,
+                            textAlignVertical: TextAlignVertical.center,
+                            style: const TextStyle(
+                              color: CustomColors.whWhite,
+                              fontSize: 16.0,
+                            ),
+                            decoration: InputDecoration(
+                              hintText: '친구들에게 보여지는 이름이예요',
+                              hintStyle: const TextStyle(
+                                fontSize: 16,
+                                color: CustomColors.whPlaceholderGrey,
+                              ),
+                              filled: true,
+                              fillColor: CustomColors.whGrey,
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(10),
+                                borderSide: const BorderSide(
+                                  width: 0,
+                                  style: BorderStyle.none,
+                                ),
+                              ),
+                              isCollapsed: true,
+                              contentPadding: const EdgeInsets.symmetric(
+                                vertical: 12.0,
+                                horizontal: 16.0,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(
+                        height: 24,
+                      ),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            '사용자 ID',
+                            style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              color: CustomColors.whWhite,
+                              fontSize: 20,
+                            ),
+                          ),
+                          Container(
+                            height: 8.0,
+                          ),
+                          TextFormField(
+                            onChanged: (value) {
+                              provider.setHandle(value);
+                              setState(() {});
+                            },
+                            cursorColor: CustomColors.whWhite,
+                            textAlignVertical: TextAlignVertical.center,
+                            inputFormatters: <TextInputFormatter>[
+                              FilteringTextInputFormatter.allow(
+                                RegExp(r'[0-9a-zA-Z!@#$%^&*(),.?":{}|<>_]'),
+                              ),
+                            ],
+                            style: const TextStyle(
+                              color: CustomColors.whWhite,
+                              fontSize: 16.0,
+                            ),
+                            decoration: InputDecoration(
+                              hintText: '친구가 나를 찾을 때 사용하는 ID예요',
+                              hintStyle: const TextStyle(
+                                fontSize: 16,
+                                color: CustomColors.whPlaceholderGrey,
+                              ),
+                              filled: true,
+                              fillColor: CustomColors.whGrey,
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(10),
+                                borderSide: const BorderSide(
+                                  width: 0,
+                                  style: BorderStyle.none,
+                                ),
+                              ),
+                              isCollapsed: true,
+                              contentPadding: const EdgeInsets.symmetric(
+                                vertical: 12.0,
+                                horizontal: 16.0,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(
+                        height: 24,
+                      ),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            '한 줄 소개',
+                            style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              color: CustomColors.whWhite,
+                              fontSize: 20,
+                            ),
+                          ),
+                          Container(
+                            height: 8.0,
+                          ),
+                          TextFormField(
+                            onChanged: (value) {
+                              provider.setAboutMe(value);
+                              setState(() {});
+                            },
+                            cursorColor: CustomColors.whWhite,
+                            textAlignVertical: TextAlignVertical.center,
+                            style: const TextStyle(
+                              color: CustomColors.whWhite,
+                              fontSize: 16.0,
+                            ),
+                            decoration: InputDecoration(
+                              hintText: '나에 대해 소개해주세요',
+                              hintStyle: const TextStyle(
+                                fontSize: 16,
+                                color: CustomColors.whPlaceholderGrey,
+                              ),
+                              filled: true,
+                              fillColor: CustomColors.whGrey,
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(10),
+                                borderSide: const BorderSide(
+                                  width: 0,
+                                  style: BorderStyle.none,
+                                ),
+                              ),
+                              isCollapsed: true,
+                              contentPadding: const EdgeInsets.symmetric(
+                                vertical: 12.0,
+                                horizontal: 16.0,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      // Expanded(child: Container()),
                     ],
                   ),
                 ),
-                const SizedBox(
-                  height: 24,
-                ),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Text(
-                      '이름',
-                      style: TextStyle(
-                        fontWeight: FontWeight.w600,
-                        color: CustomColors.whWhite,
-                        fontSize: 20,
-                      ),
-                    ),
-                    Container(
-                      height: 8.0,
-                    ),
-                    TextFormField(
-                      onChanged: (value) {
-                        provider.setName(value);
-                        setState(() {});
-                      },
-                      cursorColor: CustomColors.whWhite,
-                      textAlignVertical: TextAlignVertical.center,
-                      style: const TextStyle(
-                        color: CustomColors.whWhite,
-                        fontSize: 16.0,
-                      ),
-                      decoration: InputDecoration(
-                        hintText: '친구들에게 보여지는 이름이예요',
-                        hintStyle: const TextStyle(
-                          fontSize: 16,
-                          color: CustomColors.whPlaceholderGrey,
-                        ),
-                        filled: true,
-                        fillColor: CustomColors.whGrey,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(10),
-                          borderSide: const BorderSide(
-                            width: 0,
-                            style: BorderStyle.none,
-                          ),
-                        ),
-                        isCollapsed: true,
-                        contentPadding: const EdgeInsets.symmetric(
-                          vertical: 12.0,
-                          horizontal: 16.0,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(
-                  height: 24,
-                ),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Text(
-                      '사용자 ID',
-                      style: TextStyle(
-                        fontWeight: FontWeight.w600,
-                        color: CustomColors.whWhite,
-                        fontSize: 20,
-                      ),
-                    ),
-                    Container(
-                      height: 8.0,
-                    ),
-                    TextFormField(
-                      onChanged: (value) {
-                        provider.setHandle(value);
-                        setState(() {});
-                      },
-                      cursorColor: CustomColors.whWhite,
-                      textAlignVertical: TextAlignVertical.center,
-                      inputFormatters: <TextInputFormatter>[
-                        FilteringTextInputFormatter.allow(
-                          RegExp(r'[0-9a-zA-Z!@#$%^&*(),.?":{}|<>]'),
-                        ),
-                      ],
-                      style: const TextStyle(
-                        color: CustomColors.whWhite,
-                        fontSize: 16.0,
-                      ),
-                      decoration: InputDecoration(
-                        hintText: '친구가 나를 찾을 때 사용하는 ID예요',
-                        hintStyle: const TextStyle(
-                          fontSize: 16,
-                          color: CustomColors.whPlaceholderGrey,
-                        ),
-                        filled: true,
-                        fillColor: CustomColors.whGrey,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(10),
-                          borderSide: const BorderSide(
-                            width: 0,
-                            style: BorderStyle.none,
-                          ),
-                        ),
-                        isCollapsed: true,
-                        contentPadding: const EdgeInsets.symmetric(
-                          vertical: 12.0,
-                          horizontal: 16.0,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(
-                  height: 24,
-                ),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Text(
-                      '한 줄 소개',
-                      style: TextStyle(
-                        fontWeight: FontWeight.w600,
-                        color: CustomColors.whWhite,
-                        fontSize: 20,
-                      ),
-                    ),
-                    Container(
-                      height: 8.0,
-                    ),
-                    TextFormField(
-                      onChanged: (value) {
-                        provider.setAboutMe(value);
-                        setState(() {});
-                      },
-                      cursorColor: CustomColors.whWhite,
-                      textAlignVertical: TextAlignVertical.center,
-                      style: const TextStyle(
-                        color: CustomColors.whWhite,
-                        fontSize: 16.0,
-                      ),
-                      decoration: InputDecoration(
-                        hintText: '나에 대해 소개해주세요',
-                        hintStyle: const TextStyle(
-                          fontSize: 16,
-                          color: CustomColors.whPlaceholderGrey,
-                        ),
-                        filled: true,
-                        fillColor: CustomColors.whGrey,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(10),
-                          borderSide: const BorderSide(
-                            width: 0,
-                            style: BorderStyle.none,
-                          ),
-                        ),
-                        isCollapsed: true,
-                        contentPadding: const EdgeInsets.symmetric(
-                          vertical: 12.0,
-                          horizontal: 16.0,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                Expanded(child: Container()),
                 WideColoredButton(
                   onPressed: () async {
                     setState(() {

--- a/lib/presentation/entrance/view/sign_up_view.dart
+++ b/lib/presentation/entrance/view/sign_up_view.dart
@@ -67,6 +67,7 @@ class _SignUpAuthDataViewState extends ConsumerState<SignUpAuthDataView> {
                       height: 8.0,
                     ),
                     TextFormField(
+                      keyboardType: TextInputType.emailAddress,
                       controller: viewmodel.emailInputController,
                       onChanged: (value) {
                         provider.checkEmailEntered();

--- a/lib/presentation/friend_list/provider/friend_list_view_model_provider.dart
+++ b/lib/presentation/friend_list/provider/friend_list_view_model_provider.dart
@@ -7,7 +7,7 @@ import 'package:wehavit/presentation/friend_list/model/friend_list_view_model.da
 class FriendListViewModelProvider extends StateNotifier<FriendListViewModel> {
   FriendListViewModelProvider(
     this._getFriendListUsecase,
-    this._searchUserDataListByNicknameUsecase,
+    this._searchUserDataListByHandleUsecase,
     this._getMyUserDataUsecase,
     this._getAppliedUserListForFriendUsecase,
     this._acceptApplyingForFriendUsecase,
@@ -19,8 +19,7 @@ class FriendListViewModelProvider extends StateNotifier<FriendListViewModel> {
 
   final GetFriendListUsecase _getFriendListUsecase;
   final GetAppliedUserListForFriendUsecase _getAppliedUserListForFriendUsecase;
-  final SearchUserDataListByNicknameUsecase
-      _searchUserDataListByNicknameUsecase;
+  final SearchUserDataListByHandleUsecase _searchUserDataListByHandleUsecase;
   final GetMyUserDataUsecase _getMyUserDataUsecase;
   final AcceptApplyingForFriendUsecase _acceptApplyingForFriendUsecase;
   final RejectApplyingForFriendUsecase _rejectApplyingForFriendUsecase;
@@ -37,9 +36,9 @@ class FriendListViewModelProvider extends StateNotifier<FriendListViewModel> {
     );
   }
 
-  Future<void> searchUserByNickname({required String nickname}) async {
-    state.searchedFutureUserList = await _searchUserDataListByNicknameUsecase(
-      nickname: nickname,
+  Future<void> searchUserByHandle({required String handle}) async {
+    state.searchedFutureUserList = await _searchUserDataListByHandleUsecase(
+      handle: handle,
     ).then(
       (result) => result.fold(
         (failure) => null,

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -7,7 +7,10 @@ import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
 class FriendListView extends ConsumerStatefulWidget {
-  const FriendListView({super.key});
+  const FriendListView(this.index, this.tabController, {super.key});
+
+  final int index;
+  final TabController tabController;
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => FrinedListViewState();

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -187,12 +187,12 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                     Container(
                       margin: const EdgeInsets.only(bottom: 4.0),
                       child: FriendListTextFieldWidget(
-                        searchCallback: (searchNickname) async {
-                          if (searchNickname != null &&
-                              searchNickname.isNotEmpty) {
+                        searchCallback: (searchedHandle) async {
+                          if (searchedHandle != null &&
+                              searchedHandle.isNotEmpty) {
                             provider
-                                .searchUserByNickname(
-                                  nickname: searchNickname,
+                                .searchUserByHandle(
+                                  handle: searchedHandle,
                                 )
                                 .whenComplete(() => setState(() {}));
                           }

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
-import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
@@ -69,11 +68,11 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
               ElevatedButton(
                 // 수정 필요함!
                 onPressed: () async {
-                  await ref.read(logOutUseCaseProvider).call();
-                  if (mounted) {
-                    // ignore: use_build_context_synchronously
-                    Navigator.pushReplacementNamed(context, '/entrance');
-                  }
+                  // await ref.read(logOutUseCaseProvider).call();
+                  // if (mounted) {
+                  //   // ignore: use_build_context_synchronously
+                  //   Navigator.pushReplacementNamed(context, '/entrance');
+                  // }
                 },
                 style: ElevatedButton.styleFrom(
                   shape: RoundedRectangleBorder(

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -7,10 +7,7 @@ import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
 class FriendListView extends ConsumerStatefulWidget {
-  const FriendListView(this.index, this.tabController, {super.key});
-
-  final int index;
-  final TabController tabController;
+  const FriendListView({super.key});
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => FrinedListViewState();

--- a/lib/presentation/friend_list/view/friend_list_view_widget.dart
+++ b/lib/presentation/friend_list/view/friend_list_view_widget.dart
@@ -83,14 +83,30 @@ class _FriendListCellWidgetState extends ConsumerState<FriendListCellWidget> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    userEntity.userName ?? '',
-                    style: const TextStyle(
-                      color: CustomColors.whWhite,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    overflow: TextOverflow.ellipsis,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        '${userEntity.handle} • ',
+                        style: const TextStyle(
+                          color: CustomColors.whWhite,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Expanded(
+                        child: Text(
+                          userEntity.userName ?? '',
+                          style: const TextStyle(
+                            color: CustomColors.whSemiWhite,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
                   ),
                   Text(
                     userEntity.aboutMe ?? '',
@@ -285,7 +301,7 @@ class FriendListTextFieldWidget extends StatelessWidget {
                 decoration: const InputDecoration(
                   icon: Icon(Icons.search),
                   iconColor: CustomColors.whWhite,
-                  hintText: '닉네임으로 친구 찾기',
+                  hintText: 'ID로 친구 찾기',
                   hintStyle: TextStyle(
                     color: CustomColors.whWhite,
                     fontSize: 16,

--- a/lib/presentation/friend_list/view/friend_list_view_widget.dart
+++ b/lib/presentation/friend_list/view/friend_list_view_widget.dart
@@ -70,48 +70,45 @@ class _FriendListCellWidgetState extends ConsumerState<FriendListCellWidget> {
       ),
       forFail: Container(),
       mainWidgetCallback: (userEntity) {
-        return Container(
-          // margin: const EdgeInsets.only(top: 12),
-          child: Row(
-            children: [
-              ProfileImageCircleWidget(
-                size: 60,
-                url: userEntity.userImageUrl,
-              ),
-              const SizedBox(
-                width: 12,
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      userEntity.userName ?? '',
-                      style: const TextStyle(
-                        color: CustomColors.whWhite,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      overflow: TextOverflow.ellipsis,
+        return Row(
+          children: [
+            ProfileImageCircleWidget(
+              size: 60,
+              url: userEntity.userImageUrl,
+            ),
+            const SizedBox(
+              width: 12,
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    userEntity.userName ?? '',
+                    style: const TextStyle(
+                      color: CustomColors.whWhite,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
                     ),
-                    Text(
-                      userEntity.aboutMe ?? '',
-                      style: const TextStyle(
-                        color: CustomColors.whPlaceholderGrey,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w300,
-                      ),
-                      overflow: TextOverflow.ellipsis,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    userEntity.aboutMe ?? '',
+                    style: const TextStyle(
+                      color: CustomColors.whPlaceholderGrey,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w300,
                     ),
-                    const SizedBox(
-                      width: 8,
-                    ),
-                  ],
-                ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(
+                    width: 8,
+                  ),
+                ],
               ),
-              postfixButtonWidget(userEntity, ref),
-            ],
-          ),
+            ),
+            postfixButtonWidget(userEntity, ref),
+          ],
         );
       },
     );
@@ -402,26 +399,26 @@ class FriendListMyProfileWidget extends StatelessWidget {
                 ],
               ),
             ),
-            Column(
-              children: [
-                Image.asset(
-                  CustomIconImage.linkIcon,
-                  width: 20,
-                  height: 20,
-                ),
-                const SizedBox(
-                  height: 4,
-                ),
-                const Text(
-                  '복사하기',
-                  style: TextStyle(
-                    fontSize: 14.0,
-                    fontWeight: FontWeight.w700,
-                    color: CustomColors.whWhite,
-                  ),
-                ),
-              ],
-            ),
+            // Column(
+            //   children: [
+            //     Image.asset(
+            //       CustomIconImage.linkIcon,
+            //       width: 20,
+            //       height: 20,
+            //     ),
+            //     const SizedBox(
+            //       height: 4,
+            //     ),
+            //     const Text(
+            //       '복사하기',
+            //       style: TextStyle(
+            //         fontSize: 14.0,
+            //         fontWeight: FontWeight.w700,
+            //         color: CustomColors.whWhite,
+            //       ),
+            //     ),
+            //   ],
+            // ),
           ],
         );
       },

--- a/lib/presentation/friend_list/view/view.dart
+++ b/lib/presentation/friend_list/view/view.dart
@@ -1,3 +1,3 @@
 export 'friend_list_view.dart';
-export '../provider/friend_list_view_widget.dart';
+export 'friend_list_view_widget.dart';
 export 'screens.dart';

--- a/lib/presentation/friend_list/widgets/friend_element_widget.dart
+++ b/lib/presentation/friend_list/widgets/friend_element_widget.dart
@@ -77,7 +77,7 @@ class _FriendElementWidgetState extends State<FriendElementWidget> {
             color: Colors.black54,
             blurRadius: 5.0,
             offset: Offset(0, 2),
-          )
+          ),
         ],
       ),
     );

--- a/lib/presentation/group/model/create_group_view_model.dart
+++ b/lib/presentation/group/model/create_group_view_model.dart
@@ -4,8 +4,13 @@ class CreateGroupViewModel {
   List<bool> stepDoneList = List<bool>.filled(4, false);
   ScrollController scrollController = ScrollController();
 
+  int focusedStep = 0;
+  int currentStep = 0;
+  bool isMovableToNextStep = false;
+  List<bool> inputConditions = [false, false, false, true];
+
   String groupName = '';
   String groupDescription = '';
   String groupRule = '';
-  int groupColorIndex = -1;
+  int groupColorIndex = 0;
 }

--- a/lib/presentation/group/provider/create_group_view_model_provider.dart
+++ b/lib/presentation/group/provider/create_group_view_model_provider.dart
@@ -9,45 +9,63 @@ class CreateGroupViewModelProvider extends StateNotifier<CreateGroupViewModel> {
 
   final CreateGroupUsecase _createGroupUsecase;
 
-  bool isComplete() {
-    return !state.stepDoneList.contains(false);
-  }
+  // bool isComplete() {
+  //   return !state.stepDoneList.contains(false);
+  // }
 
-  void setStepDoneList(int index, bool value) {
-    state.stepDoneList[index] = value;
-  }
+  // void setStepDoneList(int index, bool value) {
+  //   state.stepDoneList[index] = value;
+  // }
 
   void setGroupName(String value) {
+    if (value.isEmpty) {
+      state.inputConditions[0] = false;
+    } else {
+      state.inputConditions[0] = true;
+    }
     state.groupName = value;
+    checkIsMovableToNextStep();
   }
 
-  bool isGroupNameFilled() {
-    return state.groupName.isNotEmpty;
-  }
+  // bool isGroupNameFilled() {
+  //   return state.groupName.isNotEmpty;
+  // }
 
   void setDescriptionName(String value) {
+    if (value.isEmpty) {
+      state.inputConditions[1] = false;
+    } else {
+      state.inputConditions[1] = true;
+    }
     state.groupDescription = value;
+    checkIsMovableToNextStep();
   }
 
-  bool isGroupDescriptionFilled() {
-    return state.groupDescription.isNotEmpty;
-  }
+  // bool isGroupDescriptionFilled() {
+  //   return state.groupDescription.isNotEmpty;
+  // }
 
   void setGroupRule(String value) {
+    if (value.isEmpty) {
+      state.inputConditions[2] = false;
+    } else {
+      state.inputConditions[2] = true;
+    }
     state.groupRule = value;
+    checkIsMovableToNextStep();
   }
 
-  bool isGroupRuleFilled() {
-    return state.groupRule.isNotEmpty;
-  }
+  // bool isGroupRuleFilled() {
+  //   return state.groupRule.isNotEmpty;
+  // }
 
   void setGroupColorIndex(int value) {
     state.groupColorIndex = value;
   }
 
-  bool isGroupColorIndexFilled() {
-    return state.groupColorIndex >= 0;
-  }
+  // bool isGroupColorIndexFilled() {
+  //   return state.groupColorIndex >= 0;
+  // }
 
   void scrollDown() {
     state.scrollController
@@ -68,5 +86,15 @@ class CreateGroupViewModelProvider extends StateNotifier<CreateGroupViewModel> {
             (entity) => entity,
           ),
         );
+  }
+
+  void checkIsMovableToNextStep() {
+    state.isMovableToNextStep = state.inputConditions
+        .sublist(0, state.currentStep + 1)
+        .reduce((value, element) => value & element);
+  }
+
+  void setFocusedStep(int value) {
+    state.focusedStep = value;
   }
 }

--- a/lib/presentation/group/view/done_creating_group_view.dart
+++ b/lib/presentation/group/view/done_creating_group_view.dart
@@ -1,27 +1,34 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/constants/app_colors.dart';
+import 'package:wehavit/dependency/domain/domain.dart';
+import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/presentation/common_components/common_components.dart';
+import 'package:wehavit/presentation/presentation.dart';
 
-class DoneCreatingGroupView extends StatelessWidget {
+class DoneCreatingGroupView extends ConsumerWidget {
   const DoneCreatingGroupView({super.key, required this.groupEntity});
 
   final GroupEntity groupEntity;
 
   @override
-  Widget build(BuildContext context) {
-    return WillPopScope(
-      // canPop: false,
-      onWillPop: () async {
-        return false;
-      },
+  Widget build(BuildContext context, WidgetRef ref) {
+    // ignore: discarded_futures
+    final futureUserModel = ref.read(getMyUserDataUsecaseProvider)();
+
+    return PopScope(
+      canPop: false,
+      // onWillPop: () async {
+      //   return false;
+      // },
       child: Scaffold(
         backgroundColor: CustomColors.whDarkBlack,
         appBar: WehavitAppBar(
           title: '그룹 만들기 완료',
           trailingTitle: '닫기',
-          trailingAction: () {
+          trailingAction: () async {
+            ref.read(groupViewModelProvider.notifier).loadMyGroupCellList();
+
             int count = 0;
             Navigator.of(context).popUntil((_) => count++ >= 2);
           },
@@ -39,6 +46,13 @@ class DoneCreatingGroupView extends StatelessWidget {
                           decoration: BoxDecoration(
                             color: CustomColors.whGrey,
                             borderRadius: BorderRadius.circular(15),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withAlpha(64),
+                                offset: const Offset(0, 4),
+                                blurRadius: 4,
+                              ),
+                            ],
                           ),
                           child: Container(
                             width: double.infinity,
@@ -72,16 +86,20 @@ class DoneCreatingGroupView extends StatelessWidget {
                                         '그룹 소개',
                                         style: TextStyle(
                                           fontSize: 16.0,
-                                          fontWeight: FontWeight.w500,
+                                          fontWeight: FontWeight.w600,
                                           color: CustomColors.whWhite,
                                         ),
                                       ),
-                                      Text(
-                                        groupEntity.groupDescription ?? '',
-                                        style: const TextStyle(
-                                          fontSize: 14.0,
-                                          fontWeight: FontWeight.w300,
-                                          color: CustomColors.whWhite,
+                                      Padding(
+                                        padding:
+                                            const EdgeInsets.only(left: 16.0),
+                                        child: Text(
+                                          groupEntity.groupDescription ?? '',
+                                          style: const TextStyle(
+                                            fontSize: 14.0,
+                                            fontWeight: FontWeight.w300,
+                                            color: CustomColors.whWhite,
+                                          ),
                                         ),
                                       ),
                                     ],
@@ -99,16 +117,18 @@ class DoneCreatingGroupView extends StatelessWidget {
                                         '그룹 리더',
                                         style: TextStyle(
                                           fontSize: 16.0,
-                                          fontWeight: FontWeight.w500,
+                                          fontWeight: FontWeight.w600,
                                           color: CustomColors.whWhite,
                                         ),
                                       ),
-                                      Text(
-                                        groupEntity.groupManagerUid,
-                                        style: const TextStyle(
-                                          fontSize: 14.0,
-                                          fontWeight: FontWeight.w300,
-                                          color: CustomColors.whWhite,
+                                      Padding(
+                                        padding: const EdgeInsets.only(
+                                          left: 16.0,
+                                          top: 8.0,
+                                        ),
+                                        child: FriendListCellWidget(
+                                          futureUserEntity: futureUserModel,
+                                          cellState: FriendListCellState.normal,
                                         ),
                                       ),
                                     ],
@@ -126,16 +146,20 @@ class DoneCreatingGroupView extends StatelessWidget {
                                         '그룹 규칙',
                                         style: TextStyle(
                                           fontSize: 16.0,
-                                          fontWeight: FontWeight.w500,
+                                          fontWeight: FontWeight.w600,
                                           color: CustomColors.whWhite,
                                         ),
                                       ),
-                                      Text(
-                                        groupEntity.groupRule ?? '',
-                                        style: const TextStyle(
-                                          fontSize: 14.0,
-                                          fontWeight: FontWeight.w300,
-                                          color: CustomColors.whWhite,
+                                      Padding(
+                                        padding:
+                                            const EdgeInsets.only(left: 16.0),
+                                        child: Text(
+                                          groupEntity.groupRule ?? '',
+                                          style: const TextStyle(
+                                            fontSize: 14.0,
+                                            fontWeight: FontWeight.w300,
+                                            color: CustomColors.whWhite,
+                                          ),
                                         ),
                                       ),
                                     ],
@@ -150,26 +174,46 @@ class DoneCreatingGroupView extends StatelessWidget {
                   ],
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 8.0),
-                child: WideColoredButton(
-                  buttonTitle: '그룹 코드 복사하기',
-                  foregroundColor: CustomColors.whBlack,
-                  backgroundColor: CustomColors.whYellow,
-                  onPressed: () async {
-                    Clipboard.setData(
-                      ClipboardData(text: groupEntity.groupId),
-                    );
-
-                    showToastMessage(
-                      context,
-                      text: '복사된 그룹 코드를 공유해보세요',
-                      icon: const Icon(
-                        Icons.check_circle,
-                        color: Colors.green,
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8.0),
+                child: Column(
+                  children: [
+                    Text(
+                      textAlign: TextAlign.center,
+                      '그룹 이름으로 검색하여\n참가 요청을 보낼 수 있습니다',
+                      style: TextStyle(
+                        fontSize: 16.0,
+                        fontWeight: FontWeight.w600,
+                        color: CustomColors.whWhite,
                       ),
-                    );
-                  },
+                    ),
+                    SizedBox(
+                      height: 24.0,
+                    ),
+
+                    // 이후에 링크로 초대 신청하기 기능이 나오면,
+                    // 바로 복사할 때 여기 버튼을 활용해주기!
+
+                    // WideColoredButton(
+                    //   buttonTitle: '그룹 코드 복사하기',
+                    //   foregroundColor: CustomColors.whBlack,
+                    //   backgroundColor: CustomColors.whYellow,
+                    //   onPressed: () async {
+                    //     Clipboard.setData(
+                    //       ClipboardData(text: groupEntity.groupId),
+                    //     );
+
+                    //     showToastMessage(
+                    //       context,
+                    //       text: '복사된 그룹 코드를 공유해보세요',
+                    //       icon: const Icon(
+                    //         Icons.check_circle,
+                    //         color: Colors.green,
+                    //       ),
+                    //     );
+                    //   },
+                    // ),
+                  ],
                 ),
               ),
             ],

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -34,31 +34,31 @@ class _GroupViewState extends ConsumerState<GroupView>
     final viewModel = ref.watch(groupViewModelProvider);
     final provider = ref.read(groupViewModelProvider.notifier);
 
-    List<Widget> groupListViewCellList = (viewModel.groupListViewCellModelList
-                ?.map(
-                  (cellModel) => GestureDetector(
-                    onTapUp: (details) async {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) {
-                            return GroupPostView(
-                              groupEntity: cellModel.groupEntity,
-                            );
-                          },
-                        ),
-                      ).whenComplete(
-                        () => setState(
-                          () {},
-                        ),
-                      );
-                    },
-                    child: GroupListViewCellWidget(cellModel: cellModel),
-                  ),
-                )
-                .toList() ??
-            List<Widget>.empty())
-        .append(
+    List<Widget> groupListViewCellList = [
+      ...viewModel.groupListViewCellModelList
+              ?.map(
+                (cellModel) => GestureDetector(
+                  onTapUp: (details) async {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) {
+                          return GroupPostView(
+                            groupEntity: cellModel.groupEntity,
+                          );
+                        },
+                      ),
+                    ).whenComplete(
+                      () => setState(
+                        () {},
+                      ),
+                    );
+                  },
+                  child: GroupListViewCellWidget(cellModel: cellModel),
+                ),
+              )
+              .toList() ??
+          List<Widget>.empty(),
       GroupListViewAddCellWidget(
         tapAddGroupCallback: () async {
           showAddMenuBottomSheet(
@@ -70,7 +70,7 @@ class _GroupViewState extends ConsumerState<GroupView>
           );
         },
       ),
-    ).toList();
+    ];
 
     return Scaffold(
       backgroundColor: CustomColors.whDarkBlack,
@@ -95,8 +95,7 @@ class _GroupViewState extends ConsumerState<GroupView>
                     },
                     child: ListView.builder(
                       padding: const EdgeInsets.only(bottom: 60.0),
-                      itemCount:
-                          viewModel.groupListViewCellModelList!.length + 1,
+                      itemCount: groupListViewCellList.length,
                       itemBuilder: (context, index) {
                         return Padding(
                           padding: const EdgeInsets.only(

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -10,7 +10,10 @@ import 'package:wehavit/presentation/group/group.dart';
 import 'package:wehavit/presentation/group_post/group_post.dart';
 
 class GroupView extends ConsumerStatefulWidget {
-  const GroupView({super.key});
+  const GroupView(this.index, this.tabController, {super.key});
+
+  final int index;
+  final TabController tabController;
 
   @override
   ConsumerState<GroupView> createState() => _GroupViewState();

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -29,7 +29,7 @@ class _GroupViewState extends ConsumerState<GroupView>
   Widget build(BuildContext context) {
     super.build(context);
     final viewModel = ref.watch(groupViewModelProvider);
-    // final provider = ref.read(groupViewModelProvider.notifier);
+    final provider = ref.read(groupViewModelProvider.notifier);
 
     List<Widget> groupListViewCellList = (viewModel.groupListViewCellModelList
                 ?.map(
@@ -58,7 +58,13 @@ class _GroupViewState extends ConsumerState<GroupView>
         .append(
       GroupListViewAddCellWidget(
         tapAddGroupCallback: () async {
-          showAddMenuBottomSheet(context);
+          showAddMenuBottomSheet(
+            context,
+            setStateCallback: () async {
+              await provider.loadMyGroupCellList();
+              setState(() {});
+            },
+          );
         },
       ),
     ).toList();
@@ -80,7 +86,9 @@ class _GroupViewState extends ConsumerState<GroupView>
             child: viewModel.groupListViewCellModelList != null
                 ? RefreshIndicator(
                     onRefresh: () async {
-                      unawaited(loadGroupCellList());
+                      provider
+                          .loadMyGroupCellList()
+                          .whenComplete(() => setState(() {}));
                     },
                     child: ListView.builder(
                       padding: const EdgeInsets.only(bottom: 60.0),
@@ -103,7 +111,10 @@ class _GroupViewState extends ConsumerState<GroupView>
     );
   }
 
-  Future<dynamic> showAddMenuBottomSheet(BuildContext context) {
+  Future<dynamic> showAddMenuBottomSheet(
+    BuildContext context, {
+    required void Function() setStateCallback,
+  }) {
     return showModalBottomSheet(
       context: context,
       builder: (context) {
@@ -141,7 +152,10 @@ class _GroupViewState extends ConsumerState<GroupView>
                         return const CreateGroupView();
                       },
                     ),
-                  ).then((_) => Navigator.pop(context));
+                  ).then((_) {
+                    setStateCallback();
+                    Navigator.pop(context);
+                  });
                 },
               ),
               const SizedBox(

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -9,10 +9,7 @@ import 'package:wehavit/presentation/group/group.dart';
 import 'package:wehavit/presentation/group_post/group_post.dart';
 
 class GroupView extends ConsumerStatefulWidget {
-  const GroupView(this.index, this.tabController, {super.key});
-
-  final int index;
-  final TabController tabController;
+  const GroupView({super.key});
 
   @override
   ConsumerState<GroupView> createState() => _GroupViewState();

--- a/lib/presentation/group/view/join_group_view.dart
+++ b/lib/presentation/group/view/join_group_view.dart
@@ -30,7 +30,7 @@ class _JoinGroupViewState extends ConsumerState<JoinGroupView> {
       backgroundColor: CustomColors.whDarkBlack,
       appBar: WehavitAppBar(
         title: '그룹에 참여하기',
-        leadingTitle: '취소',
+        leadingTitle: '닫기',
         leadingAction: () {
           Navigator.pop(context);
         },

--- a/lib/presentation/group_post/model/group_post_view_model.dart
+++ b/lib/presentation/group_post/model/group_post_view_model.dart
@@ -16,6 +16,9 @@ class GroupPostViewModel {
 
   String groupId = '';
 
+  // 관리자일 때만 숫자를 불러옴
+  int appliedUserCountForManager = 0;
+
   bool isShowingCalendar = true;
   DateTime selectedDate =
       DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);

--- a/lib/presentation/group_post/provider/group_post_view_model_provider.dart
+++ b/lib/presentation/group_post/provider/group_post_view_model_provider.dart
@@ -9,6 +9,7 @@ class GroupPostViewModelProvider extends StateNotifier<GroupPostViewModel> {
     this._sendEmojiReactionToConfirmPostUsecase,
     this._sendQuickShotReactionToConfirmPostUsecase,
     this._sendCommentReactionToConfirmPostUsecase,
+    this.getAppliedUserListForGroupEntityUsecase,
   ) : super(GroupPostViewModel());
 
   final GetGroupConfirmPostListByDateUsecase
@@ -20,6 +21,9 @@ class GroupPostViewModelProvider extends StateNotifier<GroupPostViewModel> {
       _sendQuickShotReactionToConfirmPostUsecase;
   final SendCommentReactionToConfirmPostUsecase
       _sendCommentReactionToConfirmPostUsecase;
+
+  final GetAppliedUserListForGroupEntityUsecase
+      getAppliedUserListForGroupEntityUsecase;
 
   Future<void> loadConfirmPostEntityListFor({
     required DateTime dateTime,
@@ -96,5 +100,13 @@ class GroupPostViewModelProvider extends StateNotifier<GroupPostViewModel> {
       );
     }
     return Future(() => null);
+  }
+
+  Future<void> loadAppliedUserCount({required GroupEntity entity}) async {
+    state.appliedUserCountForManager =
+        await getAppliedUserListForGroupEntityUsecase.call(entity).then(
+              (result) =>
+                  result.fold((failure) => 0, (uidList) => uidList.length),
+            );
   }
 }

--- a/lib/presentation/group_post/view/group_member_list_view_widget.dart
+++ b/lib/presentation/group_post/view/group_member_list_view_widget.dart
@@ -9,6 +9,7 @@ import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/domain/usecases/usecases.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 
+// ignore: must_be_immutable
 class GroupMemberListBottomSheet extends ConsumerStatefulWidget {
   GroupMemberListBottomSheet(
     this.updateParentViewGroupEntity, {

--- a/lib/presentation/group_post/view/group_member_list_view_widget.dart
+++ b/lib/presentation/group_post/view/group_member_list_view_widget.dart
@@ -92,17 +92,26 @@ class _GroupMemberListBottomSheetState
                     child: Stack(
                       alignment: Alignment.topRight,
                       children: [
-                        IconButton(
+                        TextButton(
                           onPressed: () {
                             setState(() {
                               isManagingMode = !isManagingMode;
                             });
                           },
-                          icon: const Icon(
-                            Icons.manage_accounts_outlined,
-                            color: CustomColors.whWhite,
-                            size: 24.0,
-                          ),
+                          child: isManagingMode
+                              ? const Text(
+                                  '완료',
+                                  style: TextStyle(
+                                    color: CustomColors.whWhite,
+                                    fontSize: 16.0,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                )
+                              : const Icon(
+                                  Icons.manage_accounts_outlined,
+                                  color: CustomColors.whWhite,
+                                  size: 24.0,
+                                ),
                         ),
                         Visibility(
                           visible: appliedUidList.isNotEmpty,

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -147,8 +147,10 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                     !viewModel.isShowingCalendar;
                               });
                             },
-                            icon: const Icon(
-                              Icons.keyboard_arrow_down,
+                            icon: Icon(
+                              viewModel.isShowingCalendar
+                                  ? Icons.keyboard_arrow_up
+                                  : Icons.keyboard_arrow_down,
                               color: CustomColors.whWhite,
                             ),
                           ),
@@ -285,13 +287,20 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                                       target: viewModel
                                                               .confirmPostList[
                                                           cellDate],
-                                                      forWaiting: const Padding(
-                                                        padding:
-                                                            EdgeInsets.all(2.0),
-                                                        child:
-                                                            CircularProgressIndicator(
-                                                          color: CustomColors
-                                                              .whBrightGrey,
+                                                      forWaiting:
+                                                          const SizedBox(
+                                                        width: 20,
+                                                        height: 20,
+                                                        child: Padding(
+                                                          padding:
+                                                              EdgeInsets.all(
+                                                            2.0,
+                                                          ),
+                                                          child:
+                                                              CircularProgressIndicator(
+                                                            color: CustomColors
+                                                                .whBrightGrey,
+                                                          ),
                                                         ),
                                                       ),
                                                       forFail: const Text('-'),

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -10,6 +10,7 @@ import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
+// ignore: must_be_immutable
 class GroupPostView extends ConsumerStatefulWidget {
   GroupPostView({super.key, required this.groupEntity});
 

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -26,7 +26,9 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
     super.didChangeDependencies();
     final viewModel = ref.watch(groupPostViewModelProvider);
     final provider = ref.read(groupPostViewModelProvider.notifier);
-    ref.watch(groupPostViewModelProvider).groupId = widget.groupEntity.groupId;
+    viewModel.groupId = widget.groupEntity.groupId;
+
+    unawaited(provider.loadAppliedUserCount(entity: widget.groupEntity));
 
     unawaited(
       provider
@@ -58,69 +60,34 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
       children: [
         Scaffold(
           backgroundColor: CustomColors.whBlack,
-          appBar: AppBar(
-            backgroundColor: CustomColors.whBlack,
-            scrolledUnderElevation: 0,
-            title: Text(
-              widget.groupEntity.groupName,
-              style: const TextStyle(
-                color: CustomColors.whWhite,
-                fontSize: 20.0,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            leading: IconButton(
-              onPressed: () {
-                Navigator.pop(context);
-              },
-              icon: const Icon(
-                Icons.chevron_left,
-                color: CustomColors.whWhite,
-                size: 36.0,
-              ),
-            ),
-            centerTitle: true,
-            automaticallyImplyLeading: false,
-            actions: [
-              // IconButton(
-              //   onPressed: () async {},
-              //   icon: const Icon(
-              //     Icons.campaign_outlined,
-              //     color: CustomColors.whWhite,
-              //     size: 30,
-              //   ),
-              // ),
-              // IconButton(
-              //   onPressed: () {},
-              //   icon: const Icon(
-              //     Icons.error_outline,
-              //     color: CustomColors.whWhite,
-              //     size: 30,
-              //   ),
-              // ),
-              Container(
-                margin: const EdgeInsets.only(right: 12.0),
-                child: IconButton(
-                  onPressed: () async {
-                    showModalBottomSheet(
-                      isScrollControlled: true,
-                      context: context,
-                      builder: (context) {
-                        return GroupMemberListBottomSheet(
-                          updateGroupEntity,
-                          groupEntity: widget.groupEntity,
-                        );
-                      },
-                    );
-                  },
-                  icon: const Icon(
-                    Icons.people_outline,
-                    color: CustomColors.whWhite,
-                    size: 30,
-                  ),
-                ),
-              ),
-            ],
+          appBar: WehavitAppBar(
+            title: widget.groupEntity.groupName,
+            leadingIcon: Icons.chevron_left,
+            leadingTitle: '',
+            leadingAction: () {
+              Navigator.pop(context);
+            },
+            trailingTitle: '',
+            trailingIcon: Icons.people_outline,
+            trailingAction: () async {
+              showModalBottomSheet(
+                isScrollControlled: true,
+                context: context,
+                builder: (context) {
+                  return GroupMemberListBottomSheet(
+                    updateGroupEntity,
+                    groupEntity: widget.groupEntity,
+                  );
+                },
+              ).whenComplete(() {
+                provider
+                    .loadAppliedUserCount(entity: widget.groupEntity)
+                    .whenComplete(() {
+                  setState(() {});
+                });
+              });
+            },
+            trailingIconBadgeCount: viewModel.appliedUserCountForManager,
           ),
           body: SafeArea(
             minimum: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -133,7 +133,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                             color: CustomColors.whWhite,
                           ),
                           label: const Text(
-                            '코멘트',
+                            '메시지',
                             style: TextStyle(
                               color: CustomColors.whWhite,
                               fontSize: 16.0,
@@ -293,7 +293,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                             color: CustomColors.whWhite,
                           ),
                           label: const Text(
-                            '코멘트',
+                            '메시지',
                             style: TextStyle(
                               color: CustomColors.whWhite,
                               fontSize: 16.0,
@@ -775,13 +775,22 @@ class _ConfirmPostContentWidgetState extends State<ConfirmPostContentWidget> {
                                   1)
                                 Padding(
                                   padding: const EdgeInsets.all(8.0),
-                                  child: Text(
-                                    // ignore: lines_longer_than_80_chars
-                                    '+${widget.confirmPostEntity.imageUrlList!.length - 1}',
-                                    style: const TextStyle(
-                                      color: CustomColors.whWhite,
-                                      fontSize: 16.0,
-                                      fontWeight: FontWeight.w700,
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 8.0,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(12.0),
+                                      color: CustomColors.whBlack,
+                                    ),
+                                    child: Text(
+                                      // ignore: lines_longer_than_80_chars
+                                      '+${widget.confirmPostEntity.imageUrlList!.length - 1}',
+                                      style: const TextStyle(
+                                        color: CustomColors.whWhite,
+                                        fontSize: 12.0,
+                                        fontWeight: FontWeight.w700,
+                                      ),
                                     ),
                                   ),
                                 ),

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -355,6 +355,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                               );
                               return;
                             }
+
                             await reactionCameraModelProvider
                                 .setFocusingModeTo(false);
 
@@ -372,7 +373,6 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                                 imageFilePath: imageFilePath,
                               );
                             }
-
                             // setState(() {});
                           },
                           onPointerMove: (event) async {
@@ -387,6 +387,8 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
 
                             reactionCameraModelProvider
                                 .updatePanPosition(panningPosition);
+
+                            if (reactionCameraModel.isPosInCapturingArea) {}
                           },
                           child: Container(
                             padding:

--- a/lib/presentation/main/view/main_view.dart
+++ b/lib/presentation/main/view/main_view.dart
@@ -48,9 +48,10 @@ class _MainViewState extends ConsumerState<MainView>
                   controller: tabController,
                   physics: const NeverScrollableScrollPhysics(),
                   children: [
-                    ResolutionListView(0, tabController),
-                    GroupView(1, tabController),
-                    FriendListView(2, tabController),
+                    const ResolutionListView(),
+                    const GroupView(),
+                    const FriendListView(),
+                    // 페이지 이동 시 데이터 setState 함수 수행을 위해 붙여줌
                     MyPageView(3, tabController),
                   ],
                 ),

--- a/lib/presentation/main/view/main_view.dart
+++ b/lib/presentation/main/view/main_view.dart
@@ -47,11 +47,11 @@ class _MainViewState extends ConsumerState<MainView>
                 TabBarView(
                   controller: tabController,
                   physics: const NeverScrollableScrollPhysics(),
-                  children: const [
-                    ResolutionListView(),
-                    GroupView(),
-                    FriendListView(),
-                    MyPageView(),
+                  children: [
+                    ResolutionListView(0, tabController),
+                    GroupView(1, tabController),
+                    FriendListView(2, tabController),
+                    MyPageView(3, tabController),
                   ],
                 ),
                 SizedBox(

--- a/lib/presentation/my_page/provider/add_resolution_provider.dart
+++ b/lib/presentation/my_page/provider/add_resolution_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:wehavit/common/utils/custom_types.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/domain/usecases/usecases.dart';
@@ -29,10 +28,6 @@ class AddResolutionNotifier extends StateNotifier<ResolutionEntity> {
 
   void changeActionStatement(String newStatement) {
     state = state.copyWith(actionStatement: newStatement);
-  }
-
-  void changeOathStatement(String newStatement) {
-    // state = state.copyWith(oathStatement: newStatement);
   }
 
   // EitherFuture<bool> uploadResolutionEntity() {

--- a/lib/presentation/my_page/provider/add_resolution_provider.dart
+++ b/lib/presentation/my_page/provider/add_resolution_provider.dart
@@ -1,14 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/domain/usecases/usecases.dart';
 
 class AddResolutionNotifier extends StateNotifier<ResolutionEntity> {
-  AddResolutionNotifier(Ref ref) : super(const ResolutionEntity()) {
-    _uploadResolutionUsecase = ref.watch(uploadResolutionUsecaseProvider);
-  }
-
-  late final UploadResolutionUseCase _uploadResolutionUsecase;
+  AddResolutionNotifier(Ref ref) : super(const ResolutionEntity());
 
   void changeFanList(List<UserDataEntity> newFanList) {
     state = state.copyWith(shareFriendEntityList: newFanList);

--- a/lib/presentation/my_page/view/add_resolution_screen.dart
+++ b/lib/presentation/my_page/view/add_resolution_screen.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:multiselect/multiselect.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
@@ -10,13 +9,10 @@ import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
 class MyPageView extends ConsumerStatefulWidget {
-  const MyPageView({super.key});
+  const MyPageView(this.index, this.tabController, {super.key});
 
-  static MyPageView builder(
-    BuildContext context,
-    GoRouterState state,
-  ) =>
-      const MyPageView();
+  final int index;
+  final TabController tabController;
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _MyPageScreenState();
@@ -25,34 +21,56 @@ class MyPageView extends ConsumerStatefulWidget {
 class _MyPageScreenState extends ConsumerState<MyPageView>
     with AutomaticKeepAliveClientMixin<MyPageView> {
   @override
+  bool get wantKeepAlive => true;
+
+  @override
   void initState() {
     super.initState();
+    widget.tabController.addListener(_handleTabChange);
+
     unawaited(ref.read(myPageViewModelProvider.notifier).loadData());
+  }
+
+  @override
+  void dispose() {
+    // 리스너 제거
+    widget.tabController.removeListener(_handleTabChange);
+    super.dispose();
+  }
+
+  void _handleTabChange() {
+    if (widget.tabController.index == widget.index) {
+      // 탭바에서 화면이 MainView로 전환되면 setState를 호출
+      setState(() {});
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     super.build(context);
     final viewModel = ref.watch(myPageViewModelProvider);
-    // final provider = ref.read(myPageViewModelProvider.notifier);
+    final provider = ref.watch(myPageViewModelProvider.notifier);
 
     return Scaffold(
       backgroundColor: CustomColors.whDarkBlack,
       appBar: WehavitAppBar(
-          title: '내 정보',
-          trailingTitle: '로그아웃',
-          trailingAction: () async {
-            await ref.read(logOutUseCaseProvider).call();
-            if (mounted) {
-              // ignore: use_build_context_synchronously
-              Navigator.pushReplacementNamed(context, '/entrance');
-            }
-          }),
+        title: '내 정보',
+        trailingTitle: '로그아웃',
+        trailingAction: () async {
+          await ref.read(logOutUseCaseProvider).call();
+          if (mounted) {
+            // ignore: use_build_context_synchronously
+            Navigator.pushReplacementNamed(context, '/entrance');
+          }
+        },
+      ),
       body: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16.0),
         child: RefreshIndicator(
           onRefresh: () async {
-            ref.read(myPageViewModelProvider.notifier).loadData();
+            provider.loadData().whenComplete(() {
+              setState(() {});
+            });
           },
           child: ListView(
             padding: const EdgeInsets.only(bottom: 64.0),
@@ -97,7 +115,4 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
       ),
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:wehavit/common/common.dart';
+import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
@@ -37,7 +38,16 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
 
     return Scaffold(
       backgroundColor: CustomColors.whDarkBlack,
-      appBar: WehavitAppBar(title: '내 정보'),
+      appBar: WehavitAppBar(
+          title: '내 정보',
+          trailingTitle: '로그아웃',
+          trailingAction: () async {
+            await ref.read(logOutUseCaseProvider).call();
+            if (mounted) {
+              // ignore: use_build_context_synchronously
+              Navigator.pushReplacementNamed(context, '/entrance');
+            }
+          }),
       body: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16.0),
         child: RefreshIndicator(

--- a/lib/presentation/my_page/view/my_page_view_widget.dart
+++ b/lib/presentation/my_page/view/my_page_view_widget.dart
@@ -211,10 +211,16 @@ class MySimpleStatisticsWidget extends StatelessWidget {
         return IntrinsicHeight(
           child: Row(
             children: [
-              const VerticalDivider(
-                thickness: 4,
-                width: 2,
-                color: CustomColors.whYellow,
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(2.0),
+                ),
+                clipBehavior: Clip.hardEdge,
+                child: const VerticalDivider(
+                  thickness: 4,
+                  width: 4,
+                  color: CustomColors.whYellow,
+                ),
               ),
               const SizedBox(width: 12),
               Column(

--- a/lib/presentation/reaction/widget/reaction_animation_widget.dart
+++ b/lib/presentation/reaction/widget/reaction_animation_widget.dart
@@ -137,7 +137,6 @@ class _ReactionAnimationWidgetState
     );
   }
 
-  // TODO: 이 함수를 화면이 켜졌을 때 호출하도록 로직 구현하기
   Future<void> showUnreadReactions() async {
     final fetchResult =
         await _reactionAnimationWidgetManager.getUnreadReactionGroupList();

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -27,6 +27,7 @@ class ResolutionListViewModelProvider
 
     if (resolutionList == null) {
       state.resolutionModelList = null;
+
       return;
     }
 

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -19,7 +19,6 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
   @override
   void initState() {
     super.initState();
-
     unawaited(
       ref
           .read(resolutionListViewModelProvider.notifier)
@@ -218,7 +217,7 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
             children: [
               Expanded(
                 child: WideColoredButton(
-                  buttonTitle: '반성글 작성하기',
+                  buttonTitle: '반성 남기기',
                   foregroundColor: Colors.red,
                   onPressed: () async {
                     final result = await Navigator.push(

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -8,7 +8,10 @@ import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
 class ResolutionListView extends ConsumerStatefulWidget {
-  const ResolutionListView({super.key});
+  const ResolutionListView(this.index, this.tabController, {super.key});
+
+  final int index;
+  final TabController tabController;
 
   @override
   ConsumerState<ResolutionListView> createState() => _ResolutionListViewState();
@@ -95,16 +98,19 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                               index: index,
                             );
                           },
-                        ).whenComplete(() async {
-                          await provider
-                              .loadResolutionModelList()
-                              .whenComplete(() {
-                            setState(() {
+                        ).then((returnValue) async {
+                          print("DEBUG: $returnValue");
+                          if (returnValue == true) {
+                            await provider
+                                .loadResolutionModelList()
+                                .whenComplete(() {
                               ref
                                   .watch(resolutionListViewModelProvider)
                                   .isLoadingView = false;
                             });
-                          });
+                          } else {
+                            //
+                          }
                         });
                       },
                     ),
@@ -117,7 +123,20 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                             fullscreenDialog: true,
                             builder: (context) => const AddResolutionView(),
                           ),
-                        );
+                        ).whenComplete(() async {
+                          await ref
+                              .watch(myPageViewModelProvider.notifier)
+                              .getMyResolutionListUsecase();
+                          await provider
+                              .loadResolutionModelList()
+                              .whenComplete(() {
+                            setState(() {
+                              ref
+                                  .watch(resolutionListViewModelProvider)
+                                  .isLoadingView = false;
+                            });
+                          });
+                        });
                       },
                     ),
                   ).toList(),
@@ -158,13 +177,25 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
           Column(
             children: [
               Text(
-                viewModel.resolutionModelList![index].entity.goalStatement ??
+                viewModel.resolutionModelList![index].entity.resolutionName ??
                     '',
+                textAlign: TextAlign.center,
                 style: TextStyle(
                   color: PointColors.colorList[
                       viewModel.resolutionModelList![index].entity.colorIndex ??
                           0],
                   fontSize: 18.0,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4.0),
+              Text(
+                viewModel.resolutionModelList![index].entity.goalStatement ??
+                    '',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: CustomColors.whWhite,
+                  fontSize: 16.0,
                   fontWeight: FontWeight.w600,
                 ),
               ),
@@ -197,6 +228,9 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
                 ),
               );
               if (result == true) {
+                // ignore: use_build_context_synchronously
+                Navigator.of(context).pop(true);
+
                 showToastMessage(
                   // ignore: use_build_context_synchronously
                   context,
@@ -260,7 +294,7 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
                         model: viewModel.resolutionModelList![index],
                       )
                           .whenComplete(() {
-                        Navigator.pop(context);
+                        Navigator.pop(context, true);
                         // ignore: use_build_context_synchronously
                         showToastMessage(
                           context,
@@ -285,7 +319,7 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
             backgroundColor: Colors.transparent,
             foregroundColor: CustomColors.whPlaceholderGrey,
             onPressed: () {
-              Navigator.pop(context);
+              Navigator.pop(context, false);
             },
           ),
         ],

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -8,10 +8,7 @@ import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
 class ResolutionListView extends ConsumerStatefulWidget {
-  const ResolutionListView(this.index, this.tabController, {super.key});
-
-  final int index;
-  final TabController tabController;
+  const ResolutionListView({super.key});
 
   @override
   ConsumerState<ResolutionListView> createState() => _ResolutionListViewState();
@@ -22,6 +19,7 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
   @override
   void initState() {
     super.initState();
+    print("DEBUG init");
     unawaited(
       ref
           .read(resolutionListViewModelProvider.notifier)
@@ -99,7 +97,6 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                             );
                           },
                         ).then((returnValue) async {
-                          print("DEBUG: $returnValue");
                           if (returnValue == true) {
                             await provider
                                 .loadResolutionModelList()

--- a/lib/presentation/write_post/view/writing_confirm_post_view.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view.dart
@@ -215,7 +215,6 @@ class _WritingConfirmPostViewState
                           viewModel.isUploading = false;
 
                           Navigator.of(context).pop(true);
-                          Navigator.of(context).pop();
                         });
                       },
                       style: TextButton.styleFrom(


### PR DESCRIPTION
# 설명
기능 마무리를 위해 개선이 필요한 UI, 로직, UX를 정리하고 적용

Fixes #
Closes #257 
Resolves #

# 작업 내역

### 회원가입 뷰
- 비밀번호 확인의 일치하지 않음 문구를 입력하지 않았을 때는 띄우지 않기
- ID, 비밀번호 등록 시점에도 사용자 정보 입력 뷰처럼 progress 띄워주기
- 회원가입 페이지에 키보드가 스크롤 될 수 있도록 수정
- 사용자 ID에 넣을 수 있는 특수문자에 underscore 추가하기

### 그룹만들기
- 그룹만들기 완료 뷰 UI 개선이 필요함
- 그룹만들기도 목표생성처럼 단계별로 진행되는 UI로 개선하기
- 생성하고 그룹 list로 돌아오면 목록에 추가하기 (update 해주기)

### 그룹가입
- 그룹명을 검색하면 4-5개 정도 보여주자 (친구 ID 검색처럼)
- 그룹에 참여하기 뷰에서 취소 대신 닫기 로 워딩 변경

### 그룹포스트
- 그룹 멤버 관리 Icon ... 진입시 완료 로 바꿔주기
- 그룹에 초대를 요청한 사람이 있으면 그룹포스트에서도 뱃지로 알려주기
- 사진에 +1, +2를 흰 배경에서도 좀 더 잘 보이게 개선하기
- "코멘트" → "메시지"로 워딩 수정하기

### 목표리스트
- 목표 Cell Widget 에서 2줄 넘어가는 텍스트는 ellipsis 띄우기
- 요일 동그라미 ... 글자를 가운데로 옮기기
- 목표 추가 후 돌아오면 resolution List, My Page에 목록 업데이트해주기
- 인증 남기기 bottom sheet에서 제목, goal 둘 다 보여주기

### 친구목록
- 수락하면 상대에게도 친구 추가해주기
- 친구이름 / 친구handle 같이 표기하도록 수정하기

## 작업 결과물
|회원가입 뷰|그룹만들기 뷰|그룹가입 뷰|그룹포스트 뷰|
|---|---|---|---|
|![ScreenRecording_06-12-2024 12-57-06_1](https://github.com/cau-bootcamp/wehavit/assets/39216546/aa65ed43-1b0c-4af8-82ad-9a2fc2eabfdb)|![ScreenRecording_06-12-2024 12-57-56_1](https://github.com/cau-bootcamp/wehavit/assets/39216546/156fd394-d0de-4776-a71d-8ac23163432d)|![ScreenRecording_06-12-2024 12-58-30_1](https://github.com/cau-bootcamp/wehavit/assets/39216546/4a801df0-eda0-4102-b930-373e02aec87c)|![RPReplay_Final1718165683](https://github.com/cau-bootcamp/wehavit/assets/39216546/4830db10-2d9c-4ef3-9c5b-2a76bf2015da)|

|목표리스트|친구목록|
|---|---|
|![IMG_0297](https://github.com/cau-bootcamp/wehavit/assets/39216546/f112cc74-004f-47c8-82fd-8fc0ddd7b564)|![IMG_0298](https://github.com/cau-bootcamp/wehavit/assets/39216546/76b8e746-06dc-4b6e-b933-28b0eb551dca)|

## 참고 사항(선택)
목표 추가시 MyPage에도 해당 목표를 추가해주기 위해서 MyPage 탭 버튼을 누르면 뷰 자체가 setState 를 호출하도록 되어있음. (데이터 로드 로직은 작동하지 않음) FutureBuilder로 인해, 깜빡이는 것처럼 보이는 문제가 있음. 이후에 개선 적용하기

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
