### PR TITLE
[#277] feat: 애플 로그인 시 이름 바로 받아와 회원가입 정보 입력란에 넣어주도록 구현

### DIFF
--- a/lib/data/datasources/auth_social_datasource.dart
+++ b/lib/data/datasources/auth_social_datasource.dart
@@ -6,7 +6,7 @@ abstract class AuthSocialDataSource {
 
   Future<void> googleLogOut();
 
-  EitherFuture<AuthResult> appleLogInAndSignUp();
+  EitherFuture<(AuthResult, String?)> appleLogInAndSignUp();
 
   Future<void> appleLogOut();
 }

--- a/lib/data/datasources/auth_social_datasource_impl.dart
+++ b/lib/data/datasources/auth_social_datasource_impl.dart
@@ -52,7 +52,7 @@ class AuthSocialDataSourceImpl implements AuthSocialDataSource {
   }
 
   @override
-  EitherFuture<AuthResult> appleLogInAndSignUp() async {
+  EitherFuture<(AuthResult, String?)> appleLogInAndSignUp() async {
     try {
       final appleCredential = await SignInWithApple.getAppleIDCredential(
         scopes: [
@@ -69,7 +69,7 @@ class AuthSocialDataSourceImpl implements AuthSocialDataSource {
 
       await FirebaseAuth.instance.signInWithCredential(oauthCredential);
 
-      return right(AuthResult.success);
+      return right((AuthResult.success, appleCredential.givenName));
     } on FirebaseAuthException catch (exception) {
       return left(Failure(exception.code));
     } on Exception catch (exception) {

--- a/lib/data/repositories/auth_repository_impl.dart
+++ b/lib/data/repositories/auth_repository_impl.dart
@@ -18,26 +18,32 @@ class AuthRepositoryImpl implements AuthRepository {
   final AuthSocialDataSource _authSocialDataSource;
 
   @override
-  EitherFuture<AuthResult> logIn({
+  EitherFuture<(AuthResult, String?)> logIn({
     required LogInType type,
     String? email,
     String? password,
   }) async {
-    EitherFuture<AuthResult> futureResult;
+    EitherFuture<(AuthResult, String?)> futureResult;
 
     switch (type) {
       case LogInType.wehavit:
         try {
-          futureResult = _authDataSource.logInWithEmailAndPassword(
-            email: email,
-            password: password,
+          futureResult = Future(
+            () async => (await _authDataSource.logInWithEmailAndPassword(
+              email: email,
+              password: password,
+            ))
+                .map((authResult) => (authResult, null)),
           );
         } catch (e) {
           return left(Failure(AuthResult.failure.name));
         }
       case LogInType.google:
         try {
-          futureResult = _authSocialDataSource.googleLogInAndSignUp();
+          futureResult = Future(
+            () async => (await _authSocialDataSource.googleLogInAndSignUp())
+                .map((authResult) => (authResult, null)),
+          );
         } catch (e) {
           return left(Failure(AuthResult.failure.name));
         }

--- a/lib/domain/repositories/auth_repository.dart
+++ b/lib/domain/repositories/auth_repository.dart
@@ -3,7 +3,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 
 abstract class AuthRepository {
-  EitherFuture<AuthResult> logIn({
+  EitherFuture<(AuthResult, String?)> logIn({
     required LogInType type,
     String? email,
     String? password,

--- a/lib/domain/usecases/log_in_with_apple_usecase.dart
+++ b/lib/domain/usecases/log_in_with_apple_usecase.dart
@@ -7,7 +7,7 @@ class LogInWithAppleUsecase {
 
   final AuthRepository _authRepository;
 
-  EitherFuture<AuthResult> call() async {
+  EitherFuture<(AuthResult, String?)> call() async {
     return _authRepository.logIn(type: LogInType.apple);
   }
 }

--- a/lib/domain/usecases/log_in_with_email_and_password_usecase.dart
+++ b/lib/domain/usecases/log_in_with_email_and_password_usecase.dart
@@ -7,7 +7,7 @@ class LogInWithEmailUsecase {
 
   final AuthRepository _authRepository;
 
-  EitherFuture<AuthResult> call(String email, String password) {
+  EitherFuture<(AuthResult, String?)> call(String email, String password) {
     return _authRepository.logIn(
       type: LogInType.wehavit,
       email: email,

--- a/lib/domain/usecases/log_in_with_google_usecase.dart
+++ b/lib/domain/usecases/log_in_with_google_usecase.dart
@@ -7,7 +7,7 @@ class LogInWithGoogleUsecase {
 
   final AuthRepository _authRepository;
 
-  EitherFuture<AuthResult> call() async {
+  EitherFuture<(AuthResult, String?)> call() async {
     return _authRepository.logIn(type: LogInType.google);
   }
 }

--- a/lib/presentation/entrance/provider/auth_notifier.dart
+++ b/lib/presentation/entrance/provider/auth_notifier.dart
@@ -18,7 +18,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   final GoogleLogOutUseCase _googleLogOut;
   final LogOutUsecase _logOut;
 
-  EitherFuture<AuthResult> googleLogIn() async {
+  EitherFuture<(AuthResult, String?)> googleLogIn() async {
     return _googleLogInUseCase();
   }
 
@@ -50,10 +50,10 @@ class AuthNotifier extends StateNotifier<AuthState> {
         authResult: AuthResult.failure,
         authType: AuthType.emailAndPassword,
       ),
-      (authResult) {
+      (result) {
         return state.copyWith(
           isLoading: false,
-          authResult: authResult,
+          authResult: result.$1,
           authType: AuthType.emailAndPassword,
         );
       },

--- a/lib/presentation/entrance/provider/log_in_view_model_provider.dart
+++ b/lib/presentation/entrance/provider/log_in_view_model_provider.dart
@@ -28,11 +28,11 @@ class LogInViewModelProvider extends StateNotifier<LogInViewModel> {
     );
   }
 
-  EitherFuture<AuthResult> logInWithApple() async {
+  EitherFuture<(AuthResult, String?)> logInWithApple() async {
     return _logInWithAppleUsecase();
   }
 
-  EitherFuture<AuthResult> logInWithGoogle() {
+  EitherFuture<(AuthResult, String?)> logInWithGoogle() {
     return _logInWithGoogleUsecase();
   }
 


### PR DESCRIPTION
# 설명
애플 로그인 시 이름 바로 받아와 회원가입 정보 입력란에 넣어주도록 기능 구현하기

Fixes #
Closes #277 
Resolves #

# 작업 내역
- 애플 로그인으로 데이터 받아오기
- 받아온 데이터 뷰에 넘겨주기
- 넘겨준 데이터 뷰에 정상적으로 띄워서 보여주기


## 참고 사항(선택)
Sign in with Apple 로 회원가입을 하는 경우에는, 아래와 같은 방식으로 계정 정보를 가져오게 된다. 
```
final appleCredential = await SignInWithApple.getAppleIDCredential(
  scopes: [
    AppleIDAuthorizationScopes.email,
    AppleIDAuthorizationScopes.fullName,
  ],
);
```

근데, 매우매우 유의할 점!이 있는데, 여기에서 개인정보 보호 정책상 appleCredential 을 통해서 사용자 ID 외에 이메일, 이름 등의 다른 정보들은 **"서비스에 처음으로 계정을 접속시킬 때"**에만 불러올 수 있다. 즉, 이름이나 이메일 같은 데이터를 애플 로그인 시에 가져오고 싶다면, 따로 서비스나 캐시에 저장해두고 사용자ID 값을 key로 하여 해당 데이터를 관리해야한다. 이외의 시점에는 appleCredential의 다른 데이터들은 모두 null이 들어있고 사용자ID만 딱 들어있게된다. 

요 부분은 나중에도 주의가 필요한 부분임!!


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
