### PR TITLE
[#292] feat: 목표 공유대상 수정 기능 구현

### DIFF
--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -220,7 +220,7 @@ final addResolutionViewModelProvider = StateNotifierProvider.autoDispose<
   return AddResolutionViewModelProvider(uploadResolutionUseCase);
 });
 
-final addResolutionDoneViewModelProvider = StateNotifierProvider.autoDispose<
+final addResolutionDoneViewModelProvider = StateNotifierProvider<
     AddResolutionDoneViewModelProvider, AddResolutionDoneViewModel>((ref) {
   GetFriendListUsecase getFriendListUsecase =
       ref.watch(getFriendListUseCaseProvider);
@@ -237,6 +237,8 @@ final addResolutionDoneViewModelProvider = StateNotifierProvider.autoDispose<
       ref.watch(shareResolutionToGroupUsecaseProvider);
   UnshareResolutionToGroupUsecase unshareResolutionToGroupdUsecase =
       ref.watch(unshareResolutionToGroupUsecaseProvider);
+  GetUserDataFromIdUsecase getUserDataFromIdUsecase =
+      ref.watch(getUserDataFromIdUsecaseProvider);
 
   return AddResolutionDoneViewModelProvider(
     getFriendListUsecase,
@@ -246,6 +248,7 @@ final addResolutionDoneViewModelProvider = StateNotifierProvider.autoDispose<
     unshareResolutionToFriendUsecase,
     shareResolutionToGroupdUsecase,
     unshareResolutionToGroupdUsecase,
+    getUserDataFromIdUsecase,
   );
 });
 

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -132,6 +132,7 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                                   showModifyResolutionShareTargetBottomSheet(
                                     context,
                                     () {},
+                                    resolutionList[index],
                                   );
                                 },
                                 child: ResolutionListCellWidget(
@@ -295,7 +296,11 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
   Future<dynamic> showModifyResolutionShareTargetBottomSheet(
     BuildContext context,
     Function() deleteAccount,
+    ResolutionEntity entity,
   ) {
+    ref.watch(addResolutionDoneViewModelProvider).resolutionEntity = entity;
+    final provider = ref.read(addResolutionDoneViewModelProvider.notifier);
+
     return showModalBottomSheet(
       context: context,
       builder: (context) {
@@ -306,7 +311,21 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                 buttonTitle: '목표 공유 친구 수정하기',
                 buttonIcon: Icons.people_alt_outlined,
                 onPressed: () async {
-                  Navigator.pop(context);
+                  provider.loadFriendList().whenComplete(() async {
+                    await provider.resetTempFriendList();
+                    showModalBottomSheet(
+                      isScrollControlled: true,
+                      // ignore: use_build_context_synchronously
+                      context: context,
+                      builder: (context) => GradientBottomSheet(
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * 0.82,
+                          child:
+                              const ShareResolutionToFriendBottomSheetWidget(),
+                        ),
+                      ),
+                    );
+                  });
                 },
               ),
               const SizedBox(
@@ -316,7 +335,23 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                 buttonTitle: '목표 공유 그룹 수정하기',
                 buttonIcon: Icons.flag_outlined,
                 onPressed: () async {
-                  Navigator.pop(context);
+                  provider.loadGroupList().whenComplete(
+                    () async {
+                      await provider.resetTempGroupList();
+                      showModalBottomSheet(
+                        isScrollControlled: true,
+                        // ignore: use_build_context_synchronously
+                        context: context,
+                        builder: (context) => GradientBottomSheet(
+                          SizedBox(
+                            height: MediaQuery.of(context).size.height * 0.82,
+                            child:
+                                const ShareResolutionToGroupBottomSheetWidget(),
+                          ),
+                        ),
+                      );
+                    },
+                  );
                 },
               ),
               const SizedBox(

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -131,7 +131,6 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                                 onPressed: () async {
                                   showModifyResolutionShareTargetBottomSheet(
                                     context,
-                                    () {},
                                     resolutionList[index],
                                   );
                                 },
@@ -295,7 +294,6 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
 
   Future<dynamic> showModifyResolutionShareTargetBottomSheet(
     BuildContext context,
-    Function() deleteAccount,
     ResolutionEntity entity,
   ) {
     ref.watch(addResolutionDoneViewModelProvider).resolutionEntity = entity;
@@ -324,7 +322,14 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                               const ShareResolutionToFriendBottomSheetWidget(),
                         ),
                       ),
-                    );
+                    ).whenComplete(() {
+                      ref
+                          .read(myPageViewModelProvider.notifier)
+                          .getResolutionList()
+                          .whenComplete(() {
+                        setState(() {});
+                      });
+                    });
                   });
                 },
               ),

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -322,7 +322,10 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                               const ShareResolutionToFriendBottomSheetWidget(),
                         ),
                       ),
-                    ).whenComplete(() {
+                    ).then((newEntity) {
+                      ref
+                          .watch(addResolutionDoneViewModelProvider)
+                          .resolutionEntity = newEntity;
                       ref
                           .read(myPageViewModelProvider.notifier)
                           .getResolutionList()
@@ -340,23 +343,33 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                 buttonTitle: '목표 공유 그룹 수정하기',
                 buttonIcon: Icons.flag_outlined,
                 onPressed: () async {
-                  provider.loadGroupList().whenComplete(
-                    () async {
-                      await provider.resetTempGroupList();
-                      showModalBottomSheet(
-                        isScrollControlled: true,
-                        // ignore: use_build_context_synchronously
-                        context: context,
-                        builder: (context) => GradientBottomSheet(
-                          SizedBox(
-                            height: MediaQuery.of(context).size.height * 0.82,
-                            child:
-                                const ShareResolutionToGroupBottomSheetWidget(),
-                          ),
+                  provider.loadGroupList().whenComplete(() async {
+                    await provider.resetTempGroupList();
+                    showModalBottomSheet(
+                      isScrollControlled: true,
+                      // ignore: use_build_context_synchronously
+                      context: context,
+                      builder: (context) => GradientBottomSheet(
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * 0.82,
+                          child:
+                              const ShareResolutionToGroupBottomSheetWidget(),
                         ),
-                      );
-                    },
-                  );
+                      ),
+                    ).then((newEntity) {
+                      if (newEntity != null && newEntity is ResolutionEntity) {
+                        ref
+                            .watch(addResolutionDoneViewModelProvider)
+                            .resolutionEntity = newEntity;
+                        ref
+                            .read(myPageViewModelProvider.notifier)
+                            .getResolutionList()
+                            .whenComplete(() {
+                          setState(() {});
+                        });
+                      }
+                    });
+                  });
                 },
               ),
               const SizedBox(

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -128,14 +128,10 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                                     borderRadius: BorderRadius.circular(16.0),
                                   ),
                                 ),
-                                onPressed: () {
-                                  showToastMessage(
+                                onPressed: () async {
+                                  showModifyResolutionShareTargetBottomSheet(
                                     context,
-                                    text: '현재 개발중인 기능입니다!',
-                                    icon: const Icon(
-                                      Icons.warning,
-                                      color: CustomColors.whYellow,
-                                    ),
+                                    () {},
                                   );
                                 },
                                 child: ResolutionListCellWidget(
@@ -276,6 +272,51 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                       );
                     }
                   });
+                },
+              ),
+              const SizedBox(
+                height: 12,
+              ),
+              WideColoredButton(
+                buttonTitle: '돌아가기',
+                backgroundColor: Colors.transparent,
+                foregroundColor: CustomColors.whPlaceholderGrey,
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<dynamic> showModifyResolutionShareTargetBottomSheet(
+    BuildContext context,
+    Function() deleteAccount,
+  ) {
+    return showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return GradientBottomSheet(
+          Column(
+            children: [
+              WideColoredButton(
+                buttonTitle: '목표 공유 친구 수정하기',
+                buttonIcon: Icons.people_alt_outlined,
+                onPressed: () async {
+                  Navigator.pop(context);
+                },
+              ),
+              const SizedBox(
+                height: 12,
+              ),
+              WideColoredButton(
+                buttonTitle: '목표 공유 그룹 수정하기',
+                buttonIcon: Icons.flag_outlined,
+                onPressed: () async {
+                  Navigator.pop(context);
                 },
               ),
               const SizedBox(

--- a/lib/presentation/write_post/view/add_resolution_done_view.dart
+++ b/lib/presentation/write_post/view/add_resolution_done_view.dart
@@ -162,7 +162,7 @@ class _ShareResolutionToFriendBottomSheetWidgetState
               child: TextButton(
                 onPressed: () async {
                   provider.applyChangedSharingOfFriends().whenComplete(() {
-                    Navigator.pop(context);
+                    Navigator.pop(context, viewmodel.resolutionEntity);
                   });
                 },
                 child: const Text(

--- a/lib/presentation/write_post/view/add_resolution_done_view.dart
+++ b/lib/presentation/write_post/view/add_resolution_done_view.dart
@@ -283,7 +283,7 @@ class _ShareResolutionToGroupBottomSheetWidgetState
               child: TextButton(
                 onPressed: () async {
                   provider.applyChangedSharingOfGroups().whenComplete(() {
-                    Navigator.pop(context);
+                    Navigator.pop(context, viewmodel.resolutionEntity);
                   });
                 },
                 child: const Text(


### PR DESCRIPTION
# 설명
친구, 그룹 등 목표 공유대상을 수정하는 기능을 구현

Fixes #
Closes #292 
Resolves #

# 작업 내역
- 목표를 공유하는 친구 수정 기능 구현
- 목표를 공유하는 그룹 수정 기능 구현

## 작업 결과물
<img src="https://github.com/cau-bootcamp/wehavit/assets/39216546/ea1fae97-dbb3-437c-a06e-ec9bc091fd04" width=350>


## 참고 사항(선택)
현재 사용중인 마이페이지의 버튼은 통계페이지로 이동하기 위한 버튼임.
이후에 각 목표별 통계페이지 디자인이 나오고 해당 페이지를 구현하면 통계페이지 안으로 공유대상 수정 버튼을 이동시키기.


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
