### PR TITLE
[#286] HOTFIX: 반응남기기용 카메라 기능에서 마이크 사용하지 않도록 제거

### DIFF
--- a/lib/presentation/effects/camera_quickshot/reaction_camera_widget_model_provider.dart
+++ b/lib/presentation/effects/camera_quickshot/reaction_camera_widget_model_provider.dart
@@ -37,10 +37,12 @@ class ReactionCameraWidgetModelProvider
     );
 
     if (state.cameraController == null && description != null) {
-      state.cameraController =
-          CameraController(description, ResolutionPreset.medium);
+      state.cameraController = CameraController(
+        description,
+        ResolutionPreset.medium,
+        enableAudio: false,
+      );
       await state.cameraController!.initialize();
-
       return Future(() => true);
     }
 


### PR DESCRIPTION
# 설명
앱 내에서 사용하지 않는 카메라의 마이크 기능으로 인해 그룹 뷰 진입 시 앱이 꺼지는 문제가 발생하고 있음.
앱 크래시가 발생하고 있어서, 빠르게 수정 후 재배포 예정

Fixes #
Closes #286 
Resolves #

# 작업 내역
- 마이크 기능 해제하기



## 참고 사항(선택)
문제 해결을 위해서 2가지 방법이 있었고, 더 타당하다고 생각되는 마이크 사용 기능을 제거하는 방식을 선택하여 수정함.
- 마이크 사용 권한 부여하기
- 앱 내 마이크 사용을 제거하기

어떻게 심사를 통과한거지...? 


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
