### PR TITLE
[#295] refactor: viewmodel 들의 데이터 로드 시점을 MainView 로드 시점으로 옮기기

### DIFF
--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -100,8 +100,7 @@ final reactionAnimationWidgetManagerProvider =
 
 // Group View
 final groupViewModelProvider =
-    StateNotifierProvider.autoDispose<GroupViewModelProvider, GroupViewModel>(
-        (ref) {
+    StateNotifierProvider<GroupViewModelProvider, GroupViewModel>((ref) {
   final getGroupListUsecase = ref.watch(getGroupListUseCaseProvider);
   final getGroupListViewCellWidgetModelUsecase =
       ref.watch(getGroupListViewCellWidgetModelUsecaseProvider);
@@ -123,7 +122,7 @@ final createGroupViewModelProvider = StateNotifierProvider.autoDispose<
   return CreateGroupViewModelProvider(createGroupUsecase);
 });
 
-final resolutionListViewModelProvider = StateNotifierProvider.autoDispose<
+final resolutionListViewModelProvider = StateNotifierProvider<
     ResolutionListViewModelProvider, ResolutionListViewModel>((ref) {
   final getMyResolutionListUsecase =
       ref.watch(getMyResolutionListUsecaseProvider);

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -14,27 +14,6 @@ class FriendListView extends ConsumerStatefulWidget {
 }
 
 class FrinedListViewState extends ConsumerState<FriendListView> {
-  @override
-  void initState() {
-    super.initState();
-
-    unawaited(
-      ref.read(friendListViewModelProvider.notifier).getMyUserDataEntity(),
-    );
-    unawaited(
-      ref
-          .read(friendListViewModelProvider.notifier)
-          .getAppliedFriendList()
-          .whenComplete(() => setState(() {})),
-    );
-    unawaited(
-      ref
-          .read(friendListViewModelProvider.notifier)
-          .getFriendList()
-          .whenComplete(() => setState(() {})),
-    );
-  }
-
   bool isManagingMode = false;
 
   @override

--- a/lib/presentation/group/provider/group_view_model_provider.dart
+++ b/lib/presentation/group/provider/group_view_model_provider.dart
@@ -29,8 +29,6 @@ class GroupViewModelProvider extends StateNotifier<GroupViewModel> {
       }),
     );
 
-    print(state.myGroupList);
-
     if (state.myGroupList == null) {
       state.groupListViewCellModelList = null;
       return;

--- a/lib/presentation/group/provider/group_view_model_provider.dart
+++ b/lib/presentation/group/provider/group_view_model_provider.dart
@@ -29,6 +29,8 @@ class GroupViewModelProvider extends StateNotifier<GroupViewModel> {
       }),
     );
 
+    print(state.myGroupList);
+
     if (state.myGroupList == null) {
       state.groupListViewCellModelList = null;
       return;

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -221,7 +221,4 @@ class _GroupViewState extends ConsumerState<GroupView> {
         .loadFriendCellWidgetModel(friendUidList: userIdListWithoutNull)
         .whenComplete(() => setState(() {}));
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }

--- a/lib/presentation/group/view/group_view.dart
+++ b/lib/presentation/group/view/group_view.dart
@@ -15,19 +15,9 @@ class GroupView extends ConsumerStatefulWidget {
   ConsumerState<GroupView> createState() => _GroupViewState();
 }
 
-class _GroupViewState extends ConsumerState<GroupView>
-    with AutomaticKeepAliveClientMixin<GroupView> {
-  @override
-  void initState() {
-    super.initState();
-
-    unawaited(loadGroupCellList());
-    unawaited(loadFriendCellList());
-  }
-
+class _GroupViewState extends ConsumerState<GroupView> {
   @override
   Widget build(BuildContext context) {
-    super.build(context);
     final viewModel = ref.watch(groupViewModelProvider);
     final provider = ref.read(groupViewModelProvider.notifier);
 
@@ -207,8 +197,6 @@ class _GroupViewState extends ConsumerState<GroupView>
   }
 
   Future<void> loadFriendCellList() async {
-    await ref.read(friendListViewModelProvider.notifier).getFriendList();
-
     final userIdList = await Future.wait(
       ref
               .read(friendListViewModelProvider)

--- a/lib/presentation/main/view/main_view.dart
+++ b/lib/presentation/main/view/main_view.dart
@@ -3,9 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
-import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
-import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
 class MainView extends ConsumerStatefulWidget {
@@ -18,7 +16,6 @@ class MainView extends ConsumerStatefulWidget {
 class MainViewState extends ConsumerState<MainView>
     with TickerProviderStateMixin {
   late TabController tabController;
-  late EitherFuture<UserDataEntity> userDataEntity;
 
   @override
   void initState() {
@@ -37,11 +34,12 @@ class MainViewState extends ConsumerState<MainView>
   }
 
   Future<void> loadUserData() async {
-    userDataEntity = ref.read(getMyUserDataUsecaseProvider).call();
     ref.read(friendListViewModelProvider.notifier).getMyUserDataEntity();
+    ref.read(myPageViewModelProvider.notifier).loadData();
   }
 
   Future<void> loadResolutionData() async {
+    // 인증 리스트의 목표 셀 로드
     ref
         .read(resolutionListViewModelProvider.notifier)
         .loadResolutionModelList()
@@ -53,7 +51,7 @@ class MainViewState extends ConsumerState<MainView>
   }
 
   Future<void> loadGroupData() async {
-    // loadGroupCell
+    // 그룹리스트의 그룹 셀 로드
     ref
         .read(groupViewModelProvider.notifier)
         .loadMyGroupCellList()
@@ -61,6 +59,7 @@ class MainViewState extends ConsumerState<MainView>
   }
 
   Future<void> loadFriendData() async {
+    // 친구리스트 셀 로드
     ref
         .read(friendListViewModelProvider.notifier)
         .getAppliedFriendList()
@@ -71,7 +70,7 @@ class MainViewState extends ConsumerState<MainView>
         .getFriendList()
         .whenComplete(() => setState(() {}));
 
-    // loadFriendCell
+    // 그룹리스트의 친구 셀 로드
     final userIdList = await Future.wait(
       ref
               .read(friendListViewModelProvider)
@@ -99,6 +98,7 @@ class MainViewState extends ConsumerState<MainView>
 
   @override
   Widget build(BuildContext context) {
+    final myPageViewModel = ref.watch(myPageViewModelProvider);
     return Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: CustomColors.whDarkBlack,
@@ -155,7 +155,8 @@ class MainViewState extends ConsumerState<MainView>
                             ),
                             TabBarProfileImageButton(
                               isSelected: tabController.index == 3,
-                              futureUserDataEntity: userDataEntity,
+                              futureUserDataEntity:
+                                  myPageViewModel.futureMyUserDataEntity!,
                             ),
                           ],
                         ),

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -27,8 +27,6 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
   void initState() {
     super.initState();
     widget.tabController.addListener(_handleTabChange);
-
-    unawaited(ref.read(myPageViewModelProvider.notifier).loadData());
   }
 
   @override
@@ -197,7 +195,7 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                       ),
                     ).then((result) {
                       if (result == true) {
-                        mainViewState?.loadUserData();
+                        mainViewState?.setState(() {});
 
                         ref
                             .read(myPageViewModelProvider.notifier)

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -19,22 +19,6 @@ class ResolutionListView extends ConsumerStatefulWidget {
 class _ResolutionListViewState extends ConsumerState<ResolutionListView>
     with AutomaticKeepAliveClientMixin<ResolutionListView> {
   @override
-  void initState() {
-    super.initState();
-
-    unawaited(
-      ref
-          .read(resolutionListViewModelProvider.notifier)
-          .loadResolutionModelList()
-          .whenComplete(() {
-        setState(() {
-          ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-        });
-      }),
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
     super.build(context);
     final viewModel = ref.watch(resolutionListViewModelProvider);


### PR DESCRIPTION
# 설명
작업 내역을 설명하고 어떤 이슈와 관련되어 있는지 명시합니다.

Fixes #
Closes #295 
Resolves #

# 작업 내역
- ResolutionList ViewModel의 데이터 로드 함수 → MainView 로 이동
- GroupList ViewModel의 데이터 로드 함수 → MainView 로 이동
- FriendList ViewModel의 데이터 로드 함수 → MainView 로 이동
- MyPage ViewModel의 데이터 로드 함수 → MainView 로 이동


## 참고 사항(선택)
PR을 작성하면서 요 작업의 태그가 refactor가 더 적절하다는걸 늦게 알았다. ㅋㅋㅎ
현재 각 뷰모델이 해당 뷰의 데이터와 밀접하게 관련되어있음. 그렇다보니 같은 데이터도 여러 뷰에서 로드해서 자신의 영역에서 사용하는 문제가 있다. 
현재는 내 정보 → 목표리스트 / 친구 / 마이페이지 모두에서 따로 로드해서 사용하고 있음 ... 근데 이걸 한 번만 로드해오고 각자가 MyUserData source에 접근하여 값을 가져가는 방식으로 구현하면 훨씬 쿼리를 덜 사용하도록 개선이 가능하다. 
이후에 리팩토링을 진행하면서 데이터를 좀 더 공유하면서 사용할 수 있는 방식으로 개선이 필요할 것 같다. 캐싱 데이터를 저장하는 공간을 공유메모리 공간으로 사용할 수도 있을 듯!

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
