### PR TITLE
[#257] fix: 그룹포스트뷰 로드 시점에 바로 참가신청인원 배지 보여주도록 수정

### DIFF
--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -28,7 +28,15 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
     final provider = ref.read(groupPostViewModelProvider.notifier);
     viewModel.groupId = widget.groupEntity.groupId;
 
-    unawaited(provider.loadAppliedUserCount(entity: widget.groupEntity));
+    unawaited(
+      provider
+          .loadAppliedUserCount(entity: widget.groupEntity)
+          .whenComplete(() {
+        setState(() {
+          print("load");
+        });
+      }),
+    );
 
     unawaited(
       provider
@@ -79,12 +87,9 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                     groupEntity: widget.groupEntity,
                   );
                 },
-              ).whenComplete(() {
-                provider
-                    .loadAppliedUserCount(entity: widget.groupEntity)
-                    .whenComplete(() {
-                  setState(() {});
-                });
+              ).whenComplete(() async {
+                await provider.loadAppliedUserCount(entity: widget.groupEntity);
+                setState(() {});
               });
             },
             trailingIconBadgeCount: viewModel.appliedUserCountForManager,


### PR DESCRIPTION
# 설명
그룹포스트뷰 로드 시점에 바로 참가신청인원 배지 보여주도록 수정

Fixes #257
Closes #
Resolves #

# 작업 내역
- #258 PR에서 놓친 커밋 추가

## 참고 사항(선택)
실수했어요... 녹화만 따고 커밋 push를 안했어요...

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
