### PR TITLE
[#292] fix: id에 대한 user data가 존재하지 않을 때 UI 숨기기

### DIFF
--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -220,7 +220,7 @@ final addResolutionViewModelProvider = StateNotifierProvider.autoDispose<
   return AddResolutionViewModelProvider(uploadResolutionUseCase);
 });
 
-final addResolutionDoneViewModelProvider = StateNotifierProvider.autoDispose<
+final addResolutionDoneViewModelProvider = StateNotifierProvider<
     AddResolutionDoneViewModelProvider, AddResolutionDoneViewModel>((ref) {
   GetFriendListUsecase getFriendListUsecase =
       ref.watch(getFriendListUseCaseProvider);

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -130,13 +130,10 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                               padding: const EdgeInsets.only(bottom: 64),
                               itemCount: viewModel.friendFutureUserList!.length,
                               itemBuilder: (context, index) {
-                                return Container(
-                                  margin: const EdgeInsets.only(bottom: 12),
-                                  child: FriendListCellWidget(
-                                    futureUserEntity:
-                                        viewModel.friendFutureUserList![index],
-                                    cellState: FriendListCellState.normal,
-                                  ),
+                                return FriendListCellWidget(
+                                  futureUserEntity:
+                                      viewModel.friendFutureUserList![index],
+                                  cellState: FriendListCellState.normal,
                                 );
                               },
                             ),
@@ -202,13 +199,10 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                       Column(
                         children: List<Widget>.generate(
                           viewModel.searchedFutureUserList!.length,
-                          (index) => Container(
-                            margin: const EdgeInsets.only(top: 12.0),
-                            child: FriendListCellWidget(
-                              futureUserEntity:
-                                  viewModel.searchedFutureUserList![index],
-                              cellState: FriendListCellState.toApply,
-                            ),
+                          (index) => FriendListCellWidget(
+                            futureUserEntity:
+                                viewModel.searchedFutureUserList![index],
+                            cellState: FriendListCellState.toApply,
                           ),
                         ),
                       ),
@@ -266,13 +260,10 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                       Column(
                         children: List<Widget>.generate(
                           viewModel.friendFutureUserList!.length,
-                          (index) => Container(
-                            margin: const EdgeInsets.only(top: 12.0),
-                            child: FriendListCellWidget(
-                              futureUserEntity:
-                                  viewModel.friendFutureUserList![index],
-                              cellState: FriendListCellState.managing,
-                            ),
+                          (index) => FriendListCellWidget(
+                            futureUserEntity:
+                                viewModel.friendFutureUserList![index],
+                            cellState: FriendListCellState.managing,
                           ),
                         ),
                       ),

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -99,9 +99,9 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                     children: [
                       Container(
                         alignment: Alignment.centerLeft,
-                        child: Text(
-                          '내 친구들 (${viewModel.friendFutureUserList!.length})',
-                          style: const TextStyle(
+                        child: const Text(
+                          '내 친구들',
+                          style: TextStyle(
                             fontSize: 16.0,
                             fontWeight: FontWeight.w600,
                             color: CustomColors.whWhite,
@@ -249,9 +249,9 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                       const SizedBox(
                         height: 32,
                       ),
-                      Text(
-                        '내 친구들 (${viewModel.friendFutureUserList!.length})',
-                        style: const TextStyle(
+                      const Text(
+                        '내 친구들',
+                        style: TextStyle(
                           fontSize: 16.0,
                           fontWeight: FontWeight.w600,
                           color: CustomColors.whWhite,

--- a/lib/presentation/friend_list/view/friend_list_view_widget.dart
+++ b/lib/presentation/friend_list/view/friend_list_view_widget.dart
@@ -28,53 +28,17 @@ class _FriendListCellWidgetState extends ConsumerState<FriendListCellWidget> {
   Widget build(BuildContext context) {
     return EitherFutureBuilder<UserDataEntity>(
       target: widget.futureUserEntity,
-      forWaiting: Row(
-        children: [
-          Container(
-            width: 60,
-            height: 60,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              color: CustomColors.whBlack,
-            ),
-          ),
-          const SizedBox(
-            width: 12,
-          ),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  height: 20,
-                  width: 200,
-                  decoration: BoxDecoration(
-                    color: CustomColors.whBlack,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Container(
-                  height: 20,
-                  width: 90,
-                  decoration: BoxDecoration(
-                    color: CustomColors.whBlack,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          // ColoredButton(buttonTitle: "Hi"),
-        ],
-      ),
-      forFail: Container(),
-      mainWidgetCallback: (userEntity) {
-        return Row(
+      forWaiting: Container(
+        margin: const EdgeInsets.symmetric(vertical: 6.0),
+        child: Row(
           children: [
-            ProfileImageCircleWidget(
-              size: 60,
-              url: userEntity.userImageUrl,
+            Container(
+              width: 60,
+              height: 60,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: CustomColors.whBlack,
+              ),
             ),
             const SizedBox(
               width: 12,
@@ -83,50 +47,92 @@ class _FriendListCellWidgetState extends ConsumerState<FriendListCellWidget> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Text(
-                        '${userEntity.userName}',
-                        style: const TextStyle(
-                          color: CustomColors.whWhite,
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      Expanded(
-                        child: Text(
-                          userEntity.handle != null
-                              ? ' • ${userEntity.handle}'
-                              : '',
+                  Container(
+                    height: 20,
+                    width: 200,
+                    decoration: BoxDecoration(
+                      color: CustomColors.whBlack,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Container(
+                    height: 20,
+                    width: 90,
+                    decoration: BoxDecoration(
+                      color: CustomColors.whBlack,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // ColoredButton(buttonTitle: "Hi"),
+          ],
+        ),
+      ),
+      forFail: Container(),
+      mainWidgetCallback: (userEntity) {
+        return Container(
+          margin: const EdgeInsets.symmetric(vertical: 6.0),
+          child: Row(
+            children: [
+              ProfileImageCircleWidget(
+                size: 60,
+                url: userEntity.userImageUrl,
+              ),
+              const SizedBox(
+                width: 12,
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          '${userEntity.userName}',
                           style: const TextStyle(
-                            color: CustomColors.whSemiWhite,
+                            color: CustomColors.whWhite,
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
                           ),
                           overflow: TextOverflow.ellipsis,
                         ),
-                      ),
-                    ],
-                  ),
-                  Text(
-                    userEntity.aboutMe ?? '',
-                    style: const TextStyle(
-                      color: CustomColors.whPlaceholderGrey,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w300,
+                        Expanded(
+                          child: Text(
+                            userEntity.handle != null
+                                ? ' • ${userEntity.handle}'
+                                : '',
+                            style: const TextStyle(
+                              color: CustomColors.whSemiWhite,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
                     ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(
-                    width: 8,
-                  ),
-                ],
+                    Text(
+                      userEntity.aboutMe ?? '',
+                      style: const TextStyle(
+                        color: CustomColors.whPlaceholderGrey,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w300,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(
+                      width: 8,
+                    ),
+                  ],
+                ),
               ),
-            ),
-            postfixButtonWidget(userEntity, ref),
-          ],
+              postfixButtonWidget(userEntity, ref),
+            ],
+          ),
         );
       },
     );

--- a/lib/presentation/write_post/view/add_resolution_done_view.dart
+++ b/lib/presentation/write_post/view/add_resolution_done_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
+import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
 class AddResolutionDoneView extends ConsumerStatefulWidget {
@@ -184,60 +185,64 @@ class _ShareResolutionToFriendBottomSheetWidgetState
           child: ListView(
             children: List<Widget>.generate(
               viewmodel.friendList!.length,
-              (index) => Container(
-                margin: const EdgeInsets.only(bottom: 16.0),
-                child: TextButton(
-                  onPressed: () {
-                    setState(() {
-                      provider.toggleFriendSelection(index);
-                    });
-                  },
-                  style: TextButton.styleFrom(
-                    minimumSize: Size.zero,
-                    padding: EdgeInsets.zero,
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    side: BorderSide.none,
-                    shape: const RoundedRectangleBorder(
-                      borderRadius: BorderRadius.all(
-                        Radius.circular(8.0),
-                      ),
+              (index) => TextButton(
+                onPressed: () {
+                  setState(() {
+                    provider.toggleFriendSelection(index);
+                  });
+                },
+                style: TextButton.styleFrom(
+                  minimumSize: Size.zero,
+                  padding: EdgeInsets.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  side: BorderSide.none,
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(8.0),
                     ),
-                    overlayColor: CustomColors.whYellow,
                   ),
-                  child: Stack(
-                    alignment: Alignment.centerRight,
-                    children: [
-                      FriendListCellWidget(
-                        futureUserEntity: viewmodel.friendList![index],
-                        cellState: FriendListCellState.normal,
-                      ),
-                      Container(
-                        margin: const EdgeInsets.only(
-                          right: 8.0,
-                        ),
-                        width: 24,
-                        height: 24,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: viewmodel.tempSelectedFriendList![index]
-                              ? CustomColors.whYellow
-                              : Colors.transparent,
-                          border: Border.all(
-                            color: CustomColors.whBrightGrey,
+                  overlayColor: CustomColors.whYellow,
+                ),
+                child: Stack(
+                  alignment: Alignment.centerRight,
+                  children: [
+                    FriendListCellWidget(
+                      futureUserEntity: viewmodel.friendList![index],
+                      cellState: FriendListCellState.normal,
+                    ),
+                    EitherFutureBuilder<UserDataEntity>(
+                      target: viewmodel.friendList![index],
+                      forFail: Container(),
+                      forWaiting: Container(),
+                      mainWidgetCallback: (_) {
+                        return Container(
+                          margin: const EdgeInsets.only(
+                            right: 8.0,
                           ),
-                        ),
-                        child: Visibility(
-                          visible: viewmodel.tempSelectedFriendList![index],
-                          child: const Icon(
-                            Icons.check,
-                            color: CustomColors.whWhite,
-                            size: 20,
-                            weight: 500,
+                          width: 24,
+                          height: 24,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: viewmodel.tempSelectedFriendList![index]
+                                ? CustomColors.whYellow
+                                : Colors.transparent,
+                            border: Border.all(
+                              color: CustomColors.whBrightGrey,
+                            ),
                           ),
-                        ),
-                      ),
-                    ],
-                  ),
+                          child: Visibility(
+                            visible: viewmodel.tempSelectedFriendList![index],
+                            child: const Icon(
+                              Icons.check,
+                              color: CustomColors.whWhite,
+                              size: 20,
+                              weight: 500,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
# 설명
친구의 UID에 대한 데이터가 존재하지 않을 때, UI에서 이를 보여주지 않도록 UI 코드 수정

Fixes #
Closes #292 
Resolves #

# 작업 내역
- 친구 리스트 뷰 수정
- 도전 완료 - 공유할 친구 선택 뷰 수정

## 작업 결과물
|친구리스트뷰|도전완료뷰|
|---|---|
|![Simulator Screenshot - 13 Pro simulator - 2024-07-01 at 17 56 16](https://github.com/cau-bootcamp/wehavit/assets/39216546/f63dfa70-38c0-42af-a41a-f19876e8042f)|![Simulator Screenshot - 13 Pro simulator - 2024-07-01 at 17 56 27](https://github.com/cau-bootcamp/wehavit/assets/39216546/f9c07fea-ec1f-435b-9395-7fb11071d1da)|


## 참고 사항(선택)
실제 로드된 친구의 수가 아닌 EitherFuture 리스트의 개수를 보여주고 있어서, 
친구리스트 뷰에서 내 친구의 개수에 대한 레이블을 삭제하였음.
이후에 로직 개편을 진행하면서 수정 적용해주기

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
