### PR TITLE
[#278] feat: 계정 삭제 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ migrate_working_dir/
 
 # dotenv environment variables file
 .env*
+*.env
 
 # Avoid committing generated Javascript files:
 *.dart.js

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -505,7 +505,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bootcamp.wehavit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -698,7 +698,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bootcamp.wehavit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -731,7 +731,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bootcamp.wehavit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/lib/data/datasources/auth_social_datasource.dart
+++ b/lib/data/datasources/auth_social_datasource.dart
@@ -9,4 +9,6 @@ abstract class AuthSocialDataSource {
   EitherFuture<(AuthResult, String?)> appleLogInAndSignUp();
 
   Future<void> appleLogOut();
+
+  EitherFuture<void> revokeSignInWithApple();
 }

--- a/lib/data/datasources/auth_social_datasource_impl.dart
+++ b/lib/data/datasources/auth_social_datasource_impl.dart
@@ -61,6 +61,9 @@ class AuthSocialDataSourceImpl implements AuthSocialDataSource {
         ],
       );
 
+      print(appleCredential.identityToken);
+      print(appleCredential.authorizationCode);
+
       // Create an `OAuthCredential` from the credential returned by Apple.
       final oauthCredential = OAuthProvider('apple.com').credential(
         idToken: appleCredential.identityToken,

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -2075,8 +2075,6 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
         return left(const Failure('profile-image-upload-fail'));
       }
 
-      print(uid);
-
       final isDocExist = await firestore
           .collection(
             FirebaseCollectionName.users,

--- a/lib/data/repositories/auth_repository_impl.dart
+++ b/lib/data/repositories/auth_repository_impl.dart
@@ -113,4 +113,9 @@ class AuthRepositoryImpl implements AuthRepository {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     prefs.setBool('isLoggedIn', false);
   }
+
+  @override
+  EitherFuture<void> revokeSignInWithApple() {
+    return _authSocialDataSource.revokeSignInWithApple();
+  }
 }

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -405,3 +405,9 @@ final getFriendConfirmPostListByDateUsecaseProvider =
   final confirmPostRepository = ref.watch(confirmPostRepositoryProvider);
   return GetFriendConfirmPostListByDateUsecase(confirmPostRepository);
 });
+
+final revokeAppleSignInUsecaseProvider =
+    Provider<RevokeAppleSignInUsecase>((ref) {
+  final authRepository = ref.watch(authRepositoryProvider);
+  return RevokeAppleSignInUsecase(authRepository);
+});

--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -85,10 +85,11 @@ final myPageViewModelProvider =
   final getMyResolutionListUsecase =
       ref.watch(getMyResolutionListUsecaseProvider);
   final getMyUserDataUsecase = ref.watch(getMyUserDataUsecaseProvider);
-
+  final revokeAppleSignInUsecase = ref.watch(revokeAppleSignInUsecaseProvider);
   return MyPageViewModelProvider(
     getMyResolutionListUsecase,
     getMyUserDataUsecase,
+    revokeAppleSignInUsecase,
   );
 });
 

--- a/lib/domain/repositories/auth_repository.dart
+++ b/lib/domain/repositories/auth_repository.dart
@@ -17,4 +17,6 @@ abstract class AuthRepository {
 
   Future<void> logOut();
   Stream<User?> authStateChanges();
+
+  EitherFuture<void> revokeSignInWithApple();
 }

--- a/lib/domain/usecases/revoke_apple_sign_in_usecase.dart
+++ b/lib/domain/usecases/revoke_apple_sign_in_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/domain/repositories/repositories.dart';
+
+class RevokeAppleSignInUsecase {
+  RevokeAppleSignInUsecase(this._authRepository);
+
+  final AuthRepository _authRepository;
+
+  EitherFuture<void> call() {
+    return _authRepository.revokeSignInWithApple();
+  }
+}

--- a/lib/domain/usecases/usecases.dart
+++ b/lib/domain/usecases/usecases.dart
@@ -41,6 +41,7 @@ export 'reject_applying_for_friend_usecase.dart';
 export 'reject_applying_for_joining_group_usecase.dart';
 export 'remove_friend_usecase.dart';
 export 'remove_user_data_usecase.dart';
+export 'revoke_apple_sign_in_usecase.dart';
 export 'search_group_entity_list_by_group_name_usecase.dart';
 export 'search_user_data_list_by_handle_usecase.dart';
 export 'search_user_data_list_by_nickname_usecase.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/utils/shared_prefs.dart';
 
@@ -10,7 +9,6 @@ import 'main/app.dart';
 
 Future<void> main() async {
   // ignore: avoid_redundant_argument_values
-  await dotenv.load();
   WidgetsFlutterBinding.ensureInitialized();
   await Future.wait([
     SharedPrefs.init(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/utils/shared_prefs.dart';
 
@@ -8,6 +9,8 @@ import 'firebase_options.dart';
 import 'main/app.dart';
 
 Future<void> main() async {
+  // ignore: avoid_redundant_argument_values
+  await dotenv.load();
   WidgetsFlutterBinding.ensureInitialized();
   await Future.wait([
     SharedPrefs.init(),

--- a/lib/presentation/entrance/view/edit_user_detail_view.dart
+++ b/lib/presentation/entrance/view/edit_user_detail_view.dart
@@ -45,6 +45,7 @@ class _EditUserDetailViewState extends ConsumerState<EditUserDetailView> {
         .then((result) => result.fold((failure) => null, (id) => id));
 
     viewmodel.uid = widget.uid ?? (userId ?? '');
+    viewmodel.name = widget.name ?? '';
 
     if (widget.isModifying) {
       loadDataFromArguments().whenComplete(() {
@@ -56,7 +57,6 @@ class _EditUserDetailViewState extends ConsumerState<EditUserDetailView> {
   Future<void> loadDataFromArguments() async {
     final viewmodel = ref.watch(editUserDataViewModelProvider);
 
-    viewmodel.name = widget.name ?? '';
     viewmodel.handle = widget.handle ?? '';
     viewmodel.aboutMe = widget.aboutMe ?? '';
 

--- a/lib/presentation/my_page/provider/my_page_view_model_provider.dart
+++ b/lib/presentation/my_page/provider/my_page_view_model_provider.dart
@@ -1,3 +1,5 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/domain/usecases/usecases.dart';
 import 'package:wehavit/presentation/my_page/model/model.dart';
@@ -27,11 +29,57 @@ class MyPageViewModelProvider extends StateNotifier<MyPageViewModel> {
   }
 
   Future<bool> revokeAppleSignIn() async {
-    return await revokeAppleSignInUsecase.call().then(
-          (result) => result.fold(
-            (failure) => false,
-            (success) => true,
-          ),
-        );
+    return await revokeAppleSignInUsecase().then(
+      (result) => result.fold(
+        (failure) => false,
+        (success) => true,
+      ),
+    );
+  }
+
+  Future<bool> deleteAccount(BuildContext context) async {
+    final isAppleLogin = FirebaseAuth.instance.currentUser?.providerData.any(
+      (info) => info.providerId == 'apple.com',
+    );
+
+    bool isRevokable;
+
+    try {
+      if (isAppleLogin == true) {
+        isRevokable = await revokeAppleSignIn();
+      } else {
+        isRevokable = true;
+      }
+
+      // 계정을 삭제할 준비가 완료됨
+      if (isRevokable == true) {
+        User? user = FirebaseAuth.instance.currentUser;
+        if (user != null) {
+          await user.delete();
+
+          // ignore: avoid_print
+          print('사용자 계정이 성공적으로 삭제되었습니다.');
+        }
+
+        // // 창 닫기
+        if (mounted) {
+          Navigator.pushReplacementNamed(
+            // ignore: use_build_context_synchronously
+            context,
+            '/entrance',
+          );
+        }
+
+        return true;
+      }
+    } on Exception catch (e) {
+      print("DEBUG : 사용자 계정 삭제 중 exception : ${e.toString()}");
+      return false;
+    }
+    if (mounted) {
+      // ignore: use_build_context_synchronously
+      Navigator.pop(context, false);
+    }
+    return false;
   }
 }

--- a/lib/presentation/my_page/provider/my_page_view_model_provider.dart
+++ b/lib/presentation/my_page/provider/my_page_view_model_provider.dart
@@ -6,10 +6,12 @@ class MyPageViewModelProvider extends StateNotifier<MyPageViewModel> {
   MyPageViewModelProvider(
     this.getMyResolutionListUsecase,
     this.getMyUserDataUsecase,
+    this.revokeAppleSignInUsecase,
   ) : super(MyPageViewModel());
 
   final GetMyResolutionListUsecase getMyResolutionListUsecase;
   final GetMyUserDataUsecase getMyUserDataUsecase;
+  final RevokeAppleSignInUsecase revokeAppleSignInUsecase;
 
   Future<void> loadData() async {
     getResolutionList();
@@ -22,5 +24,14 @@ class MyPageViewModelProvider extends StateNotifier<MyPageViewModel> {
 
   Future<void> getMyUserData() async {
     state.futureMyUserDataEntity = getMyUserDataUsecase();
+  }
+
+  Future<bool> revokeAppleSignIn() async {
+    return await revokeAppleSignInUsecase.call().then(
+          (result) => result.fold(
+            (failure) => false,
+            (success) => true,
+          ),
+        );
   }
 }

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -253,7 +253,7 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                             isDefaultAction: true,
                             child: const Text('취소'),
                             onPressed: () {
-                              Navigator.pop(context, false);
+                              Navigator.pop(context);
                             },
                           ),
                           CupertinoDialogAction(

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -46,110 +45,123 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
     }
   }
 
+  Future<void> deleteAccount() async {
+    ref.watch(myPageViewModelProvider.notifier).deleteAccount(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
     final viewModel = ref.watch(myPageViewModelProvider);
     final provider = ref.watch(myPageViewModelProvider.notifier);
 
-    return Scaffold(
-      backgroundColor: CustomColors.whDarkBlack,
-      appBar: WehavitAppBar(
-        title: '내 정보',
-        trailingTitle: '',
-        trailingIcon: Icons.menu,
-        trailingAction: () async {
-          // 변경사항을 TabBar에 알리기 위해 mainViewState를 참조
-          MainViewState? mainViewState =
-              context.findAncestorStateOfType<MainViewState>();
-          showMyPageMenuBottomSheet(context, mainViewState);
-        },
-      ),
-      body: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-        child: RefreshIndicator(
-          onRefresh: () async {
-            provider.loadData().whenComplete(() {
-              setState(() {});
-            });
-          },
-          child: ListView(
-            padding: const EdgeInsets.only(bottom: 64.0),
-            children: [
-              // 내 프로필
-              MyPageWehavitSummaryWidget(
-                futureUserEntity: viewModel.futureMyUserDataEntity,
-              ),
-              const SizedBox(
-                height: 16,
-              ),
-              const Text(
-                '도전중인 목표',
-                style: TextStyle(
-                  fontWeight: FontWeight.w600,
-                  color: Colors.white,
-                  fontSize: 20,
-                ),
-              ),
-              const SizedBox(
-                height: 16,
-              ),
-              EitherFutureBuilder<List<ResolutionEntity>>(
-                target: viewModel.futureMyyResolutionList,
-                forWaiting: Container(),
-                forFail: Container(),
-                mainWidgetCallback: (resolutionList) {
-                  return Visibility(
-                    replacement: const ResolutionListPlaceholderWidget(),
-                    visible: resolutionList.isNotEmpty,
-                    child: Column(
-                      children: List<Widget>.generate(
-                        resolutionList.length,
-                        (index) => Container(
-                          margin: const EdgeInsets.only(bottom: 16.0),
-                          child: TextButton(
-                            style: TextButton.styleFrom(
-                              backgroundColor: CustomColors.whSemiBlack,
-                              shadowColor: Colors.transparent,
-                              surfaceTintColor: Colors.transparent,
-                              overlayColor: PointColors.colorList[
-                                  resolutionList[index].colorIndex ?? 0],
-                              padding: const EdgeInsets.all(0),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16.0),
-                              ),
-                            ),
-                            onPressed: () {
-                              showToastMessage(
-                                context,
-                                text: '현재 개발중인 기능입니다!',
-                                icon: const Icon(
-                                  Icons.warning,
-                                  color: CustomColors.whYellow,
+    return Stack(
+      children: [
+        Scaffold(
+          backgroundColor: CustomColors.whDarkBlack,
+          appBar: WehavitAppBar(
+            title: '내 정보',
+            trailingTitle: '',
+            trailingIcon: Icons.menu,
+            trailingAction: () async {
+              // 변경사항을 TabBar에 알리기 위해 mainViewState를 참조
+              MainViewState? mainViewState =
+                  context.findAncestorStateOfType<MainViewState>();
+              showMyPageMenuBottomSheet(
+                context,
+                mainViewState,
+                deleteAccount,
+              );
+            },
+          ),
+          body: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: RefreshIndicator(
+              onRefresh: () async {
+                provider.loadData().whenComplete(() {
+                  setState(() {});
+                });
+              },
+              child: ListView(
+                padding: const EdgeInsets.only(bottom: 64.0),
+                children: [
+                  // 내 프로필
+                  MyPageWehavitSummaryWidget(
+                    futureUserEntity: viewModel.futureMyUserDataEntity,
+                  ),
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  const Text(
+                    '도전중인 목표',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white,
+                      fontSize: 20,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 16,
+                  ),
+                  EitherFutureBuilder<List<ResolutionEntity>>(
+                    target: viewModel.futureMyyResolutionList,
+                    forWaiting: Container(),
+                    forFail: Container(),
+                    mainWidgetCallback: (resolutionList) {
+                      return Visibility(
+                        replacement: const ResolutionListPlaceholderWidget(),
+                        visible: resolutionList.isNotEmpty,
+                        child: Column(
+                          children: List<Widget>.generate(
+                            resolutionList.length,
+                            (index) => Container(
+                              margin: const EdgeInsets.only(bottom: 16.0),
+                              child: TextButton(
+                                style: TextButton.styleFrom(
+                                  backgroundColor: CustomColors.whSemiBlack,
+                                  shadowColor: Colors.transparent,
+                                  surfaceTintColor: Colors.transparent,
+                                  overlayColor: PointColors.colorList[
+                                      resolutionList[index].colorIndex ?? 0],
+                                  padding: const EdgeInsets.all(0),
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(16.0),
+                                  ),
                                 ),
-                              );
-                            },
-                            child: ResolutionListCellWidget(
-                              resolutionEntity: resolutionList[index],
-                              showDetails: true,
+                                onPressed: () {
+                                  showToastMessage(
+                                    context,
+                                    text: '현재 개발중인 기능입니다!',
+                                    icon: const Icon(
+                                      Icons.warning,
+                                      color: CustomColors.whYellow,
+                                    ),
+                                  );
+                                },
+                                child: ResolutionListCellWidget(
+                                  resolutionEntity: resolutionList[index],
+                                  showDetails: true,
+                                ),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ),
-                  );
-                },
+                      );
+                    },
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
-      ),
+      ],
     );
   }
 
   Future<dynamic> showMyPageMenuBottomSheet(
     BuildContext context,
     MainViewState? mainViewState,
+    Function() deleteAccount,
   ) {
     return showModalBottomSheet(
       context: context,
@@ -241,51 +253,29 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                             isDefaultAction: true,
                             child: const Text('취소'),
                             onPressed: () {
-                              Navigator.pop(context);
+                              Navigator.pop(context, false);
                             },
                           ),
                           CupertinoDialogAction(
                             isDestructiveAction: true,
+                            onPressed: deleteAccount,
                             child: const Text('탈퇴하기'),
-                            onPressed: () async {
-                              final isAppleLogin = FirebaseAuth
-                                  .instance.currentUser?.providerData
-                                  .any(
-                                (info) => info.providerId == 'apple.com',
-                              );
-
-                              bool isRevokable = true;
-
-                              if (isAppleLogin == true) {
-                                isRevokable = await ref
-                                    .read(myPageViewModelProvider.notifier)
-                                    .revokeAppleSignIn();
-                              }
-
-                              // 계정을 삭제할 준비가 완료됨
-                              if (isRevokable == true) {
-                                User? user = FirebaseAuth.instance.currentUser;
-                                if (user != null) {
-                                  await user.delete();
-                                  // ignore: avoid_print
-                                  print('사용자 계정이 성공적으로 삭제되었습니다.');
-                                }
-                              }
-
-                              // 창 닫기
-                              if (mounted) {
-                                Navigator.pushReplacementNamed(
-                                  // ignore: use_build_context_synchronously
-                                  context,
-                                  '/entrance',
-                                );
-                              }
-                            },
                           ),
                         ],
                       );
                     },
-                  );
+                  ).then((result) {
+                    if (result == false) {
+                      showToastMessage(
+                        context,
+                        text: '오류 발생, 문의 부탁드립니다',
+                        icon: const Icon(
+                          Icons.report_problem,
+                          color: CustomColors.whYellow,
+                        ),
+                      );
+                    }
+                  });
                 },
               ),
               const SizedBox(

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -1,14 +1,8 @@
 import 'dart:async';
-import 'dart:convert';
-
-import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:http/http.dart' as http;
-import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
@@ -106,7 +100,7 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                 forFail: Container(),
                 mainWidgetCallback: (resolutionList) {
                   return Visibility(
-                    replacement: ResolutionListPlaceholderWidget(),
+                    replacement: const ResolutionListPlaceholderWidget(),
                     visible: resolutionList.isNotEmpty,
                     child: Column(
                       children: List<Widget>.generate(
@@ -234,103 +228,64 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                 foregroundColor: PointColors.red,
                 onPressed: () async {
                   showCupertinoDialog(
-                      context: context,
-                      builder: (context) {
-                        return CupertinoAlertDialog(
-                          title: const Text('정말 탈퇴하시겠어요?'),
-                          content: const Text('작성하신 인증글의 복구가 불가능합니다'),
-                          actions: [
-                            CupertinoDialogAction(
-                              textStyle: const TextStyle(
-                                color: PointColors.blue,
-                              ),
-                              isDefaultAction: true,
-                              child: const Text('취소'),
-                              onPressed: () {
-                                Navigator.pop(context);
-                              },
+                    context: context,
+                    builder: (context) {
+                      return CupertinoAlertDialog(
+                        title: const Text('정말 탈퇴하시겠어요?'),
+                        content: const Text('작성하신 인증글의 복구가 불가능합니다'),
+                        actions: [
+                          CupertinoDialogAction(
+                            textStyle: const TextStyle(
+                              color: PointColors.blue,
                             ),
-                            CupertinoDialogAction(
-                              isDestructiveAction: true,
-                              child: const Text('탈퇴하기'),
-                              onPressed: () async {
-                                final isAppleLogin = FirebaseAuth
-                                    .instance.currentUser?.providerData
-                                    .any(
-                                  (info) => info.providerId == 'apple.com',
-                                );
-                                if (isAppleLogin == true) {
-                                  try {
-                                    final appleCredential =
-                                        await SignInWithApple
-                                            .getAppleIDCredential(
-                                      scopes: [
-                                        AppleIDAuthorizationScopes.email,
-                                        AppleIDAuthorizationScopes.fullName,
-                                      ],
-                                    );
+                            isDefaultAction: true,
+                            child: const Text('취소'),
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                          ),
+                          CupertinoDialogAction(
+                            isDestructiveAction: true,
+                            child: const Text('탈퇴하기'),
+                            onPressed: () async {
+                              final isAppleLogin = FirebaseAuth
+                                  .instance.currentUser?.providerData
+                                  .any(
+                                (info) => info.providerId == 'apple.com',
+                              );
 
-                                    final String privateKey = [
-                                      dotenv.env['APPLE_PRIVATE_KEY_LINE1']!,
-                                      dotenv.env['APPLE_PRIVATE_KEY_LINE2']!,
-                                      dotenv.env['APPLE_PRIVATE_KEY_LINE3']!,
-                                      dotenv.env['APPLE_PRIVATE_KEY_LINE4']!,
-                                      dotenv.env['APPLE_PRIVATE_KEY_LINE5']!,
-                                      dotenv.env['APPLE_PRIVATE_KEY_LINE6']!
-                                    ].join('\n');
+                              bool isRevokable = true;
 
-                                    const String teamId = 'JPL38XBHJ4';
-                                    const String clientId =
-                                        'com.bootcamp.wehavit';
-                                    const String keyId = '67F4G5H6JW';
-                                    // 'USER_ID_TOKEN_OR_REFRESH_TOKEN';
-                                    final String authCode =
-                                        appleCredential.authorizationCode!;
+                              if (isAppleLogin == true) {
+                                isRevokable = await ref
+                                    .read(myPageViewModelProvider.notifier)
+                                    .revokeAppleSignIn();
+                              }
 
-                                    final String clientSecret = createJwt(
-                                      teamId: teamId,
-                                      clientId: clientId,
-                                      keyId: keyId,
-                                      privateKey: privateKey,
-                                    );
-
-                                    final access_token =
-                                        (await requestAppleTokens(
-                                      authCode,
-                                      clientSecret,
-                                    ))['access_token'] as String;
-
-                                    const String tokenTypeHint = 'access_token';
-                                    await revokeAppleToken(
-                                      clientId: clientId,
-                                      clientSecret: clientSecret,
-                                      token: access_token,
-                                      tokenTypeHint: tokenTypeHint,
-                                    ).then((_) => print("DEBUG : DONE"));
-                                  } catch (e, stack) {
-                                    print(stack);
-                                    print("사용자 계정 삭제 중 오류 발생: $e");
-                                  }
-                                }
-
+                              // 계정을 삭제할 준비가 완료됨
+                              if (isRevokable == true) {
                                 User? user = FirebaseAuth.instance.currentUser;
                                 if (user != null) {
                                   await user.delete();
-                                  print("사용자 계정이 성공적으로 삭제되었습니다.");
+                                  // ignore: avoid_print
+                                  print('사용자 계정이 성공적으로 삭제되었습니다.');
                                 }
+                              }
 
-                                if (mounted) {
+                              // 창 닫기
+                              if (mounted) {
+                                Navigator.pushReplacementNamed(
                                   // ignore: use_build_context_synchronously
-                                  Navigator.pushReplacementNamed(
-                                    context,
-                                    '/entrance',
-                                  );
-                                }
-                              },
-                            ),
-                          ],
-                        );
-                      });
+                                  context,
+                                  '/entrance',
+                                );
+                              }
+                            },
+                          ),
+                        ],
+                      );
+                    },
+                  );
                 },
               ),
               const SizedBox(
@@ -349,84 +304,5 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
         );
       },
     );
-  }
-}
-
-// JWT 생성 함수
-String createJwt({
-  required String teamId,
-  required String clientId,
-  required String keyId,
-  required String privateKey,
-}) {
-  final jwt = JWT(
-    {
-      'iss': teamId,
-      'iat': DateTime.now().millisecondsSinceEpoch ~/ 1000,
-      'exp': (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 3600,
-      'aud': 'https://appleid.apple.com',
-      'sub': clientId,
-    },
-    header: {
-      'kid': keyId,
-      'alg': 'ES256',
-    },
-  );
-
-  final key = ECPrivateKey(privateKey);
-  return jwt.sign(key, algorithm: JWTAlgorithm.ES256);
-}
-
-// 사용자 토큰 취소 함수
-Future<void> revokeAppleToken({
-  required String clientId,
-  required String clientSecret,
-  required String token,
-  required String tokenTypeHint,
-}) async {
-  final url = Uri.parse('https://appleid.apple.com/auth/revoke');
-  final response = await http.post(
-    url,
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: {
-      'client_id': clientId,
-      'client_secret': clientSecret,
-      'token': token,
-      'token_type_hint': tokenTypeHint,
-    },
-  );
-
-  if (response.statusCode == 200) {
-    print('토큰이 성공적으로 취소되었습니다.');
-  } else {
-    print('토큰 취소 중 오류 발생: ${response.statusCode}');
-  }
-}
-
-Future<Map<String, dynamic>> requestAppleTokens(
-  String authorizationCode,
-  String clientSecret,
-) async {
-  final response = await http.post(
-    Uri.parse('https://appleid.apple.com/auth/token'),
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: {
-      'client_id': 'com.bootcamp.wehavit',
-      'client_secret': clientSecret,
-      'code': authorizationCode,
-      'grant_type': 'authorization_code',
-      'redirect_uri': 'YOUR_REDIRECT_URI', // 필요시 설정
-    },
-  );
-
-  if (response.statusCode == 200) {
-    print(jsonDecode(response.body));
-    return jsonDecode(response.body);
-  } else {
-    throw Exception('토큰 요청 실패: ${response.body}');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,8 @@ dependencies:
   visibility_detector: ^0.4.0+2
   photo_view: ^0.15.0
   sign_in_with_apple: ^6.1.1
+  dart_jsonwebtoken: ^2.14.0
+  flutter_dotenv: ^5.1.0
 
 
 
@@ -74,6 +76,7 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
+    - .env
     - assets/images/emoji_3d/
     - assets/logo/
     - assets/images/icons/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: wehavit
 description: A new Havit tracking app without the comparing others.
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.1+1
 
 environment:
   sdk: '>=3.4.3 <4.0.0'
@@ -76,7 +76,6 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - .env
     - assets/images/emoji_3d/
     - assets/logo/
     - assets/images/icons/


### PR DESCRIPTION
# 설명
회원 탈퇴 시 계정 삭제 로직을 구현함

Fixes #
Closes #278 
Resolves #

# 작업 내역
- 회원 탈퇴 기능 구현
  - 애플 계정으로 회원가입 시 애플로그인으로 인증 후 탈퇴
  - 구글 계정/이메일로 회원가입 시 바로 탈퇴 

## 작업 결과물
|회원탈퇴(Google / 이메일)|회원탈퇴(Apple)|애플회원탈퇴 시 메일|
|---|---|-----|
|<img src="https://github.com/cau-bootcamp/wehavit/assets/39216546/6571c575-92e6-460b-8a9c-409721d0bfe6" width=200>|<img src="https://github.com/cau-bootcamp/wehavit/assets/39216546/056f84c9-2d90-4bc0-af97-10b2268464f5" width=200>|<img width="500" alt="image" src="https://github.com/cau-bootcamp/wehavit/assets/39216546/63cfb4c4-22c3-4998-aa62-0e1002c60979">|

## 참고 사항(선택)
회원탈퇴를 바닐라Dart 로 구현하기 위해서 꽤나 고생을 좀 했다. 생각보다 바닐라 Dart로 이를 구현해둔 예제가 없었고, 다들 Spring, Java 등으로 우회해서 처리하는 곳이 많았음. 그래서 닥치는대로 자료를 찾아보고 공부해서 Dart 만으로 로그아웃을 구현하는 코드를 작성했음! 아래 참고하기.
https://etst.tistory.com/383

애플 회원탈퇴 시 애플 서버에 이를 알려야하는데, 여기에 사용되는 Private Key를 gitignore에 등록해두었음. 외부에서 key 없이 빌드 시 애플 회원탈퇴 로직이 정상적으로 작동하지 않음.

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
