### PR TITLE
[#305] feat: 목표 별 상세 통계페이지 구현

### DIFF
--- a/lib/common/constants/app_colors.dart
+++ b/lib/common/constants/app_colors.dart
@@ -22,7 +22,7 @@ class CustomColors {
   static const Color whBlack = Color(0xff2b2b2b);
   static const Color whDarkBlack = Color(0xff1F1F1F);
   static const Color whSemiBlack = Color(0xff404040);
-  static const Color whGrey = Color(0xff565656);
+  static const Color whGrey = Color(0xff404040);
   static const Color whBrightGrey = Color(0xff838383);
   static const Color whWhite = Color(0xffFFFFFF);
   static const Color whSemiWhite = Color(0xffEEEEEE);

--- a/lib/common/constants/app_colors.dart
+++ b/lib/common/constants/app_colors.dart
@@ -30,8 +30,8 @@ class CustomColors {
   static const Color whYellow = Color(0xffFFB800);
   static const Color whYellowBright = Color(0xfffadf92);
   static const Color whYellowDark = Color(0xff705100);
-  static const Color whRed = Color(0xffA23333);
-  static const Color whRedBright = Color(0xffDA3A3A);
+  static const Color whRed = Color(0xffF55748);
+
   static const Color whUnSelectedTextColor = Color(0xffA2A2A2);
   static const Color whSelectedTextColor = Color(0xff000000);
   static const Color whPlaceholderGrey = Color(0xffC3C2C7);

--- a/lib/common/constants/firebase_field_name.dart
+++ b/lib/common/constants/firebase_field_name.dart
@@ -28,7 +28,7 @@ class FirebaseResolutionFieldName {
   static const resolutionShareGroupIdList = 'shareGroupIdList';
   static const resolutionWrittenPostCount = 'writtenPostCount';
   static const resolutionReceivedReactionCount = 'receivedReactionCount';
-  static const resolutionWeekSuccessCount = 'weekSuccessCount';
+  static const resolutionWeekSuccessList = 'weekSuccessList';
 }
 
 @immutable

--- a/lib/common/constants/firebase_field_name.dart
+++ b/lib/common/constants/firebase_field_name.dart
@@ -28,7 +28,8 @@ class FirebaseResolutionFieldName {
   static const resolutionShareGroupIdList = 'shareGroupIdList';
   static const resolutionWrittenPostCount = 'writtenPostCount';
   static const resolutionReceivedReactionCount = 'receivedReactionCount';
-  static const resolutionWeekSuccessList = 'weekSuccessList';
+  static const resolutionWeekSuccessList = 'successWeekMondayList';
+  static const resolutionWeeklyPostcountList = 'weeklyPostCountList';
 }
 
 @immutable

--- a/lib/common/constants/firebase_field_name.dart
+++ b/lib/common/constants/firebase_field_name.dart
@@ -26,6 +26,9 @@ class FirebaseResolutionFieldName {
   static const resolutionIsActive = 'isActive';
   static const resolutionShareFriendIdList = 'shareFriendIdList';
   static const resolutionShareGroupIdList = 'shareGroupIdList';
+  static const resolutionWrittenPostCount = 'writtenPostCount';
+  static const resolutionReceivedReactionCount = 'receivedReactionCount';
+  static const resolutionWeekSuccessCount = 'weekSuccessCount';
 }
 
 @immutable

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -2475,4 +2475,49 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
       );
     }
   }
+
+  @override
+  EitherFuture<void> incrementReceivedReactionCount({
+    required String targetResolutionId,
+  }) async {
+    try {
+      final myUid = getMyUserId();
+
+      final currentPostCount = await firestore
+          .collection(
+            FirebaseCollectionName.getTargetResolutionCollectionName(myUid),
+          )
+          .doc(targetResolutionId)
+          .get()
+          .then(
+            (doc) => doc.data()?[FirebaseResolutionFieldName
+                .resolutionReceivedReactionCount] as int?,
+          );
+
+      if (currentPostCount == null) {
+        return Future(
+          () =>
+              left(const Failure('can\'t get current received reaction count')),
+        );
+      }
+
+      await firestore
+          .collection(
+            FirebaseCollectionName.getTargetResolutionCollectionName(myUid),
+          )
+          .doc(targetResolutionId)
+          .update({
+        FirebaseResolutionFieldName.resolutionReceivedReactionCount:
+            currentPostCount + 1,
+      });
+
+      return Future(() => right(null));
+    } on Exception {
+      return Future(
+        () => left(
+          const Failure('catch error on incrementReceivedReactionCount'),
+        ),
+      );
+    }
+  }
 }

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -2432,4 +2432,47 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
       );
     }
   }
+
+  @override
+  EitherFuture<void> incrementResolutionPostcount({
+    required String targetResolutionId,
+  }) async {
+    try {
+      final myUid = getMyUserId();
+
+      final currentPostCount = await firestore
+          .collection(
+            FirebaseCollectionName.getTargetResolutionCollectionName(myUid),
+          )
+          .doc(targetResolutionId)
+          .get()
+          .then(
+            (doc) => doc.data()?[
+                FirebaseResolutionFieldName.resolutionWrittenPostCount] as int?,
+          );
+
+      if (currentPostCount == null) {
+        return Future(
+          () => left(const Failure('can\'t get current post count')),
+        );
+      }
+
+      await firestore
+          .collection(
+            FirebaseCollectionName.getTargetResolutionCollectionName(myUid),
+          )
+          .doc(targetResolutionId)
+          .update({
+        FirebaseResolutionFieldName.resolutionWrittenPostCount:
+            currentPostCount + 1,
+      });
+
+      return Future(() => right(null));
+    } on Exception {
+      return Future(
+        () =>
+            left(const Failure('catch error on incrementResolutionPostcount')),
+      );
+    }
+  }
 }

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -6,7 +6,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
 import 'package:fpdart/fpdart.dart';
-import 'package:path/path.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/data/datasources/datasources.dart';
 import 'package:wehavit/data/models/firebase_models/group_announcement_model/firebase_group_announcement_model.dart';
@@ -2531,7 +2530,8 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
 
       final resolutionActionPerWeek = await firestore
           .collection(
-              FirebaseCollectionName.getTargetResolutionCollectionName(myUid))
+            FirebaseCollectionName.getTargetResolutionCollectionName(myUid),
+          )
           .doc(targetResolutionId)
           .get()
           .then(
@@ -2625,12 +2625,6 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
         }
         return <int>[];
       });
-
-      if (currentList == null) {
-        return left(
-          const Failure('fail to load current weekly post count list'),
-        );
-      }
 
       currentList[createdDate.weekday - 1] += 1;
 

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -208,4 +208,8 @@ abstract class WehavitDatasource {
   EitherFuture<void> incrementReceivedReactionCount({
     required String targetResolutionId,
   });
+
+  EitherFuture<void> updateWeekSuccessCount({
+    required targetResolutionId,
+  });
 }

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -200,4 +200,8 @@ abstract class WehavitDatasource {
     required String targetResolutionId,
     required ResolutionEntity newEntity,
   });
+
+  EitherFuture<void> incrementResolutionPostcount({
+    required String targetResolutionId,
+  });
 }

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -217,4 +217,9 @@ abstract class WehavitDatasource {
     required String targetResolutionId,
     required DateTime? createdDate,
   });
+
+  EitherFuture<List<ConfirmPostEntity>> getConfirmPostEntityByDate({
+    required DateTime selectedDate,
+    required String targetResolutionId,
+  });
 }

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -204,4 +204,8 @@ abstract class WehavitDatasource {
   EitherFuture<void> incrementResolutionPostcount({
     required String targetResolutionId,
   });
+
+  EitherFuture<void> incrementReceivedReactionCount({
+    required String targetResolutionId,
+  });
 }

--- a/lib/data/datasources/wehavit_datasource.dart
+++ b/lib/data/datasources/wehavit_datasource.dart
@@ -212,4 +212,9 @@ abstract class WehavitDatasource {
   EitherFuture<void> updateWeekSuccessCount({
     required targetResolutionId,
   });
+
+  EitherFuture<void> updateWeeklyPostCount({
+    required String targetResolutionId,
+    required DateTime? createdDate,
+  });
 }

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
@@ -22,7 +22,7 @@ class FirebaseResolutionModel with _$FirebaseResolutionModel {
     required List<String>? shareGroupIdList,
     required int? writtenPostCount,
     required int? receivedReactionCount,
-    @TimestampConverter() required List<DateTime>? successWeekList,
+    @TimestampConverter() required List<DateTime>? successWeekMondayList,
   }) = _FirebaseResolutionModel;
 
   factory FirebaseResolutionModel.fromJson(Map<String, dynamic> json) =>
@@ -54,7 +54,7 @@ class FirebaseResolutionModel with _$FirebaseResolutionModel {
             [],
         writtenPostCount: entity.writtenPostCount,
         receivedReactionCount: entity.receivedReactionCount,
-        successWeekList: entity.successWeekList,
+        successWeekMondayList: entity.successWeekMondayList,
       );
 }
 
@@ -78,7 +78,7 @@ extension ConvertFirebaseResolutionModel on FirebaseResolutionModel {
       shareGroupEntityList: shareGroupEntityList,
       writtenPostCount: writtenPostCount,
       receivedReactionCount: receivedReactionCount,
-      successWeekList: successWeekList,
+      successWeekMondayList: successWeekMondayList,
     );
   }
 }

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
@@ -23,6 +23,7 @@ class FirebaseResolutionModel with _$FirebaseResolutionModel {
     required int? writtenPostCount,
     required int? receivedReactionCount,
     @TimestampConverter() required List<DateTime>? successWeekMondayList,
+    required List<int>? weeklyPostCountList,
   }) = _FirebaseResolutionModel;
 
   factory FirebaseResolutionModel.fromJson(Map<String, dynamic> json) =>
@@ -55,6 +56,7 @@ class FirebaseResolutionModel with _$FirebaseResolutionModel {
         writtenPostCount: entity.writtenPostCount,
         receivedReactionCount: entity.receivedReactionCount,
         successWeekMondayList: entity.successWeekMondayList,
+        weeklyPostCountList: entity.weeklyPostCountList,
       );
 }
 
@@ -79,6 +81,7 @@ extension ConvertFirebaseResolutionModel on FirebaseResolutionModel {
       writtenPostCount: writtenPostCount,
       receivedReactionCount: receivedReactionCount,
       successWeekMondayList: successWeekMondayList,
+      weeklyPostCountList: weeklyPostCountList,
     );
   }
 }

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.dart
@@ -20,6 +20,9 @@ class FirebaseResolutionModel with _$FirebaseResolutionModel {
     @TimestampConverter() required DateTime? startDate,
     required List<String>? shareFriendIdList,
     required List<String>? shareGroupIdList,
+    required int? writtenPostCount,
+    required int? receivedReactionCount,
+    @TimestampConverter() required List<DateTime>? successWeekList,
   }) = _FirebaseResolutionModel;
 
   factory FirebaseResolutionModel.fromJson(Map<String, dynamic> json) =>
@@ -49,6 +52,9 @@ class FirebaseResolutionModel with _$FirebaseResolutionModel {
                 ?.map((groupEntity) => groupEntity.groupId)
                 .toList() ??
             [],
+        writtenPostCount: entity.writtenPostCount,
+        receivedReactionCount: entity.receivedReactionCount,
+        successWeekList: entity.successWeekList,
       );
 }
 
@@ -70,6 +76,9 @@ extension ConvertFirebaseResolutionModel on FirebaseResolutionModel {
       startDate: startDate,
       shareFriendEntityList: shareFriendEntityList,
       shareGroupEntityList: shareGroupEntityList,
+      writtenPostCount: writtenPostCount,
+      receivedReactionCount: receivedReactionCount,
+      successWeekList: successWeekList,
     );
   }
 }

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.freezed.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.freezed.dart
@@ -37,6 +37,7 @@ mixin _$FirebaseResolutionModel {
   @TimestampConverter()
   List<DateTime>? get successWeekMondayList =>
       throw _privateConstructorUsedError;
+  List<int>? get weeklyPostCountList => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -63,7 +64,8 @@ abstract class $FirebaseResolutionModelCopyWith<$Res> {
       List<String>? shareGroupIdList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      @TimestampConverter() List<DateTime>? successWeekMondayList});
+      @TimestampConverter() List<DateTime>? successWeekMondayList,
+      List<int>? weeklyPostCountList});
 }
 
 /// @nodoc
@@ -93,6 +95,7 @@ class _$FirebaseResolutionModelCopyWithImpl<$Res,
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
     Object? successWeekMondayList = freezed,
+    Object? weeklyPostCountList = freezed,
   }) {
     return _then(_value.copyWith(
       resolutionName: freezed == resolutionName
@@ -147,6 +150,10 @@ class _$FirebaseResolutionModelCopyWithImpl<$Res,
           ? _value.successWeekMondayList
           : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
+      weeklyPostCountList: freezed == weeklyPostCountList
+          ? _value.weeklyPostCountList
+          : weeklyPostCountList // ignore: cast_nullable_to_non_nullable
+              as List<int>?,
     ) as $Val);
   }
 }
@@ -173,7 +180,8 @@ abstract class _$$FirebaseResolutionModelImplCopyWith<$Res>
       List<String>? shareGroupIdList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      @TimestampConverter() List<DateTime>? successWeekMondayList});
+      @TimestampConverter() List<DateTime>? successWeekMondayList,
+      List<int>? weeklyPostCountList});
 }
 
 /// @nodoc
@@ -202,6 +210,7 @@ class __$$FirebaseResolutionModelImplCopyWithImpl<$Res>
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
     Object? successWeekMondayList = freezed,
+    Object? weeklyPostCountList = freezed,
   }) {
     return _then(_$FirebaseResolutionModelImpl(
       resolutionName: freezed == resolutionName
@@ -256,6 +265,10 @@ class __$$FirebaseResolutionModelImplCopyWithImpl<$Res>
           ? _value._successWeekMondayList
           : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
+      weeklyPostCountList: freezed == weeklyPostCountList
+          ? _value._weeklyPostCountList
+          : weeklyPostCountList // ignore: cast_nullable_to_non_nullable
+              as List<int>?,
     ));
   }
 }
@@ -278,10 +291,12 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
       required this.writtenPostCount,
       required this.receivedReactionCount,
       @TimestampConverter()
-      required final List<DateTime>? successWeekMondayList})
+      required final List<DateTime>? successWeekMondayList,
+      required final List<int>? weeklyPostCountList})
       : _shareFriendIdList = shareFriendIdList,
         _shareGroupIdList = shareGroupIdList,
-        _successWeekMondayList = successWeekMondayList;
+        _successWeekMondayList = successWeekMondayList,
+        _weeklyPostCountList = weeklyPostCountList;
 
   factory _$FirebaseResolutionModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$FirebaseResolutionModelImplFromJson(json);
@@ -341,9 +356,20 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
     return EqualUnmodifiableListView(value);
   }
 
+  final List<int>? _weeklyPostCountList;
+  @override
+  List<int>? get weeklyPostCountList {
+    final value = _weeklyPostCountList;
+    if (value == null) return null;
+    if (_weeklyPostCountList is EqualUnmodifiableListView)
+      return _weeklyPostCountList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
   @override
   String toString() {
-    return 'FirebaseResolutionModel(resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, colorIndex: $colorIndex, iconIndex: $iconIndex, actionPerWeek: $actionPerWeek, startDate: $startDate, shareFriendIdList: $shareFriendIdList, shareGroupIdList: $shareGroupIdList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekMondayList: $successWeekMondayList)';
+    return 'FirebaseResolutionModel(resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, colorIndex: $colorIndex, iconIndex: $iconIndex, actionPerWeek: $actionPerWeek, startDate: $startDate, shareFriendIdList: $shareFriendIdList, shareGroupIdList: $shareGroupIdList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekMondayList: $successWeekMondayList, weeklyPostCountList: $weeklyPostCountList)';
   }
 
   @override
@@ -376,7 +402,9 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
             (identical(other.receivedReactionCount, receivedReactionCount) ||
                 other.receivedReactionCount == receivedReactionCount) &&
             const DeepCollectionEquality()
-                .equals(other._successWeekMondayList, _successWeekMondayList));
+                .equals(other._successWeekMondayList, _successWeekMondayList) &&
+            const DeepCollectionEquality()
+                .equals(other._weeklyPostCountList, _weeklyPostCountList));
   }
 
   @JsonKey(ignore: true)
@@ -395,7 +423,8 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
       const DeepCollectionEquality().hash(_shareGroupIdList),
       writtenPostCount,
       receivedReactionCount,
-      const DeepCollectionEquality().hash(_successWeekMondayList));
+      const DeepCollectionEquality().hash(_successWeekMondayList),
+      const DeepCollectionEquality().hash(_weeklyPostCountList));
 
   @JsonKey(ignore: true)
   @override
@@ -427,7 +456,8 @@ abstract class _FirebaseResolutionModel implements FirebaseResolutionModel {
           required final int? writtenPostCount,
           required final int? receivedReactionCount,
           @TimestampConverter()
-          required final List<DateTime>? successWeekMondayList}) =
+          required final List<DateTime>? successWeekMondayList,
+          required final List<int>? weeklyPostCountList}) =
       _$FirebaseResolutionModelImpl;
 
   factory _FirebaseResolutionModel.fromJson(Map<String, dynamic> json) =
@@ -461,6 +491,8 @@ abstract class _FirebaseResolutionModel implements FirebaseResolutionModel {
   @override
   @TimestampConverter()
   List<DateTime>? get successWeekMondayList;
+  @override
+  List<int>? get weeklyPostCountList;
   @override
   @JsonKey(ignore: true)
   _$$FirebaseResolutionModelImplCopyWith<_$FirebaseResolutionModelImpl>

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.freezed.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.freezed.dart
@@ -35,7 +35,8 @@ mixin _$FirebaseResolutionModel {
   int? get writtenPostCount => throw _privateConstructorUsedError;
   int? get receivedReactionCount => throw _privateConstructorUsedError;
   @TimestampConverter()
-  List<DateTime>? get successWeekList => throw _privateConstructorUsedError;
+  List<DateTime>? get successWeekMondayList =>
+      throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -62,7 +63,7 @@ abstract class $FirebaseResolutionModelCopyWith<$Res> {
       List<String>? shareGroupIdList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      @TimestampConverter() List<DateTime>? successWeekList});
+      @TimestampConverter() List<DateTime>? successWeekMondayList});
 }
 
 /// @nodoc
@@ -91,7 +92,7 @@ class _$FirebaseResolutionModelCopyWithImpl<$Res,
     Object? shareGroupIdList = freezed,
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
-    Object? successWeekList = freezed,
+    Object? successWeekMondayList = freezed,
   }) {
     return _then(_value.copyWith(
       resolutionName: freezed == resolutionName
@@ -142,9 +143,9 @@ class _$FirebaseResolutionModelCopyWithImpl<$Res,
           ? _value.receivedReactionCount
           : receivedReactionCount // ignore: cast_nullable_to_non_nullable
               as int?,
-      successWeekList: freezed == successWeekList
-          ? _value.successWeekList
-          : successWeekList // ignore: cast_nullable_to_non_nullable
+      successWeekMondayList: freezed == successWeekMondayList
+          ? _value.successWeekMondayList
+          : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
     ) as $Val);
   }
@@ -172,7 +173,7 @@ abstract class _$$FirebaseResolutionModelImplCopyWith<$Res>
       List<String>? shareGroupIdList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      @TimestampConverter() List<DateTime>? successWeekList});
+      @TimestampConverter() List<DateTime>? successWeekMondayList});
 }
 
 /// @nodoc
@@ -200,7 +201,7 @@ class __$$FirebaseResolutionModelImplCopyWithImpl<$Res>
     Object? shareGroupIdList = freezed,
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
-    Object? successWeekList = freezed,
+    Object? successWeekMondayList = freezed,
   }) {
     return _then(_$FirebaseResolutionModelImpl(
       resolutionName: freezed == resolutionName
@@ -251,9 +252,9 @@ class __$$FirebaseResolutionModelImplCopyWithImpl<$Res>
           ? _value.receivedReactionCount
           : receivedReactionCount // ignore: cast_nullable_to_non_nullable
               as int?,
-      successWeekList: freezed == successWeekList
-          ? _value._successWeekList
-          : successWeekList // ignore: cast_nullable_to_non_nullable
+      successWeekMondayList: freezed == successWeekMondayList
+          ? _value._successWeekMondayList
+          : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
     ));
   }
@@ -276,10 +277,11 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
       required final List<String>? shareGroupIdList,
       required this.writtenPostCount,
       required this.receivedReactionCount,
-      @TimestampConverter() required final List<DateTime>? successWeekList})
+      @TimestampConverter()
+      required final List<DateTime>? successWeekMondayList})
       : _shareFriendIdList = shareFriendIdList,
         _shareGroupIdList = shareGroupIdList,
-        _successWeekList = successWeekList;
+        _successWeekMondayList = successWeekMondayList;
 
   factory _$FirebaseResolutionModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$FirebaseResolutionModelImplFromJson(json);
@@ -327,20 +329,21 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
   final int? writtenPostCount;
   @override
   final int? receivedReactionCount;
-  final List<DateTime>? _successWeekList;
+  final List<DateTime>? _successWeekMondayList;
   @override
   @TimestampConverter()
-  List<DateTime>? get successWeekList {
-    final value = _successWeekList;
+  List<DateTime>? get successWeekMondayList {
+    final value = _successWeekMondayList;
     if (value == null) return null;
-    if (_successWeekList is EqualUnmodifiableListView) return _successWeekList;
+    if (_successWeekMondayList is EqualUnmodifiableListView)
+      return _successWeekMondayList;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
 
   @override
   String toString() {
-    return 'FirebaseResolutionModel(resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, colorIndex: $colorIndex, iconIndex: $iconIndex, actionPerWeek: $actionPerWeek, startDate: $startDate, shareFriendIdList: $shareFriendIdList, shareGroupIdList: $shareGroupIdList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekList: $successWeekList)';
+    return 'FirebaseResolutionModel(resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, colorIndex: $colorIndex, iconIndex: $iconIndex, actionPerWeek: $actionPerWeek, startDate: $startDate, shareFriendIdList: $shareFriendIdList, shareGroupIdList: $shareGroupIdList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekMondayList: $successWeekMondayList)';
   }
 
   @override
@@ -373,7 +376,7 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
             (identical(other.receivedReactionCount, receivedReactionCount) ||
                 other.receivedReactionCount == receivedReactionCount) &&
             const DeepCollectionEquality()
-                .equals(other._successWeekList, _successWeekList));
+                .equals(other._successWeekMondayList, _successWeekMondayList));
   }
 
   @JsonKey(ignore: true)
@@ -392,7 +395,7 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
       const DeepCollectionEquality().hash(_shareGroupIdList),
       writtenPostCount,
       receivedReactionCount,
-      const DeepCollectionEquality().hash(_successWeekList));
+      const DeepCollectionEquality().hash(_successWeekMondayList));
 
   @JsonKey(ignore: true)
   @override
@@ -424,7 +427,7 @@ abstract class _FirebaseResolutionModel implements FirebaseResolutionModel {
           required final int? writtenPostCount,
           required final int? receivedReactionCount,
           @TimestampConverter()
-          required final List<DateTime>? successWeekList}) =
+          required final List<DateTime>? successWeekMondayList}) =
       _$FirebaseResolutionModelImpl;
 
   factory _FirebaseResolutionModel.fromJson(Map<String, dynamic> json) =
@@ -457,7 +460,7 @@ abstract class _FirebaseResolutionModel implements FirebaseResolutionModel {
   int? get receivedReactionCount;
   @override
   @TimestampConverter()
-  List<DateTime>? get successWeekList;
+  List<DateTime>? get successWeekMondayList;
   @override
   @JsonKey(ignore: true)
   _$$FirebaseResolutionModelImplCopyWith<_$FirebaseResolutionModelImpl>

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.freezed.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.freezed.dart
@@ -32,6 +32,10 @@ mixin _$FirebaseResolutionModel {
   DateTime? get startDate => throw _privateConstructorUsedError;
   List<String>? get shareFriendIdList => throw _privateConstructorUsedError;
   List<String>? get shareGroupIdList => throw _privateConstructorUsedError;
+  int? get writtenPostCount => throw _privateConstructorUsedError;
+  int? get receivedReactionCount => throw _privateConstructorUsedError;
+  @TimestampConverter()
+  List<DateTime>? get successWeekList => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -55,7 +59,10 @@ abstract class $FirebaseResolutionModelCopyWith<$Res> {
       int? actionPerWeek,
       @TimestampConverter() DateTime? startDate,
       List<String>? shareFriendIdList,
-      List<String>? shareGroupIdList});
+      List<String>? shareGroupIdList,
+      int? writtenPostCount,
+      int? receivedReactionCount,
+      @TimestampConverter() List<DateTime>? successWeekList});
 }
 
 /// @nodoc
@@ -82,6 +89,9 @@ class _$FirebaseResolutionModelCopyWithImpl<$Res,
     Object? startDate = freezed,
     Object? shareFriendIdList = freezed,
     Object? shareGroupIdList = freezed,
+    Object? writtenPostCount = freezed,
+    Object? receivedReactionCount = freezed,
+    Object? successWeekList = freezed,
   }) {
     return _then(_value.copyWith(
       resolutionName: freezed == resolutionName
@@ -124,6 +134,18 @@ class _$FirebaseResolutionModelCopyWithImpl<$Res,
           ? _value.shareGroupIdList
           : shareGroupIdList // ignore: cast_nullable_to_non_nullable
               as List<String>?,
+      writtenPostCount: freezed == writtenPostCount
+          ? _value.writtenPostCount
+          : writtenPostCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      receivedReactionCount: freezed == receivedReactionCount
+          ? _value.receivedReactionCount
+          : receivedReactionCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      successWeekList: freezed == successWeekList
+          ? _value.successWeekList
+          : successWeekList // ignore: cast_nullable_to_non_nullable
+              as List<DateTime>?,
     ) as $Val);
   }
 }
@@ -147,7 +169,10 @@ abstract class _$$FirebaseResolutionModelImplCopyWith<$Res>
       int? actionPerWeek,
       @TimestampConverter() DateTime? startDate,
       List<String>? shareFriendIdList,
-      List<String>? shareGroupIdList});
+      List<String>? shareGroupIdList,
+      int? writtenPostCount,
+      int? receivedReactionCount,
+      @TimestampConverter() List<DateTime>? successWeekList});
 }
 
 /// @nodoc
@@ -173,6 +198,9 @@ class __$$FirebaseResolutionModelImplCopyWithImpl<$Res>
     Object? startDate = freezed,
     Object? shareFriendIdList = freezed,
     Object? shareGroupIdList = freezed,
+    Object? writtenPostCount = freezed,
+    Object? receivedReactionCount = freezed,
+    Object? successWeekList = freezed,
   }) {
     return _then(_$FirebaseResolutionModelImpl(
       resolutionName: freezed == resolutionName
@@ -215,6 +243,18 @@ class __$$FirebaseResolutionModelImplCopyWithImpl<$Res>
           ? _value._shareGroupIdList
           : shareGroupIdList // ignore: cast_nullable_to_non_nullable
               as List<String>?,
+      writtenPostCount: freezed == writtenPostCount
+          ? _value.writtenPostCount
+          : writtenPostCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      receivedReactionCount: freezed == receivedReactionCount
+          ? _value.receivedReactionCount
+          : receivedReactionCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      successWeekList: freezed == successWeekList
+          ? _value._successWeekList
+          : successWeekList // ignore: cast_nullable_to_non_nullable
+              as List<DateTime>?,
     ));
   }
 }
@@ -233,9 +273,13 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
       required this.actionPerWeek,
       @TimestampConverter() required this.startDate,
       required final List<String>? shareFriendIdList,
-      required final List<String>? shareGroupIdList})
+      required final List<String>? shareGroupIdList,
+      required this.writtenPostCount,
+      required this.receivedReactionCount,
+      @TimestampConverter() required final List<DateTime>? successWeekList})
       : _shareFriendIdList = shareFriendIdList,
-        _shareGroupIdList = shareGroupIdList;
+        _shareGroupIdList = shareGroupIdList,
+        _successWeekList = successWeekList;
 
   factory _$FirebaseResolutionModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$FirebaseResolutionModelImplFromJson(json);
@@ -280,8 +324,23 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
   }
 
   @override
+  final int? writtenPostCount;
+  @override
+  final int? receivedReactionCount;
+  final List<DateTime>? _successWeekList;
+  @override
+  @TimestampConverter()
+  List<DateTime>? get successWeekList {
+    final value = _successWeekList;
+    if (value == null) return null;
+    if (_successWeekList is EqualUnmodifiableListView) return _successWeekList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
   String toString() {
-    return 'FirebaseResolutionModel(resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, colorIndex: $colorIndex, iconIndex: $iconIndex, actionPerWeek: $actionPerWeek, startDate: $startDate, shareFriendIdList: $shareFriendIdList, shareGroupIdList: $shareGroupIdList)';
+    return 'FirebaseResolutionModel(resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, colorIndex: $colorIndex, iconIndex: $iconIndex, actionPerWeek: $actionPerWeek, startDate: $startDate, shareFriendIdList: $shareFriendIdList, shareGroupIdList: $shareGroupIdList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekList: $successWeekList)';
   }
 
   @override
@@ -308,7 +367,13 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
             const DeepCollectionEquality()
                 .equals(other._shareFriendIdList, _shareFriendIdList) &&
             const DeepCollectionEquality()
-                .equals(other._shareGroupIdList, _shareGroupIdList));
+                .equals(other._shareGroupIdList, _shareGroupIdList) &&
+            (identical(other.writtenPostCount, writtenPostCount) ||
+                other.writtenPostCount == writtenPostCount) &&
+            (identical(other.receivedReactionCount, receivedReactionCount) ||
+                other.receivedReactionCount == receivedReactionCount) &&
+            const DeepCollectionEquality()
+                .equals(other._successWeekList, _successWeekList));
   }
 
   @JsonKey(ignore: true)
@@ -324,7 +389,10 @@ class _$FirebaseResolutionModelImpl implements _FirebaseResolutionModel {
       actionPerWeek,
       startDate,
       const DeepCollectionEquality().hash(_shareFriendIdList),
-      const DeepCollectionEquality().hash(_shareGroupIdList));
+      const DeepCollectionEquality().hash(_shareGroupIdList),
+      writtenPostCount,
+      receivedReactionCount,
+      const DeepCollectionEquality().hash(_successWeekList));
 
   @JsonKey(ignore: true)
   @override
@@ -352,7 +420,11 @@ abstract class _FirebaseResolutionModel implements FirebaseResolutionModel {
           required final int? actionPerWeek,
           @TimestampConverter() required final DateTime? startDate,
           required final List<String>? shareFriendIdList,
-          required final List<String>? shareGroupIdList}) =
+          required final List<String>? shareGroupIdList,
+          required final int? writtenPostCount,
+          required final int? receivedReactionCount,
+          @TimestampConverter()
+          required final List<DateTime>? successWeekList}) =
       _$FirebaseResolutionModelImpl;
 
   factory _FirebaseResolutionModel.fromJson(Map<String, dynamic> json) =
@@ -379,6 +451,13 @@ abstract class _FirebaseResolutionModel implements FirebaseResolutionModel {
   List<String>? get shareFriendIdList;
   @override
   List<String>? get shareGroupIdList;
+  @override
+  int? get writtenPostCount;
+  @override
+  int? get receivedReactionCount;
+  @override
+  @TimestampConverter()
+  List<DateTime>? get successWeekList;
   @override
   @JsonKey(ignore: true)
   _$$FirebaseResolutionModelImplCopyWith<_$FirebaseResolutionModelImpl>

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.g.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.g.dart
@@ -24,6 +24,11 @@ _$FirebaseResolutionModelImpl _$$FirebaseResolutionModelImplFromJson(
       shareGroupIdList: (json['shareGroupIdList'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      writtenPostCount: (json['writtenPostCount'] as num?)?.toInt(),
+      receivedReactionCount: (json['receivedReactionCount'] as num?)?.toInt(),
+      successWeekList: (json['successWeekList'] as List<dynamic>?)
+          ?.map((e) => const TimestampConverter().fromJson(e as Timestamp))
+          .toList(),
     );
 
 Map<String, dynamic> _$$FirebaseResolutionModelImplToJson(
@@ -40,6 +45,11 @@ Map<String, dynamic> _$$FirebaseResolutionModelImplToJson(
           instance.startDate, const TimestampConverter().toJson),
       'shareFriendIdList': instance.shareFriendIdList,
       'shareGroupIdList': instance.shareGroupIdList,
+      'writtenPostCount': instance.writtenPostCount,
+      'receivedReactionCount': instance.receivedReactionCount,
+      'successWeekList': instance.successWeekList
+          ?.map(const TimestampConverter().toJson)
+          .toList(),
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.g.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.g.dart
@@ -29,6 +29,9 @@ _$FirebaseResolutionModelImpl _$$FirebaseResolutionModelImplFromJson(
       successWeekMondayList: (json['successWeekMondayList'] as List<dynamic>?)
           ?.map((e) => const TimestampConverter().fromJson(e as Timestamp))
           .toList(),
+      weeklyPostCountList: (json['weeklyPostCountList'] as List<dynamic>?)
+          ?.map((e) => (e as num).toInt())
+          .toList(),
     );
 
 Map<String, dynamic> _$$FirebaseResolutionModelImplToJson(
@@ -50,6 +53,7 @@ Map<String, dynamic> _$$FirebaseResolutionModelImplToJson(
       'successWeekMondayList': instance.successWeekMondayList
           ?.map(const TimestampConverter().toJson)
           .toList(),
+      'weeklyPostCountList': instance.weeklyPostCountList,
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.g.dart
+++ b/lib/data/models/firebase_models/resolution_model/firebase_resolution_model.g.dart
@@ -26,7 +26,7 @@ _$FirebaseResolutionModelImpl _$$FirebaseResolutionModelImplFromJson(
           .toList(),
       writtenPostCount: (json['writtenPostCount'] as num?)?.toInt(),
       receivedReactionCount: (json['receivedReactionCount'] as num?)?.toInt(),
-      successWeekList: (json['successWeekList'] as List<dynamic>?)
+      successWeekMondayList: (json['successWeekMondayList'] as List<dynamic>?)
           ?.map((e) => const TimestampConverter().fromJson(e as Timestamp))
           .toList(),
     );
@@ -47,7 +47,7 @@ Map<String, dynamic> _$$FirebaseResolutionModelImplToJson(
       'shareGroupIdList': instance.shareGroupIdList,
       'writtenPostCount': instance.writtenPostCount,
       'receivedReactionCount': instance.receivedReactionCount,
-      'successWeekList': instance.successWeekList
+      'successWeekMondayList': instance.successWeekMondayList
           ?.map(const TimestampConverter().toJson)
           .toList(),
     };

--- a/lib/data/repositories/confirm_post_repository_impl.dart
+++ b/lib/data/repositories/confirm_post_repository_impl.dart
@@ -140,4 +140,15 @@ class ConfirmPostRepositoryImpl implements ConfirmPostRepository {
       selectedDate,
     );
   }
+
+  @override
+  EitherFuture<List<ConfirmPostEntity>> getConfirmPostEntityByDate({
+    required DateTime selectedDate,
+    required String targetResolutionId,
+  }) {
+    return _wehavitDatasource.getConfirmPostEntityByDate(
+      selectedDate: selectedDate,
+      targetResolutionId: targetResolutionId,
+    );
+  }
 }

--- a/lib/data/repositories/confirm_post_repository_impl.dart
+++ b/lib/data/repositories/confirm_post_repository_impl.dart
@@ -41,6 +41,21 @@ class ConfirmPostRepositoryImpl implements ConfirmPostRepository {
         },
       );
 
+      _wehavitDatasource.incrementUserDataCounter(
+        type: UserIncrementalDataType.post,
+      );
+      _wehavitDatasource.incrementResolutionPostcount(
+        targetResolutionId: resolutionId,
+      );
+      _wehavitDatasource.updateWeekSuccessCount(
+        targetResolutionId: resolutionId,
+      );
+
+      _wehavitDatasource.updateWeeklyPostCount(
+        targetResolutionId: resolutionId,
+        createdDate: confirmPostEntity.createdAt,
+      );
+
       return Future(() => right(true));
     } on FirebaseException catch (e) {
       return left(Failure(e.message ?? 'FirebaseException'));

--- a/lib/data/repositories/resolution_repository_impl.dart
+++ b/lib/data/repositories/resolution_repository_impl.dart
@@ -133,4 +133,13 @@ class ResolutionRepositoryImpl implements ResolutionRepository {
       targetResolutionId: targetResolutionId,
     );
   }
+
+  @override
+  EitherFuture<void> updateWeekSuccessCount({
+    required String targetResolutionId,
+  }) {
+    return _wehavitDatasource.updateWeekSuccessCount(
+      targetResolutionId: targetResolutionId,
+    );
+  }
 }

--- a/lib/data/repositories/resolution_repository_impl.dart
+++ b/lib/data/repositories/resolution_repository_impl.dart
@@ -115,4 +115,13 @@ class ResolutionRepositoryImpl implements ResolutionRepository {
       newEntity: newEntity,
     );
   }
+
+  @override
+  EitherFuture<void> incrementWrittenPostCount({
+    required String targetResolutionId,
+  }) {
+    return _wehavitDatasource.incrementResolutionPostcount(
+      targetResolutionId: targetResolutionId,
+    );
+  }
 }

--- a/lib/data/repositories/resolution_repository_impl.dart
+++ b/lib/data/repositories/resolution_repository_impl.dart
@@ -124,4 +124,13 @@ class ResolutionRepositoryImpl implements ResolutionRepository {
       targetResolutionId: targetResolutionId,
     );
   }
+
+  @override
+  EitherFuture<void> incrementReceivedReactionCount({
+    required String targetResolutionId,
+  }) {
+    return _wehavitDatasource.incrementReceivedReactionCount(
+      targetResolutionId: targetResolutionId,
+    );
+  }
 }

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -429,3 +429,11 @@ final setResolutionDeactiveUsecaseProvider =
   final resolutionRepository = ref.watch(resolutionRepositoryProvider);
   return SetResolutionDeactiveUsecase(resolutionRepository);
 });
+
+final getConfirmPostOfDatetimeFromTargetResolutionUsecaseProvider =
+    Provider<GetConfirmPostOfDatetimeFromTargetResolutionUsecase>((ref) {
+  final confirmPostRepository = ref.watch(confirmPostRepositoryProvider);
+  return GetConfirmPostOfDatetimeFromTargetResolutionUsecase(
+    confirmPostRepository,
+  );
+});

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -69,11 +69,13 @@ final sendQuickShotReactionToConfirmPostUsecaseProvider =
   final reactionRepository = ref.watch(reactionRepositoryProvider);
   final userModelRepository = ref.watch(userModelRepositoryProvider);
   final photoRepository = ref.watch(photoRepositoryProvider);
+  final resolutionRepository = ref.watch(resolutionRepositoryProvider);
 
   return SendQuickShotReactionToConfirmPostUsecase(
     reactionRepository,
     userModelRepository,
     photoRepository,
+    resolutionRepository,
   );
 });
 
@@ -81,9 +83,11 @@ final sendEmojiReactionToConfirmPostUsecaseProvider =
     Provider<SendEmojiReactionToConfirmPostUsecase>((ref) {
   final reactionRepository = ref.watch(reactionRepositoryProvider);
   final userModelRepository = ref.watch(userModelRepositoryProvider);
+  final resolutionRepository = ref.watch(resolutionRepositoryProvider);
   return SendEmojiReactionToConfirmPostUsecase(
     reactionRepository,
     userModelRepository,
+    resolutionRepository,
   );
 });
 
@@ -91,9 +95,11 @@ final sendCommentReactionToConfirmPostUsecaseProvider =
     Provider<SendCommentReactionToConfirmPostUsecase>((ref) {
   final reactionRepository = ref.watch(reactionRepositoryProvider);
   final userModelRepository = ref.watch(userModelRepositoryProvider);
+  final resolutionRepository = ref.watch(resolutionRepositoryProvider);
   return SendCommentReactionToConfirmPostUsecase(
     reactionRepository,
     userModelRepository,
+    resolutionRepository,
   );
 });
 

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -60,6 +60,7 @@ final uploadConfirmPostUseCaseProvider = Provider<UploadConfirmPostUseCase>(
   (ref) => UploadConfirmPostUseCase(
     ref.watch(confirmPostRepositoryProvider),
     ref.watch(userModelRepositoryProvider),
+    ref.watch(resolutionRepositoryProvider),
   ),
 );
 

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -60,7 +60,6 @@ final uploadConfirmPostUseCaseProvider = Provider<UploadConfirmPostUseCase>(
   (ref) => UploadConfirmPostUseCase(
     ref.watch(confirmPostRepositoryProvider),
     ref.watch(userModelRepositoryProvider),
-    ref.watch(resolutionRepositoryProvider),
   ),
 );
 

--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -272,3 +272,13 @@ final friendPostViewModelProvider = StateNotifierProvider.autoDispose<
     sendCommentReactionToConfirmPostUsecase,
   );
 });
+
+final resolutionDetailViewModelProvider = StateNotifierProvider.autoDispose<
+    ResolutionDetailViewModelProvider, ResolutionDetailViewModel>((ref) {
+  final GetConfirmPostListForResolutionIdUsecase
+      getConfirmPostListForResolutionIdUsecase =
+      ref.watch(getConfirmPostListForResolutionIdUsecaseProvider);
+  return ResolutionDetailViewModelProvider(
+    getConfirmPostListForResolutionIdUsecase,
+  );
+});

--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -278,7 +278,11 @@ final resolutionDetailViewModelProvider = StateNotifierProvider.autoDispose<
   final GetConfirmPostListForResolutionIdUsecase
       getConfirmPostListForResolutionIdUsecase =
       ref.watch(getConfirmPostListForResolutionIdUsecaseProvider);
+  final GetConfirmPostOfDatetimeFromTargetResolutionUsecase
+      getConfirmPostOfDatetimeFromTargetResolutionUsecase =
+      ref.watch(getConfirmPostOfDatetimeFromTargetResolutionUsecaseProvider);
   return ResolutionDetailViewModelProvider(
     getConfirmPostListForResolutionIdUsecase,
+    getConfirmPostOfDatetimeFromTargetResolutionUsecase,
   );
 });

--- a/lib/domain/entities/confirm_post_entity/confirm_post_entity.dart
+++ b/lib/domain/entities/confirm_post_entity/confirm_post_entity.dart
@@ -79,3 +79,16 @@ class TimestampConverter implements JsonConverter<DateTime, Timestamp> {
   @override
   Timestamp toJson(DateTime date) => Timestamp.fromDate(date);
 }
+
+extension ConfirmPostEntityDummy on ConfirmPostEntity {
+  static ConfirmPostEntity dummy = ConfirmPostEntity(
+    resolutionGoalStatement: 'dummy goal statement',
+    resolutionId: 'vR3lA2WTqm7wDC4ve1LN',
+    content: 'content',
+    imageUrlList: [],
+    owner: '69dlXoGSBKhzrySuhb8t9MvqzdD3',
+    recentStrike: 3,
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  );
+}

--- a/lib/domain/entities/resolution_entity/resolution_entity.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.dart
@@ -22,6 +22,9 @@ class ResolutionEntity with _$ResolutionEntity {
     DateTime? startDate,
     List<UserDataEntity>? shareFriendEntityList,
     List<GroupEntity>? shareGroupEntityList,
+    int? writtenPostCount,
+    int? receivedReactionCount,
+    List<DateTime>? successWeekList,
   }) = _ResolutionEntity;
 
   factory ResolutionEntity.fromJson(Map<String, dynamic> json) =>

--- a/lib/domain/entities/resolution_entity/resolution_entity.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.dart
@@ -25,6 +25,7 @@ class ResolutionEntity with _$ResolutionEntity {
     int? writtenPostCount,
     int? receivedReactionCount,
     List<DateTime>? successWeekMondayList,
+    List<int>? weeklyPostCountList,
   }) = _ResolutionEntity;
 
   factory ResolutionEntity.fromJson(Map<String, dynamic> json) =>

--- a/lib/domain/entities/resolution_entity/resolution_entity.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.dart
@@ -24,7 +24,7 @@ class ResolutionEntity with _$ResolutionEntity {
     List<GroupEntity>? shareGroupEntityList,
     int? writtenPostCount,
     int? receivedReactionCount,
-    List<DateTime>? successWeekList,
+    List<DateTime>? successWeekMondayList,
   }) = _ResolutionEntity;
 
   factory ResolutionEntity.fromJson(Map<String, dynamic> json) =>

--- a/lib/domain/entities/resolution_entity/resolution_entity.freezed.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.freezed.dart
@@ -37,6 +37,7 @@ mixin _$ResolutionEntity {
   int? get receivedReactionCount => throw _privateConstructorUsedError;
   List<DateTime>? get successWeekMondayList =>
       throw _privateConstructorUsedError;
+  List<int>? get weeklyPostCountList => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -64,7 +65,8 @@ abstract class $ResolutionEntityCopyWith<$Res> {
       List<GroupEntity>? shareGroupEntityList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      List<DateTime>? successWeekMondayList});
+      List<DateTime>? successWeekMondayList,
+      List<int>? weeklyPostCountList});
 }
 
 /// @nodoc
@@ -94,6 +96,7 @@ class _$ResolutionEntityCopyWithImpl<$Res, $Val extends ResolutionEntity>
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
     Object? successWeekMondayList = freezed,
+    Object? weeklyPostCountList = freezed,
   }) {
     return _then(_value.copyWith(
       resolutionId: freezed == resolutionId
@@ -152,6 +155,10 @@ class _$ResolutionEntityCopyWithImpl<$Res, $Val extends ResolutionEntity>
           ? _value.successWeekMondayList
           : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
+      weeklyPostCountList: freezed == weeklyPostCountList
+          ? _value.weeklyPostCountList
+          : weeklyPostCountList // ignore: cast_nullable_to_non_nullable
+              as List<int>?,
     ) as $Val);
   }
 }
@@ -178,7 +185,8 @@ abstract class _$$ResolutionEntityImplCopyWith<$Res>
       List<GroupEntity>? shareGroupEntityList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      List<DateTime>? successWeekMondayList});
+      List<DateTime>? successWeekMondayList,
+      List<int>? weeklyPostCountList});
 }
 
 /// @nodoc
@@ -206,6 +214,7 @@ class __$$ResolutionEntityImplCopyWithImpl<$Res>
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
     Object? successWeekMondayList = freezed,
+    Object? weeklyPostCountList = freezed,
   }) {
     return _then(_$ResolutionEntityImpl(
       resolutionId: freezed == resolutionId
@@ -264,6 +273,10 @@ class __$$ResolutionEntityImplCopyWithImpl<$Res>
           ? _value._successWeekMondayList
           : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
+      weeklyPostCountList: freezed == weeklyPostCountList
+          ? _value._weeklyPostCountList
+          : weeklyPostCountList // ignore: cast_nullable_to_non_nullable
+              as List<int>?,
     ));
   }
 }
@@ -287,10 +300,12 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
       final List<GroupEntity>? shareGroupEntityList,
       this.writtenPostCount,
       this.receivedReactionCount,
-      final List<DateTime>? successWeekMondayList})
+      final List<DateTime>? successWeekMondayList,
+      final List<int>? weeklyPostCountList})
       : _shareFriendEntityList = shareFriendEntityList,
         _shareGroupEntityList = shareGroupEntityList,
-        _successWeekMondayList = successWeekMondayList;
+        _successWeekMondayList = successWeekMondayList,
+        _weeklyPostCountList = weeklyPostCountList;
 
   factory _$ResolutionEntityImpl.fromJson(Map<String, dynamic> json) =>
       _$$ResolutionEntityImplFromJson(json);
@@ -350,9 +365,20 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
     return EqualUnmodifiableListView(value);
   }
 
+  final List<int>? _weeklyPostCountList;
+  @override
+  List<int>? get weeklyPostCountList {
+    final value = _weeklyPostCountList;
+    if (value == null) return null;
+    if (_weeklyPostCountList is EqualUnmodifiableListView)
+      return _weeklyPostCountList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
   @override
   String toString() {
-    return 'ResolutionEntity(resolutionId: $resolutionId, resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, actionPerWeek: $actionPerWeek, colorIndex: $colorIndex, iconIndex: $iconIndex, startDate: $startDate, shareFriendEntityList: $shareFriendEntityList, shareGroupEntityList: $shareGroupEntityList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekMondayList: $successWeekMondayList)';
+    return 'ResolutionEntity(resolutionId: $resolutionId, resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, actionPerWeek: $actionPerWeek, colorIndex: $colorIndex, iconIndex: $iconIndex, startDate: $startDate, shareFriendEntityList: $shareFriendEntityList, shareGroupEntityList: $shareGroupEntityList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekMondayList: $successWeekMondayList, weeklyPostCountList: $weeklyPostCountList)';
   }
 
   @override
@@ -387,7 +413,9 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
             (identical(other.receivedReactionCount, receivedReactionCount) ||
                 other.receivedReactionCount == receivedReactionCount) &&
             const DeepCollectionEquality()
-                .equals(other._successWeekMondayList, _successWeekMondayList));
+                .equals(other._successWeekMondayList, _successWeekMondayList) &&
+            const DeepCollectionEquality()
+                .equals(other._weeklyPostCountList, _weeklyPostCountList));
   }
 
   @JsonKey(ignore: true)
@@ -407,7 +435,8 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
       const DeepCollectionEquality().hash(_shareGroupEntityList),
       writtenPostCount,
       receivedReactionCount,
-      const DeepCollectionEquality().hash(_successWeekMondayList));
+      const DeepCollectionEquality().hash(_successWeekMondayList),
+      const DeepCollectionEquality().hash(_weeklyPostCountList));
 
   @JsonKey(ignore: true)
   @override
@@ -439,7 +468,8 @@ abstract class _ResolutionEntity implements ResolutionEntity {
       final List<GroupEntity>? shareGroupEntityList,
       final int? writtenPostCount,
       final int? receivedReactionCount,
-      final List<DateTime>? successWeekMondayList}) = _$ResolutionEntityImpl;
+      final List<DateTime>? successWeekMondayList,
+      final List<int>? weeklyPostCountList}) = _$ResolutionEntityImpl;
 
   factory _ResolutionEntity.fromJson(Map<String, dynamic> json) =
       _$ResolutionEntityImpl.fromJson;
@@ -472,6 +502,8 @@ abstract class _ResolutionEntity implements ResolutionEntity {
   int? get receivedReactionCount;
   @override
   List<DateTime>? get successWeekMondayList;
+  @override
+  List<int>? get weeklyPostCountList;
   @override
   @JsonKey(ignore: true)
   _$$ResolutionEntityImplCopyWith<_$ResolutionEntityImpl> get copyWith =>

--- a/lib/domain/entities/resolution_entity/resolution_entity.freezed.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.freezed.dart
@@ -35,7 +35,8 @@ mixin _$ResolutionEntity {
       throw _privateConstructorUsedError;
   int? get writtenPostCount => throw _privateConstructorUsedError;
   int? get receivedReactionCount => throw _privateConstructorUsedError;
-  List<DateTime>? get successWeekList => throw _privateConstructorUsedError;
+  List<DateTime>? get successWeekMondayList =>
+      throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -63,7 +64,7 @@ abstract class $ResolutionEntityCopyWith<$Res> {
       List<GroupEntity>? shareGroupEntityList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      List<DateTime>? successWeekList});
+      List<DateTime>? successWeekMondayList});
 }
 
 /// @nodoc
@@ -92,7 +93,7 @@ class _$ResolutionEntityCopyWithImpl<$Res, $Val extends ResolutionEntity>
     Object? shareGroupEntityList = freezed,
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
-    Object? successWeekList = freezed,
+    Object? successWeekMondayList = freezed,
   }) {
     return _then(_value.copyWith(
       resolutionId: freezed == resolutionId
@@ -147,9 +148,9 @@ class _$ResolutionEntityCopyWithImpl<$Res, $Val extends ResolutionEntity>
           ? _value.receivedReactionCount
           : receivedReactionCount // ignore: cast_nullable_to_non_nullable
               as int?,
-      successWeekList: freezed == successWeekList
-          ? _value.successWeekList
-          : successWeekList // ignore: cast_nullable_to_non_nullable
+      successWeekMondayList: freezed == successWeekMondayList
+          ? _value.successWeekMondayList
+          : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
     ) as $Val);
   }
@@ -177,7 +178,7 @@ abstract class _$$ResolutionEntityImplCopyWith<$Res>
       List<GroupEntity>? shareGroupEntityList,
       int? writtenPostCount,
       int? receivedReactionCount,
-      List<DateTime>? successWeekList});
+      List<DateTime>? successWeekMondayList});
 }
 
 /// @nodoc
@@ -204,7 +205,7 @@ class __$$ResolutionEntityImplCopyWithImpl<$Res>
     Object? shareGroupEntityList = freezed,
     Object? writtenPostCount = freezed,
     Object? receivedReactionCount = freezed,
-    Object? successWeekList = freezed,
+    Object? successWeekMondayList = freezed,
   }) {
     return _then(_$ResolutionEntityImpl(
       resolutionId: freezed == resolutionId
@@ -259,9 +260,9 @@ class __$$ResolutionEntityImplCopyWithImpl<$Res>
           ? _value.receivedReactionCount
           : receivedReactionCount // ignore: cast_nullable_to_non_nullable
               as int?,
-      successWeekList: freezed == successWeekList
-          ? _value._successWeekList
-          : successWeekList // ignore: cast_nullable_to_non_nullable
+      successWeekMondayList: freezed == successWeekMondayList
+          ? _value._successWeekMondayList
+          : successWeekMondayList // ignore: cast_nullable_to_non_nullable
               as List<DateTime>?,
     ));
   }
@@ -286,10 +287,10 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
       final List<GroupEntity>? shareGroupEntityList,
       this.writtenPostCount,
       this.receivedReactionCount,
-      final List<DateTime>? successWeekList})
+      final List<DateTime>? successWeekMondayList})
       : _shareFriendEntityList = shareFriendEntityList,
         _shareGroupEntityList = shareGroupEntityList,
-        _successWeekList = successWeekList;
+        _successWeekMondayList = successWeekMondayList;
 
   factory _$ResolutionEntityImpl.fromJson(Map<String, dynamic> json) =>
       _$$ResolutionEntityImplFromJson(json);
@@ -338,19 +339,20 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
   final int? writtenPostCount;
   @override
   final int? receivedReactionCount;
-  final List<DateTime>? _successWeekList;
+  final List<DateTime>? _successWeekMondayList;
   @override
-  List<DateTime>? get successWeekList {
-    final value = _successWeekList;
+  List<DateTime>? get successWeekMondayList {
+    final value = _successWeekMondayList;
     if (value == null) return null;
-    if (_successWeekList is EqualUnmodifiableListView) return _successWeekList;
+    if (_successWeekMondayList is EqualUnmodifiableListView)
+      return _successWeekMondayList;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
 
   @override
   String toString() {
-    return 'ResolutionEntity(resolutionId: $resolutionId, resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, actionPerWeek: $actionPerWeek, colorIndex: $colorIndex, iconIndex: $iconIndex, startDate: $startDate, shareFriendEntityList: $shareFriendEntityList, shareGroupEntityList: $shareGroupEntityList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekList: $successWeekList)';
+    return 'ResolutionEntity(resolutionId: $resolutionId, resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, actionPerWeek: $actionPerWeek, colorIndex: $colorIndex, iconIndex: $iconIndex, startDate: $startDate, shareFriendEntityList: $shareFriendEntityList, shareGroupEntityList: $shareGroupEntityList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekMondayList: $successWeekMondayList)';
   }
 
   @override
@@ -385,7 +387,7 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
             (identical(other.receivedReactionCount, receivedReactionCount) ||
                 other.receivedReactionCount == receivedReactionCount) &&
             const DeepCollectionEquality()
-                .equals(other._successWeekList, _successWeekList));
+                .equals(other._successWeekMondayList, _successWeekMondayList));
   }
 
   @JsonKey(ignore: true)
@@ -405,7 +407,7 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
       const DeepCollectionEquality().hash(_shareGroupEntityList),
       writtenPostCount,
       receivedReactionCount,
-      const DeepCollectionEquality().hash(_successWeekList));
+      const DeepCollectionEquality().hash(_successWeekMondayList));
 
   @JsonKey(ignore: true)
   @override
@@ -437,7 +439,7 @@ abstract class _ResolutionEntity implements ResolutionEntity {
       final List<GroupEntity>? shareGroupEntityList,
       final int? writtenPostCount,
       final int? receivedReactionCount,
-      final List<DateTime>? successWeekList}) = _$ResolutionEntityImpl;
+      final List<DateTime>? successWeekMondayList}) = _$ResolutionEntityImpl;
 
   factory _ResolutionEntity.fromJson(Map<String, dynamic> json) =
       _$ResolutionEntityImpl.fromJson;
@@ -469,7 +471,7 @@ abstract class _ResolutionEntity implements ResolutionEntity {
   @override
   int? get receivedReactionCount;
   @override
-  List<DateTime>? get successWeekList;
+  List<DateTime>? get successWeekMondayList;
   @override
   @JsonKey(ignore: true)
   _$$ResolutionEntityImplCopyWith<_$ResolutionEntityImpl> get copyWith =>

--- a/lib/domain/entities/resolution_entity/resolution_entity.freezed.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.freezed.dart
@@ -33,6 +33,9 @@ mixin _$ResolutionEntity {
       throw _privateConstructorUsedError;
   List<GroupEntity>? get shareGroupEntityList =>
       throw _privateConstructorUsedError;
+  int? get writtenPostCount => throw _privateConstructorUsedError;
+  int? get receivedReactionCount => throw _privateConstructorUsedError;
+  List<DateTime>? get successWeekList => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -57,7 +60,10 @@ abstract class $ResolutionEntityCopyWith<$Res> {
       int? iconIndex,
       DateTime? startDate,
       List<UserDataEntity>? shareFriendEntityList,
-      List<GroupEntity>? shareGroupEntityList});
+      List<GroupEntity>? shareGroupEntityList,
+      int? writtenPostCount,
+      int? receivedReactionCount,
+      List<DateTime>? successWeekList});
 }
 
 /// @nodoc
@@ -84,6 +90,9 @@ class _$ResolutionEntityCopyWithImpl<$Res, $Val extends ResolutionEntity>
     Object? startDate = freezed,
     Object? shareFriendEntityList = freezed,
     Object? shareGroupEntityList = freezed,
+    Object? writtenPostCount = freezed,
+    Object? receivedReactionCount = freezed,
+    Object? successWeekList = freezed,
   }) {
     return _then(_value.copyWith(
       resolutionId: freezed == resolutionId
@@ -130,6 +139,18 @@ class _$ResolutionEntityCopyWithImpl<$Res, $Val extends ResolutionEntity>
           ? _value.shareGroupEntityList
           : shareGroupEntityList // ignore: cast_nullable_to_non_nullable
               as List<GroupEntity>?,
+      writtenPostCount: freezed == writtenPostCount
+          ? _value.writtenPostCount
+          : writtenPostCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      receivedReactionCount: freezed == receivedReactionCount
+          ? _value.receivedReactionCount
+          : receivedReactionCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      successWeekList: freezed == successWeekList
+          ? _value.successWeekList
+          : successWeekList // ignore: cast_nullable_to_non_nullable
+              as List<DateTime>?,
     ) as $Val);
   }
 }
@@ -153,7 +174,10 @@ abstract class _$$ResolutionEntityImplCopyWith<$Res>
       int? iconIndex,
       DateTime? startDate,
       List<UserDataEntity>? shareFriendEntityList,
-      List<GroupEntity>? shareGroupEntityList});
+      List<GroupEntity>? shareGroupEntityList,
+      int? writtenPostCount,
+      int? receivedReactionCount,
+      List<DateTime>? successWeekList});
 }
 
 /// @nodoc
@@ -178,6 +202,9 @@ class __$$ResolutionEntityImplCopyWithImpl<$Res>
     Object? startDate = freezed,
     Object? shareFriendEntityList = freezed,
     Object? shareGroupEntityList = freezed,
+    Object? writtenPostCount = freezed,
+    Object? receivedReactionCount = freezed,
+    Object? successWeekList = freezed,
   }) {
     return _then(_$ResolutionEntityImpl(
       resolutionId: freezed == resolutionId
@@ -224,6 +251,18 @@ class __$$ResolutionEntityImplCopyWithImpl<$Res>
           ? _value._shareGroupEntityList
           : shareGroupEntityList // ignore: cast_nullable_to_non_nullable
               as List<GroupEntity>?,
+      writtenPostCount: freezed == writtenPostCount
+          ? _value.writtenPostCount
+          : writtenPostCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      receivedReactionCount: freezed == receivedReactionCount
+          ? _value.receivedReactionCount
+          : receivedReactionCount // ignore: cast_nullable_to_non_nullable
+              as int?,
+      successWeekList: freezed == successWeekList
+          ? _value._successWeekList
+          : successWeekList // ignore: cast_nullable_to_non_nullable
+              as List<DateTime>?,
     ));
   }
 }
@@ -244,9 +283,13 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
       this.iconIndex,
       this.startDate,
       final List<UserDataEntity>? shareFriendEntityList,
-      final List<GroupEntity>? shareGroupEntityList})
+      final List<GroupEntity>? shareGroupEntityList,
+      this.writtenPostCount,
+      this.receivedReactionCount,
+      final List<DateTime>? successWeekList})
       : _shareFriendEntityList = shareFriendEntityList,
-        _shareGroupEntityList = shareGroupEntityList;
+        _shareGroupEntityList = shareGroupEntityList,
+        _successWeekList = successWeekList;
 
   factory _$ResolutionEntityImpl.fromJson(Map<String, dynamic> json) =>
       _$$ResolutionEntityImplFromJson(json);
@@ -292,8 +335,22 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
   }
 
   @override
+  final int? writtenPostCount;
+  @override
+  final int? receivedReactionCount;
+  final List<DateTime>? _successWeekList;
+  @override
+  List<DateTime>? get successWeekList {
+    final value = _successWeekList;
+    if (value == null) return null;
+    if (_successWeekList is EqualUnmodifiableListView) return _successWeekList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
   String toString() {
-    return 'ResolutionEntity(resolutionId: $resolutionId, resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, actionPerWeek: $actionPerWeek, colorIndex: $colorIndex, iconIndex: $iconIndex, startDate: $startDate, shareFriendEntityList: $shareFriendEntityList, shareGroupEntityList: $shareGroupEntityList)';
+    return 'ResolutionEntity(resolutionId: $resolutionId, resolutionName: $resolutionName, goalStatement: $goalStatement, actionStatement: $actionStatement, isActive: $isActive, actionPerWeek: $actionPerWeek, colorIndex: $colorIndex, iconIndex: $iconIndex, startDate: $startDate, shareFriendEntityList: $shareFriendEntityList, shareGroupEntityList: $shareGroupEntityList, writtenPostCount: $writtenPostCount, receivedReactionCount: $receivedReactionCount, successWeekList: $successWeekList)';
   }
 
   @override
@@ -322,7 +379,13 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
             const DeepCollectionEquality()
                 .equals(other._shareFriendEntityList, _shareFriendEntityList) &&
             const DeepCollectionEquality()
-                .equals(other._shareGroupEntityList, _shareGroupEntityList));
+                .equals(other._shareGroupEntityList, _shareGroupEntityList) &&
+            (identical(other.writtenPostCount, writtenPostCount) ||
+                other.writtenPostCount == writtenPostCount) &&
+            (identical(other.receivedReactionCount, receivedReactionCount) ||
+                other.receivedReactionCount == receivedReactionCount) &&
+            const DeepCollectionEquality()
+                .equals(other._successWeekList, _successWeekList));
   }
 
   @JsonKey(ignore: true)
@@ -339,7 +402,10 @@ class _$ResolutionEntityImpl implements _ResolutionEntity {
       iconIndex,
       startDate,
       const DeepCollectionEquality().hash(_shareFriendEntityList),
-      const DeepCollectionEquality().hash(_shareGroupEntityList));
+      const DeepCollectionEquality().hash(_shareGroupEntityList),
+      writtenPostCount,
+      receivedReactionCount,
+      const DeepCollectionEquality().hash(_successWeekList));
 
   @JsonKey(ignore: true)
   @override
@@ -368,7 +434,10 @@ abstract class _ResolutionEntity implements ResolutionEntity {
       final int? iconIndex,
       final DateTime? startDate,
       final List<UserDataEntity>? shareFriendEntityList,
-      final List<GroupEntity>? shareGroupEntityList}) = _$ResolutionEntityImpl;
+      final List<GroupEntity>? shareGroupEntityList,
+      final int? writtenPostCount,
+      final int? receivedReactionCount,
+      final List<DateTime>? successWeekList}) = _$ResolutionEntityImpl;
 
   factory _ResolutionEntity.fromJson(Map<String, dynamic> json) =
       _$ResolutionEntityImpl.fromJson;
@@ -395,6 +464,12 @@ abstract class _ResolutionEntity implements ResolutionEntity {
   List<UserDataEntity>? get shareFriendEntityList;
   @override
   List<GroupEntity>? get shareGroupEntityList;
+  @override
+  int? get writtenPostCount;
+  @override
+  int? get receivedReactionCount;
+  @override
+  List<DateTime>? get successWeekList;
   @override
   @JsonKey(ignore: true)
   _$$ResolutionEntityImplCopyWith<_$ResolutionEntityImpl> get copyWith =>

--- a/lib/domain/entities/resolution_entity/resolution_entity.g.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.g.dart
@@ -30,6 +30,9 @@ _$ResolutionEntityImpl _$$ResolutionEntityImplFromJson(
       successWeekMondayList: (json['successWeekMondayList'] as List<dynamic>?)
           ?.map((e) => const TimestampConverter().fromJson(e as Timestamp))
           .toList(),
+      weeklyPostCountList: (json['weeklyPostCountList'] as List<dynamic>?)
+          ?.map((e) => (e as num).toInt())
+          .toList(),
     );
 
 Map<String, dynamic> _$$ResolutionEntityImplToJson(
@@ -52,6 +55,7 @@ Map<String, dynamic> _$$ResolutionEntityImplToJson(
       'successWeekMondayList': instance.successWeekMondayList
           ?.map(const TimestampConverter().toJson)
           .toList(),
+      'weeklyPostCountList': instance.weeklyPostCountList,
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/lib/domain/entities/resolution_entity/resolution_entity.g.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.g.dart
@@ -27,7 +27,7 @@ _$ResolutionEntityImpl _$$ResolutionEntityImplFromJson(
           .toList(),
       writtenPostCount: (json['writtenPostCount'] as num?)?.toInt(),
       receivedReactionCount: (json['receivedReactionCount'] as num?)?.toInt(),
-      successWeekList: (json['successWeekList'] as List<dynamic>?)
+      successWeekMondayList: (json['successWeekMondayList'] as List<dynamic>?)
           ?.map((e) => const TimestampConverter().fromJson(e as Timestamp))
           .toList(),
     );
@@ -49,7 +49,7 @@ Map<String, dynamic> _$$ResolutionEntityImplToJson(
       'shareGroupEntityList': instance.shareGroupEntityList,
       'writtenPostCount': instance.writtenPostCount,
       'receivedReactionCount': instance.receivedReactionCount,
-      'successWeekList': instance.successWeekList
+      'successWeekMondayList': instance.successWeekMondayList
           ?.map(const TimestampConverter().toJson)
           .toList(),
     };

--- a/lib/domain/entities/resolution_entity/resolution_entity.g.dart
+++ b/lib/domain/entities/resolution_entity/resolution_entity.g.dart
@@ -25,6 +25,11 @@ _$ResolutionEntityImpl _$$ResolutionEntityImplFromJson(
       shareGroupEntityList: (json['shareGroupEntityList'] as List<dynamic>?)
           ?.map((e) => GroupEntity.fromJson(e as Map<String, dynamic>))
           .toList(),
+      writtenPostCount: (json['writtenPostCount'] as num?)?.toInt(),
+      receivedReactionCount: (json['receivedReactionCount'] as num?)?.toInt(),
+      successWeekList: (json['successWeekList'] as List<dynamic>?)
+          ?.map((e) => const TimestampConverter().fromJson(e as Timestamp))
+          .toList(),
     );
 
 Map<String, dynamic> _$$ResolutionEntityImplToJson(
@@ -42,6 +47,11 @@ Map<String, dynamic> _$$ResolutionEntityImplToJson(
           instance.startDate, const TimestampConverter().toJson),
       'shareFriendEntityList': instance.shareFriendEntityList,
       'shareGroupEntityList': instance.shareGroupEntityList,
+      'writtenPostCount': instance.writtenPostCount,
+      'receivedReactionCount': instance.receivedReactionCount,
+      'successWeekList': instance.successWeekList
+          ?.map(const TimestampConverter().toJson)
+          .toList(),
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/lib/domain/repositories/confirm_post_repository.dart
+++ b/lib/domain/repositories/confirm_post_repository.dart
@@ -7,6 +7,11 @@ abstract class ConfirmPostRepository {
     required String groupId,
   });
 
+  EitherFuture<List<ConfirmPostEntity>> getConfirmPostEntityByDate({
+    required DateTime selectedDate,
+    required String targetResolutionId,
+  });
+
   EitherFuture<List<ConfirmPostEntity>> getConfirmPostEntityListByResolutionId({
     required String resolutionId,
   });

--- a/lib/domain/repositories/resolution_repository.dart
+++ b/lib/domain/repositories/resolution_repository.dart
@@ -50,4 +50,8 @@ abstract class ResolutionRepository {
     required String targetResolutionId,
     required ResolutionEntity newEntity,
   });
+
+  EitherFuture<void> incrementWrittenPostCount({
+    required String targetResolutionId,
+  });
 }

--- a/lib/domain/repositories/resolution_repository.dart
+++ b/lib/domain/repositories/resolution_repository.dart
@@ -54,4 +54,8 @@ abstract class ResolutionRepository {
   EitherFuture<void> incrementWrittenPostCount({
     required String targetResolutionId,
   });
+
+  EitherFuture<void> incrementReceivedReactionCount({
+    required String targetResolutionId,
+  });
 }

--- a/lib/domain/repositories/resolution_repository.dart
+++ b/lib/domain/repositories/resolution_repository.dart
@@ -58,4 +58,8 @@ abstract class ResolutionRepository {
   EitherFuture<void> incrementReceivedReactionCount({
     required String targetResolutionId,
   });
+
+  EitherFuture<void> updateWeekSuccessCount({
+    required String targetResolutionId,
+  });
 }

--- a/lib/domain/usecases/get_confirm_post_of_datetime_from_target_resolution_usecase.dart
+++ b/lib/domain/usecases/get_confirm_post_of_datetime_from_target_resolution_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/repositories/repositories.dart';
+
+class GetConfirmPostOfDatetimeFromTargetResolutionUsecase {
+  GetConfirmPostOfDatetimeFromTargetResolutionUsecase(
+    this._confirmPostRepository,
+  );
+
+  final ConfirmPostRepository _confirmPostRepository;
+
+  EitherFuture<List<ConfirmPostEntity>> call({
+    required String resolutionId,
+    required DateTime targetDateTime,
+  }) {
+    return _confirmPostRepository.getConfirmPostEntityByDate(
+      targetResolutionId: resolutionId,
+      selectedDate: targetDateTime,
+    );
+  }
+}

--- a/lib/domain/usecases/send_comment_reaction_to_confirm_post_usecase.dart
+++ b/lib/domain/usecases/send_comment_reaction_to_confirm_post_usecase.dart
@@ -8,9 +8,11 @@ class SendCommentReactionToConfirmPostUsecase
   SendCommentReactionToConfirmPostUsecase(
     this._reactionRepository,
     this._userModelRepository,
+    this._resolutionRepository,
   );
   final ReactionRepository _reactionRepository;
   final UserModelRepository _userModelRepository;
+  final ResolutionRepository _resolutionRepository;
 
   @override
   EitherFuture<bool> call((ConfirmPostEntity, String) params) async {
@@ -37,6 +39,9 @@ class SendCommentReactionToConfirmPostUsecase
         .whenComplete(() {
       _userModelRepository.incrementUserDataCounter(
         type: UserIncrementalDataType.reaction,
+      );
+      _resolutionRepository.incrementReceivedReactionCount(
+        targetResolutionId: params.$1.resolutionId ?? '',
       );
     });
   }

--- a/lib/domain/usecases/send_emoji_reaction_to_confirm_post_usercase.dart
+++ b/lib/domain/usecases/send_emoji_reaction_to_confirm_post_usercase.dart
@@ -8,9 +8,11 @@ class SendEmojiReactionToConfirmPostUsecase
   SendEmojiReactionToConfirmPostUsecase(
     this._reactionRepository,
     this._userModelRepository,
+    this._resolutionRepository,
   );
   final ReactionRepository _reactionRepository;
   final UserModelRepository _userModelRepository;
+  final ResolutionRepository _resolutionRepository;
 
   @override
   EitherFuture<bool> call((ConfirmPostEntity, List<int>) params) async {
@@ -42,6 +44,9 @@ class SendEmojiReactionToConfirmPostUsecase
         .whenComplete(() {
       _userModelRepository.incrementUserDataCounter(
         type: UserIncrementalDataType.reaction,
+      );
+      _resolutionRepository.incrementReceivedReactionCount(
+        targetResolutionId: params.$1.resolutionId ?? '',
       );
     });
   }

--- a/lib/domain/usecases/send_quickshot_reaction_to_confirm_post_usecase.dart
+++ b/lib/domain/usecases/send_quickshot_reaction_to_confirm_post_usecase.dart
@@ -9,10 +9,12 @@ class SendQuickShotReactionToConfirmPostUsecase
     this._reactionRepository,
     this._userModelRepository,
     this._photoRepository,
+    this._resolutionRepository,
   );
   final ReactionRepository _reactionRepository;
   final UserModelRepository _userModelRepository;
   final PhotoRepository _photoRepository;
+  final ResolutionRepository _resolutionRepository;
 
   @override
   EitherFuture<bool> call((ConfirmPostEntity, String) params) async {
@@ -56,6 +58,9 @@ class SendQuickShotReactionToConfirmPostUsecase
         .whenComplete(() {
       _userModelRepository.incrementUserDataCounter(
         type: UserIncrementalDataType.reaction,
+      );
+      _resolutionRepository.incrementReceivedReactionCount(
+        targetResolutionId: params.$1.resolutionId ?? '',
       );
     });
   }

--- a/lib/domain/usecases/upload_confirm_post_usecase.dart
+++ b/lib/domain/usecases/upload_confirm_post_usecase.dart
@@ -8,10 +8,12 @@ class UploadConfirmPostUseCase {
   UploadConfirmPostUseCase(
     this._confirmPostRepository,
     this._userModelRepository,
+    this._resolutionRepository,
   );
 
   final ConfirmPostRepository _confirmPostRepository;
   final UserModelRepository _userModelRepository;
+  final ResolutionRepository _resolutionRepository;
 
   EitherFuture<bool> call({
     required String resolutionGoalStatement,
@@ -70,6 +72,9 @@ class UploadConfirmPostUseCase {
           .whenComplete(() {
         _userModelRepository.incrementUserDataCounter(
           type: UserIncrementalDataType.post,
+        );
+        _resolutionRepository.incrementWrittenPostCount(
+          targetResolutionId: resolutionId,
         );
       });
     } on Exception catch (e) {

--- a/lib/domain/usecases/upload_confirm_post_usecase.dart
+++ b/lib/domain/usecases/upload_confirm_post_usecase.dart
@@ -69,13 +69,21 @@ class UploadConfirmPostUseCase {
 
       return await _confirmPostRepository
           .createConfirmPost(confirmPost)
-          .whenComplete(() {
-        _userModelRepository.incrementUserDataCounter(
-          type: UserIncrementalDataType.post,
-        );
-        _resolutionRepository.incrementWrittenPostCount(
-          targetResolutionId: resolutionId,
-        );
+          .then((result) {
+        return result.fold((failure) {
+          return left(failure);
+        }, (success) {
+          _userModelRepository.incrementUserDataCounter(
+            type: UserIncrementalDataType.post,
+          );
+          _resolutionRepository.incrementWrittenPostCount(
+            targetResolutionId: resolutionId,
+          );
+          _resolutionRepository.updateWeekSuccessCount(
+            targetResolutionId: resolutionId,
+          );
+          return right(success);
+        });
       });
     } on Exception catch (e) {
       return Future(() => left(Failure(e.toString())));

--- a/lib/domain/usecases/upload_confirm_post_usecase.dart
+++ b/lib/domain/usecases/upload_confirm_post_usecase.dart
@@ -8,12 +8,10 @@ class UploadConfirmPostUseCase {
   UploadConfirmPostUseCase(
     this._confirmPostRepository,
     this._userModelRepository,
-    this._resolutionRepository,
   );
 
   final ConfirmPostRepository _confirmPostRepository;
   final UserModelRepository _userModelRepository;
-  final ResolutionRepository _resolutionRepository;
 
   EitherFuture<bool> call({
     required String resolutionGoalStatement,
@@ -73,15 +71,6 @@ class UploadConfirmPostUseCase {
         return result.fold((failure) {
           return left(failure);
         }, (success) {
-          _userModelRepository.incrementUserDataCounter(
-            type: UserIncrementalDataType.post,
-          );
-          _resolutionRepository.incrementWrittenPostCount(
-            targetResolutionId: resolutionId,
-          );
-          _resolutionRepository.updateWeekSuccessCount(
-            targetResolutionId: resolutionId,
-          );
           return right(success);
         });
       });

--- a/lib/domain/usecases/upload_resolution_usecase.dart
+++ b/lib/domain/usecases/upload_resolution_usecase.dart
@@ -37,7 +37,7 @@ class UploadResolutionUseCase {
       resolutionId: '',
       writtenPostCount: 0,
       receivedReactionCount: 0,
-      successWeekList: [],
+      successWeekMondayList: [],
     );
 
     return _resolutionRepository.uploadResolutionEntity(entity).then(

--- a/lib/domain/usecases/upload_resolution_usecase.dart
+++ b/lib/domain/usecases/upload_resolution_usecase.dart
@@ -38,6 +38,7 @@ class UploadResolutionUseCase {
       writtenPostCount: 0,
       receivedReactionCount: 0,
       successWeekMondayList: [],
+      weeklyPostCountList: List<int>.generate(7, (_) => 0),
     );
 
     return _resolutionRepository.uploadResolutionEntity(entity).then(

--- a/lib/domain/usecases/upload_resolution_usecase.dart
+++ b/lib/domain/usecases/upload_resolution_usecase.dart
@@ -35,6 +35,9 @@ class UploadResolutionUseCase {
       colorIndex: colorIndex,
       iconIndex: iconIndex,
       resolutionId: '',
+      writtenPostCount: 0,
+      receivedReactionCount: 0,
+      successWeekList: [],
     );
 
     return _resolutionRepository.uploadResolutionEntity(entity).then(

--- a/lib/domain/usecases/usecases.dart
+++ b/lib/domain/usecases/usecases.dart
@@ -11,6 +11,7 @@ export 'get_achivement_percentage_for_group_member_usecase.dart';
 export 'get_applied_user_list_for_friend_usecase.dart';
 export 'get_applied_user_list_for_group_entity_usecase.dart';
 export 'get_confirm_post_list_for_resolution_id.dart';
+export 'get_confirm_post_of_datetime_from_target_resolution_usecase.dart';
 export 'get_friend_confirm_post_list_by_date_usecase.dart';
 export 'get_friend_list_usecase.dart';
 export 'get_group_announcement_list_usecase.dart';

--- a/lib/presentation/group_post/provider/group_post_view_model_provider.dart
+++ b/lib/presentation/group_post/provider/group_post_view_model_provider.dart
@@ -74,16 +74,6 @@ class GroupPostViewModelProvider extends StateNotifier<GroupPostViewModel> {
 
   Future<void> changeSelectedDate({required DateTime to}) async {
     state.selectedDate = to;
-
-    // final fetchResult = await _getGroupConfirmPostListByDateUsecase
-    //     .call(state.groupId, to)
-    //     .then((result) => result.fold((failure) => null, (list) => list));
-
-    // if (fetchResult == null) {
-    //   return;
-    // }
-
-    // state.confirmPostList[to] = fetchResult;
   }
 
   void resetSendingEmojis() {

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -265,7 +265,9 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
   }
 
   AnimatedContainer putScrollCalendarWidget(
-      GroupPostViewModel viewModel, GroupPostViewModelProvider provider) {
+    GroupPostViewModel viewModel,
+    GroupPostViewModelProvider provider,
+  ) {
     return AnimatedContainer(
       duration: const Duration(milliseconds: 250),
       curve: Curves.fastOutSlowIn,

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -11,17 +11,18 @@ import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 import 'package:wehavit/presentation/effects/effects.dart';
 import 'package:wehavit/presentation/group_post/group_post.dart';
-import 'package:wehavit/presentation/group_post/view/confirm_post_photo_view.dart';
 
 class ConfirmPostWidget extends ConsumerStatefulWidget {
   const ConfirmPostWidget({
     required this.confirmPostEntity,
     required this.createdDate,
+    this.showReactionToolbar = true,
     super.key,
   });
 
   final ConfirmPostEntity confirmPostEntity;
   final DateTime createdDate;
+  final bool showReactionToolbar;
 
   @override
   ConsumerState<ConfirmPostWidget> createState() => _ConfirmPostWidgetState();
@@ -85,45 +86,47 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                 borderRadius: BorderRadius.all(
                   Radius.circular(16.0),
                 ),
+                border: Border(
+                  top: BorderSide(
+                    width: 8.0,
+                    color: CustomColors.whDarkBlack,
+                    strokeAlign: BorderSide.strokeAlignOutside,
+                  ),
+                  left: BorderSide(
+                    width: 8.0,
+                    color: CustomColors.whDarkBlack,
+                    strokeAlign: BorderSide.strokeAlignOutside,
+                  ),
+                  right: BorderSide(
+                    width: 8.0,
+                    color: CustomColors.whDarkBlack,
+                    strokeAlign: BorderSide.strokeAlignOutside,
+                  ),
+                ),
               ),
-              child: Padding(
-                padding: const EdgeInsets.all(0.0),
-                child: Column(
-                  children: [
-                    Container(
-                      decoration: const BoxDecoration(
-                        color: CustomColors.whGrey,
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(16.0),
-                        ),
-                        border: Border(
-                          top: BorderSide(
-                            width: 8.0,
-                            color: CustomColors.whDarkBlack,
-                          ),
-                          left: BorderSide(
-                            width: 8.0,
-                            color: CustomColors.whDarkBlack,
-                          ),
-                          right: BorderSide(
-                            width: 8.0,
-                            color: CustomColors.whDarkBlack,
-                          ),
-                        ),
-                      ),
-                      padding: const EdgeInsets.only(
-                        left: 8.0,
-                        right: 8.0,
-                        top: 4.0,
-                        bottom: 12.0,
-                      ),
-                      height: 244,
-                      child: const Center(
-                        child: CircularProgressIndicator(
-                          color: CustomColors.whYellow,
-                        ),
+              child: Column(
+                children: [
+                  Container(
+                    decoration: const BoxDecoration(
+                      color: CustomColors.whGrey,
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(16.0),
                       ),
                     ),
+                    padding: const EdgeInsets.only(
+                      left: 8.0,
+                      right: 8.0,
+                      top: 4.0,
+                      bottom: 12.0,
+                    ),
+                    height: 244,
+                    child: const Center(
+                      child: CircularProgressIndicator(
+                        color: CustomColors.whYellow,
+                      ),
+                    ),
+                  ),
+                  if (widget.showReactionToolbar)
                     ConfirmPostReactionButtonListWidget(
                       onMessagePressed: () {},
                       onEmojiPressed: () {},
@@ -131,8 +134,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                       onQuickShotPointerUp: (_) {},
                       onQuickShotPointerMove: (_) {},
                     ),
-                  ],
-                ),
+                ],
               ),
             ),
           ],
@@ -143,10 +145,28 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
         child: Stack(
           children: [
             Container(
-              decoration: const BoxDecoration(
+              decoration: BoxDecoration(
                 color: CustomColors.whDarkBlack,
-                borderRadius: BorderRadius.all(
+                borderRadius: const BorderRadius.all(
                   Radius.circular(16.0),
+                ),
+                border: Border(
+                  top: const BorderSide(
+                    width: 8.0,
+                    color: CustomColors.whDarkBlack,
+                  ),
+                  left: const BorderSide(
+                    width: 8.0,
+                    color: CustomColors.whDarkBlack,
+                  ),
+                  right: const BorderSide(
+                    width: 8.0,
+                    color: CustomColors.whDarkBlack,
+                  ),
+                  bottom: BorderSide(
+                    width: widget.showReactionToolbar ? 0.1 : 8.0,
+                    color: CustomColors.whDarkBlack,
+                  ),
                 ),
               ),
               child: Padding(
@@ -157,21 +177,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                       decoration: const BoxDecoration(
                         color: CustomColors.whGrey,
                         borderRadius: BorderRadius.all(
-                          Radius.circular(16.0),
-                        ),
-                        border: Border(
-                          top: BorderSide(
-                            width: 8.0,
-                            color: CustomColors.whDarkBlack,
-                          ),
-                          left: BorderSide(
-                            width: 8.0,
-                            color: CustomColors.whDarkBlack,
-                          ),
-                          right: BorderSide(
-                            width: 8.0,
-                            color: CustomColors.whDarkBlack,
-                          ),
+                          Radius.circular(8.0),
                         ),
                       ),
                       padding: const EdgeInsets.only(
@@ -232,83 +238,84 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                         ],
                       ),
                     ),
-                    ConfirmPostReactionButtonListWidget(
-                      onMessagePressed: () {
-                        setState(() {
-                          isShowingCommentField = !isShowingCommentField;
-                        });
-                      },
-                      onEmojiPressed: () async {
-                        showEmojiSheet(viewModel, provider, context);
-                      },
-                      onQuickShotPointerDown: (event) {
-                        isTouchMoved = false;
+                    if (widget.showReactionToolbar)
+                      ConfirmPostReactionButtonListWidget(
+                        onMessagePressed: () {
+                          setState(() {
+                            isShowingCommentField = !isShowingCommentField;
+                          });
+                        },
+                        onEmojiPressed: () async {
+                          showEmojiSheet(viewModel, provider, context);
+                        },
+                        onQuickShotPointerDown: (event) {
+                          isTouchMoved = false;
 
-                        if (reactionCameraModel.cameraController == null) {
-                          return;
-                        }
+                          if (reactionCameraModel.cameraController == null) {
+                            return;
+                          }
 
-                        panningPosition = Point(
-                          event.position.dx,
-                          event.position.dy,
-                        );
-
-                        reactionCameraModelProvider
-                            .updatePanPosition(panningPosition);
-
-                        if (mounted) {
-                          setState(() {});
-                        }
-                      },
-                      onQuickShotPointerUp: (event) async {
-                        if (!isTouchMoved) {
-                          showToastMessage(
-                            context,
-                            text: '퀵샷 버튼을 누르고 드래그 해주세요!',
-                            icon: const Icon(
-                              Icons.warning,
-                              color: CustomColors.whYellow,
-                            ),
+                          panningPosition = Point(
+                            event.position.dx,
+                            event.position.dy,
                           );
-                          return;
-                        }
 
-                        await reactionCameraModelProvider
-                            .setFocusingModeTo(false);
+                          reactionCameraModelProvider
+                              .updatePanPosition(panningPosition);
 
-                        if (reactionCameraModel.cameraController == null) {
-                          return;
-                        }
+                          if (mounted) {
+                            setState(() {});
+                          }
+                        },
+                        onQuickShotPointerUp: (event) async {
+                          if (!isTouchMoved) {
+                            showToastMessage(
+                              context,
+                              text: '퀵샷 버튼을 누르고 드래그 해주세요!',
+                              icon: const Icon(
+                                Icons.warning,
+                                color: CustomColors.whYellow,
+                              ),
+                            );
+                            return;
+                          }
 
-                        if (ref
-                            .read(reactionCameraWidgetModelProvider)
-                            .isPosInCapturingArea) {
-                          final imageFilePath =
-                              await reactionCameraModelProvider
-                                  .endOnCapturingArea();
+                          await reactionCameraModelProvider
+                              .setFocusingModeTo(false);
 
-                          await provider.sendImageReaction(
-                            entity: widget.confirmPostEntity,
-                            imageFilePath: imageFilePath,
+                          if (reactionCameraModel.cameraController == null) {
+                            return;
+                          }
+
+                          if (ref
+                              .read(reactionCameraWidgetModelProvider)
+                              .isPosInCapturingArea) {
+                            final imageFilePath =
+                                await reactionCameraModelProvider
+                                    .endOnCapturingArea();
+
+                            await provider.sendImageReaction(
+                              entity: widget.confirmPostEntity,
+                              imageFilePath: imageFilePath,
+                            );
+                          }
+                        },
+                        onQuickShotPointerMove: (event) async {
+                          isTouchMoved = true;
+                          await reactionCameraModelProvider
+                              .setFocusingModeTo(true);
+
+                          panningPosition = Point(
+                            event.position.dx,
+                            event.position.dy,
                           );
-                        }
-                      },
-                      onQuickShotPointerMove: (event) async {
-                        isTouchMoved = true;
-                        await reactionCameraModelProvider
-                            .setFocusingModeTo(true);
 
-                        panningPosition = Point(
-                          event.position.dx,
-                          event.position.dy,
-                        );
+                          reactionCameraModelProvider
+                              .updatePanPosition(panningPosition);
 
-                        reactionCameraModelProvider
-                            .updatePanPosition(panningPosition);
-
-                        if (reactionCameraModel.isPosInCapturingArea) {}
-                      },
-                    ),
+                          if (reactionCameraModel.isPosInCapturingArea) {}
+                        },
+                      ),
                     Visibility(
                       visible: isShowingCommentField,
                       child: Padding(

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -437,7 +437,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                                         ),
                                 color: Color.lerp(
                                   CustomColors.whYellow,
-                                  CustomColors.whRedBright,
+                                  CustomColors.whRed,
                                   min(1, viewModel.countSend / 24),
                                 ),
                                 fontWeight: FontWeight.w700,

--- a/lib/presentation/my_page/model/model.dart
+++ b/lib/presentation/my_page/model/model.dart
@@ -1,1 +1,2 @@
 export 'my_page_view_model.dart';
+export 'resolution_detail_view_model.dart';

--- a/lib/presentation/my_page/model/resolution_detail_view_model.dart
+++ b/lib/presentation/my_page/model/resolution_detail_view_model.dart
@@ -1,0 +1,15 @@
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/presentation/group_post/model/group_post_view_model.dart';
+import 'package:wehavit/presentation/presentation.dart';
+
+class ResolutionDetailViewModel extends PostViewModel {
+  ResolutionDetailViewModel();
+
+  ResolutionEntity? resolutionEntity;
+
+  static final mondayOfThisWeek = DateTime(
+    DateTime.now().year,
+    DateTime.now().month,
+    DateTime.now().day,
+  ).subtract(Duration(days: DateTime.now().weekday - 1));
+}

--- a/lib/presentation/my_page/provider/provider.dart
+++ b/lib/presentation/my_page/provider/provider.dart
@@ -1,3 +1,4 @@
 export 'add_resolution_provider.dart';
 export 'my_page_view_model_provider.dart';
 export 'providers.dart';
+export 'resolution_detail_view_model_provider.dart';

--- a/lib/presentation/my_page/provider/resolution_detail_view_model_provider.dart
+++ b/lib/presentation/my_page/provider/resolution_detail_view_model_provider.dart
@@ -6,21 +6,43 @@ class ResolutionDetailViewModelProvider
     extends StateNotifier<ResolutionDetailViewModel> {
   ResolutionDetailViewModelProvider(
     this.getConfirmPostListForResolutionIdUsecase,
+    this.getConfirmPostOfDatetimeFromTargetResolutionUsecase,
   ) : super(ResolutionDetailViewModel());
 
   final GetConfirmPostListForResolutionIdUsecase
       getConfirmPostListForResolutionIdUsecase;
+  final GetConfirmPostOfDatetimeFromTargetResolutionUsecase
+      getConfirmPostOfDatetimeFromTargetResolutionUsecase;
 
   Future<void> changeSelectedDate({required DateTime to}) async {
     state.selectedDate = to;
   }
 
-  Future<void> loadConfirmPosts({
-    required String resolutionId,
+  Future<void> loadConfirmPostsForWeek({
     required DateTime mondayOfTargetWeek,
   }) async {
-    getConfirmPostListForResolutionIdUsecase.call(resolutionId);
-
+    for (int i = 0; i < 7; i++) {
+      await loadConfirmPostEntityListFor(
+        dateTime: mondayOfTargetWeek.add(Duration(days: i)),
+      );
+    }
     return Future(() => null);
+  }
+
+  Future<void> loadConfirmPostEntityListFor({
+    required DateTime dateTime,
+  }) async {
+    final selectedDate = DateTime(dateTime.year, dateTime.month, dateTime.day);
+
+    if (state.resolutionEntity == null ||
+        state.resolutionEntity?.resolutionId == null) {
+      return;
+    }
+
+    state.confirmPostList[selectedDate] =
+        getConfirmPostOfDatetimeFromTargetResolutionUsecase.call(
+      resolutionId: state.resolutionEntity!.resolutionId!,
+      targetDateTime: dateTime,
+    );
   }
 }

--- a/lib/presentation/my_page/provider/resolution_detail_view_model_provider.dart
+++ b/lib/presentation/my_page/provider/resolution_detail_view_model_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/domain/usecases/usecases.dart';
+import 'package:wehavit/presentation/my_page/model/resolution_detail_view_model.dart';
+
+class ResolutionDetailViewModelProvider
+    extends StateNotifier<ResolutionDetailViewModel> {
+  ResolutionDetailViewModelProvider(
+    this.getConfirmPostListForResolutionIdUsecase,
+  ) : super(ResolutionDetailViewModel());
+
+  final GetConfirmPostListForResolutionIdUsecase
+      getConfirmPostListForResolutionIdUsecase;
+
+  Future<void> changeSelectedDate({required DateTime to}) async {
+    state.selectedDate = to;
+  }
+
+  Future<void> loadConfirmPosts({
+    required String resolutionId,
+    required DateTime mondayOfTargetWeek,
+  }) async {
+    getConfirmPostListForResolutionIdUsecase.call(resolutionId);
+
+    return Future(() => null);
+  }
+}

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -15,10 +15,10 @@ class MyPageView extends ConsumerStatefulWidget {
   final TabController tabController;
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _MyPageScreenState();
+  ConsumerState<ConsumerStatefulWidget> createState() => MyPageScreenState();
 }
 
-class _MyPageScreenState extends ConsumerState<MyPageView>
+class MyPageScreenState extends ConsumerState<MyPageView>
     with AutomaticKeepAliveClientMixin<MyPageView> {
   @override
   bool get wantKeepAlive => true;
@@ -127,9 +127,14 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                                   ),
                                 ),
                                 onPressed: () async {
-                                  showModifyResolutionBottomSheet(
+                                  Navigator.push(
                                     context,
-                                    resolutionList[index],
+                                    MaterialPageRoute(
+                                      builder: (context) =>
+                                          ResolutionDetailView(
+                                        entity: resolutionList[index],
+                                      ),
+                                    ),
                                   );
                                 },
                                 child: ResolutionListCellWidget(
@@ -254,176 +259,6 @@ class _MyPageScreenState extends ConsumerState<MyPageView>
                             isDestructiveAction: true,
                             onPressed: deleteAccount,
                             child: const Text('탈퇴하기'),
-                          ),
-                        ],
-                      );
-                    },
-                  ).then((result) {
-                    if (result == false) {
-                      showToastMessage(
-                        context,
-                        text: '오류 발생, 문의 부탁드립니다',
-                        icon: const Icon(
-                          Icons.report_problem,
-                          color: CustomColors.whYellow,
-                        ),
-                      );
-                    }
-                  });
-                },
-              ),
-              const SizedBox(
-                height: 12,
-              ),
-              WideColoredButton(
-                buttonTitle: '돌아가기',
-                backgroundColor: Colors.transparent,
-                foregroundColor: CustomColors.whPlaceholderGrey,
-                onPressed: () {
-                  Navigator.pop(context);
-                },
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  Future<dynamic> showModifyResolutionBottomSheet(
-    BuildContext context,
-    ResolutionEntity entity,
-  ) {
-    ref.watch(addResolutionDoneViewModelProvider).resolutionEntity = entity;
-    final provider = ref.read(addResolutionDoneViewModelProvider.notifier);
-
-    return showModalBottomSheet(
-      context: context,
-      builder: (context) {
-        return GradientBottomSheet(
-          Column(
-            children: [
-              WideColoredButton(
-                buttonTitle: '목표 공유 친구 수정하기',
-                buttonIcon: Icons.people_alt_outlined,
-                onPressed: () async {
-                  provider.loadFriendList().whenComplete(() async {
-                    await provider.resetTempFriendList();
-                    showModalBottomSheet(
-                      isScrollControlled: true,
-                      // ignore: use_build_context_synchronously
-                      context: context,
-                      builder: (context) => GradientBottomSheet(
-                        SizedBox(
-                          height: MediaQuery.of(context).size.height * 0.82,
-                          child:
-                              const ShareResolutionToFriendBottomSheetWidget(),
-                        ),
-                      ),
-                    ).then((newEntity) {
-                      ref
-                          .watch(addResolutionDoneViewModelProvider)
-                          .resolutionEntity = newEntity;
-                      ref
-                          .read(myPageViewModelProvider.notifier)
-                          .getResolutionList()
-                          .whenComplete(() {
-                        setState(() {});
-                      });
-                    });
-                  });
-                },
-              ),
-              const SizedBox(
-                height: 12,
-              ),
-              WideColoredButton(
-                buttonTitle: '목표 공유 그룹 수정하기',
-                buttonIcon: Icons.flag_outlined,
-                onPressed: () async {
-                  provider.loadGroupList().whenComplete(() async {
-                    await provider.resetTempGroupList();
-                    showModalBottomSheet(
-                      isScrollControlled: true,
-                      // ignore: use_build_context_synchronously
-                      context: context,
-                      builder: (context) => GradientBottomSheet(
-                        SizedBox(
-                          height: MediaQuery.of(context).size.height * 0.82,
-                          child:
-                              const ShareResolutionToGroupBottomSheetWidget(),
-                        ),
-                      ),
-                    ).then((newEntity) {
-                      if (newEntity != null && newEntity is ResolutionEntity) {
-                        ref
-                            .watch(addResolutionDoneViewModelProvider)
-                            .resolutionEntity = newEntity;
-                        ref
-                            .read(myPageViewModelProvider.notifier)
-                            .getResolutionList()
-                            .whenComplete(() {
-                          setState(() {});
-                        });
-                      }
-                    });
-                  });
-                },
-              ),
-              const SizedBox(
-                height: 12,
-              ),
-              WideColoredButton(
-                buttonTitle: '목표 삭제하기',
-                buttonIcon: Icons.flag_outlined,
-                foregroundColor: PointColors.red,
-                onPressed: () async {
-                  showCupertinoDialog(
-                    context: context,
-                    builder: (context) {
-                      return CupertinoAlertDialog(
-                        title: const Text('정말 삭제하시겠어요?'),
-                        content: const Text('목표에 대해 작성하신 인증 글은 유지됩니다'),
-                        actions: [
-                          CupertinoDialogAction(
-                            textStyle: const TextStyle(
-                              color: PointColors.blue,
-                            ),
-                            isDefaultAction: true,
-                            child: const Text('취소'),
-                            onPressed: () {
-                              Navigator.pop(context);
-                            },
-                          ),
-                          CupertinoDialogAction(
-                            isDestructiveAction: true,
-                            onPressed: () {
-                              ref
-                                  .read(myPageViewModelProvider.notifier)
-                                  .deactiveResolution(
-                                    targetResolutionEntity: entity,
-                                  )
-                                  .whenComplete(() async {
-                                ref
-                                    .read(
-                                      resolutionListViewModelProvider.notifier,
-                                    )
-                                    .loadResolutionModelList();
-                                await ref
-                                    .read(myPageViewModelProvider.notifier)
-                                    .loadData()
-                                    .whenComplete(() {
-                                  context
-                                      .findAncestorStateOfType<
-                                          _MyPageScreenState>()
-                                      ?.setState(() {});
-                                });
-                                Navigator.pop(context);
-                                Navigator.pop(context);
-                                setState(() {});
-                              });
-                            },
-                            child: const Text('삭제'),
                           ),
                         ],
                       );

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -37,6 +37,8 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
         widget.entity;
   }
 
+  static List<String> weekdayString = ['월', '화', '수', '목', '금', '토', '일'];
+
   @override
   Widget build(BuildContext context) {
     final viewModel = ref.watch(resolutionDetailViewModelProvider);
@@ -180,36 +182,39 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                 const SizedBox(
                   height: 16.0,
                 ),
-                const Row(
+                Row(
                   children: [
                     ResolutionSingleStatisticCellWidget(
-                      primary: '32회',
+                      primary: '${widget.entity.writtenPostCount}회',
                       secondary: '실천 인증 횟수',
                     ),
-                    SizedBox(
+                    const SizedBox(
                       width: 16.0,
                     ),
                     ResolutionSingleStatisticCellWidget(
-                      primary: '32회',
-                      secondary: '실천 인증 횟수',
+                      primary:
+                          '${widget.entity.successWeekMondayList?.length}회',
+                      secondary: '주간 목표 달성 횟수',
                     ),
                   ],
                 ),
                 const SizedBox(
                   height: 16.0,
                 ),
-                const Row(
+                Row(
                   children: [
                     ResolutionSingleStatisticCellWidget(
-                      primary: '32회',
-                      secondary: '실천 인증 횟수',
+                      primary: '${widget.entity.receivedReactionCount}회',
+                      secondary: '받은 격려 수',
                     ),
-                    SizedBox(
+                    const SizedBox(
                       width: 16.0,
                     ),
                     ResolutionSingleStatisticCellWidget(
-                      primary: '32회',
-                      secondary: '실천 인증 횟수',
+                      primary:
+                          // ignore: lines_longer_than_80_chars
+                          '${DateTime.now().difference(widget.entity.startDate ?? DateTime.now()).inDays + 1}일',
+                      secondary: '도전을 함께한 일 수',
                     ),
                   ],
                 ),
@@ -274,15 +279,14 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                           ),
                           color: PointColors
                               .colorList[widget.entity.colorIndex ?? 0],
-                          dataSource: [
-                            ChartData('월', 35),
-                            ChartData('화', 28),
-                            ChartData('수', 34),
-                            ChartData('목', 32),
-                            ChartData('금', 40),
-                            ChartData('토', 40),
-                            ChartData('일', 40),
-                          ],
+                          dataSource: List<ChartData>.generate(
+                            widget.entity.weeklyPostCountList!.length,
+                            (index) => ChartData(
+                              weekdayString[index],
+                              widget.entity.weeklyPostCountList![index]
+                                  .toDouble(),
+                            ),
+                          ),
                           xValueMapper: (ChartData data, _) => data.x,
                           yValueMapper: (ChartData data, _) => data.y,
                           borderRadius: const BorderRadius.only(

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -1,0 +1,483 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:wehavit/common/constants/constants.dart';
+import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/presentation/presentation.dart';
+
+class ResolutionDetailView extends ConsumerStatefulWidget {
+  const ResolutionDetailView({
+    super.key,
+    required this.entity,
+  });
+
+  final ResolutionEntity entity;
+  @override
+  ConsumerState<ResolutionDetailView> createState() =>
+      _ResolutionDetailViewState();
+}
+
+class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: WehavitAppBar(
+        title: widget.entity.resolutionName ?? '나의 도전',
+        leadingIcon: Icons.chevron_left,
+        leadingAction: () {
+          Navigator.pop(context);
+        },
+        leadingTitle: '',
+        trailingTitle: '',
+        trailingIcon: Icons.more_horiz,
+        trailingAction: () {
+          showModifyResolutionBottomSheet(
+            context,
+            widget.entity,
+          );
+        },
+      ),
+      body: SafeArea(
+        minimum: const EdgeInsets.symmetric(
+          horizontal: 16.0,
+        ),
+        child: ListView(
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '나의 목표',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                const SizedBox(
+                  height: 16,
+                ),
+                Column(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(20.0),
+                      width: double.infinity,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(16.0),
+                        color: CustomColors.whGrey,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '⛳️ 나의 목표',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  color: PointColors
+                                      .colorList[widget.entity.colorIndex ?? 0],
+                                  fontSize: 16,
+                                ),
+                              ),
+                              Container(
+                                padding: const EdgeInsets.only(left: 16.0),
+                                child: Text(
+                                  widget.entity.goalStatement ?? '',
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w400,
+                                    color: Colors.white,
+                                    fontSize: 14,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 20),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '📋 나의 실천 계획',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  color: PointColors
+                                      .colorList[widget.entity.colorIndex ?? 0],
+                                  fontSize: 16,
+                                ),
+                              ),
+                              Container(
+                                padding: const EdgeInsets.only(left: 16.0),
+                                child: Text(
+                                  // ignore: lines_longer_than_80_chars
+                                  '${widget.entity.actionStatement ?? ''}\n일주일에 ${widget.entity.actionPerWeek ?? 0}회 실천하기',
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w400,
+                                    color: Colors.white,
+                                    fontSize: 14,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 20),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '📅 도전 시작일',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  color: PointColors
+                                      .colorList[widget.entity.colorIndex ?? 0],
+                                  fontSize: 16,
+                                ),
+                              ),
+                              Container(
+                                padding: const EdgeInsets.only(left: 16.0),
+                                child: Text(
+                                  DateFormat('yyyy년 M월 d일').format(
+                                    widget.entity.startDate ?? DateTime.now(),
+                                  ),
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w400,
+                                    color: Colors.white,
+                                    fontSize: 14,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 16.0,
+                ),
+                Row(
+                  children: [
+                    const ResolutionSingleStatisticCellWidget(
+                      primary: '32회',
+                      secondary: '실천 인증 횟수',
+                    ),
+                    const SizedBox(
+                      width: 16.0,
+                    ),
+                    const ResolutionSingleStatisticCellWidget(
+                      primary: '32회',
+                      secondary: '실천 인증 횟수',
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 16.0,
+                ),
+                Row(
+                  children: [
+                    const ResolutionSingleStatisticCellWidget(
+                      primary: '32회',
+                      secondary: '실천 인증 횟수',
+                    ),
+                    const SizedBox(
+                      width: 16.0,
+                    ),
+                    const ResolutionSingleStatisticCellWidget(
+                      primary: '32회',
+                      secondary: '실천 인증 횟수',
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(
+              height: 32.0,
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '요일 별 인증 횟수',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                const SizedBox(
+                  height: 16,
+                ),
+                Container(
+                  padding: const EdgeInsets.all(20.0),
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(16.0),
+                    color: CustomColors.whGrey,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(
+              height: 32.0,
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '내 인증글',
+                  textAlign: TextAlign.start,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                    fontSize: 20,
+                  ),
+                ),
+                const SizedBox(
+                  height: 16,
+                ),
+                Container(
+                  padding: const EdgeInsets.all(20.0),
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(16.0),
+                    color: CustomColors.whGrey,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(
+              height: 32.0,
+            ),
+            WideColoredButton(buttonTitle: '목표 삭제하기'),
+          ],
+        ),
+      ),
+      backgroundColor: CustomColors.whDarkBlack,
+    );
+  }
+
+  Future<dynamic> showModifyResolutionBottomSheet(
+    BuildContext context,
+    ResolutionEntity entity,
+  ) {
+    ref.watch(addResolutionDoneViewModelProvider).resolutionEntity = entity;
+    final provider = ref.read(addResolutionDoneViewModelProvider.notifier);
+
+    return showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return GradientBottomSheet(
+          Column(
+            children: [
+              WideColoredButton(
+                buttonTitle: '목표 공유 친구 수정하기',
+                buttonIcon: Icons.people_alt_outlined,
+                onPressed: () async {
+                  provider.loadFriendList().whenComplete(() async {
+                    await provider.resetTempFriendList();
+                    showModalBottomSheet(
+                      isScrollControlled: true,
+                      // ignore: use_build_context_synchronously
+                      context: context,
+                      builder: (context) => GradientBottomSheet(
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * 0.82,
+                          child:
+                              const ShareResolutionToFriendBottomSheetWidget(),
+                        ),
+                      ),
+                    ).then((newEntity) {
+                      ref
+                          .watch(addResolutionDoneViewModelProvider)
+                          .resolutionEntity = newEntity;
+                      ref
+                          .read(myPageViewModelProvider.notifier)
+                          .getResolutionList()
+                          .whenComplete(() {
+                        setState(() {});
+                      });
+                    });
+                  });
+                },
+              ),
+              const SizedBox(
+                height: 12,
+              ),
+              WideColoredButton(
+                buttonTitle: '목표 공유 그룹 수정하기',
+                buttonIcon: Icons.flag_outlined,
+                onPressed: () async {
+                  provider.loadGroupList().whenComplete(() async {
+                    await provider.resetTempGroupList();
+                    showModalBottomSheet(
+                      isScrollControlled: true,
+                      // ignore: use_build_context_synchronously
+                      context: context,
+                      builder: (context) => GradientBottomSheet(
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * 0.82,
+                          child:
+                              const ShareResolutionToGroupBottomSheetWidget(),
+                        ),
+                      ),
+                    ).then((newEntity) {
+                      if (newEntity != null && newEntity is ResolutionEntity) {
+                        ref
+                            .watch(addResolutionDoneViewModelProvider)
+                            .resolutionEntity = newEntity;
+                        ref
+                            .read(myPageViewModelProvider.notifier)
+                            .getResolutionList()
+                            .whenComplete(() {
+                          setState(() {});
+                        });
+                      }
+                    });
+                  });
+                },
+              ),
+              const SizedBox(
+                height: 12,
+              ),
+              WideColoredButton(
+                buttonTitle: '목표 삭제하기',
+                buttonIcon: Icons.flag_outlined,
+                foregroundColor: PointColors.red,
+                onPressed: () async {
+                  showCupertinoDialog(
+                    context: context,
+                    builder: (context) {
+                      return CupertinoAlertDialog(
+                        title: const Text('정말 삭제하시겠어요?'),
+                        content: const Text('목표에 대해 작성하신 인증 글은 유지됩니다'),
+                        actions: [
+                          CupertinoDialogAction(
+                            textStyle: const TextStyle(
+                              color: PointColors.blue,
+                            ),
+                            isDefaultAction: true,
+                            child: const Text('취소'),
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                          ),
+                          CupertinoDialogAction(
+                            isDestructiveAction: true,
+                            onPressed: () {
+                              ref
+                                  .read(myPageViewModelProvider.notifier)
+                                  .deactiveResolution(
+                                    targetResolutionEntity: entity,
+                                  )
+                                  .whenComplete(() async {
+                                ref
+                                    .read(
+                                      resolutionListViewModelProvider.notifier,
+                                    )
+                                    .loadResolutionModelList();
+                                await ref
+                                    .read(myPageViewModelProvider.notifier)
+                                    .loadData()
+                                    .whenComplete(() {
+                                  context
+                                      .findAncestorStateOfType<
+                                          MyPageScreenState>()
+                                      ?.setState(() {});
+                                });
+                                // ignore: use_build_context_synchronously
+                                Navigator.pop(context);
+                                // ignore: use_build_context_synchronously
+                                Navigator.pop(context);
+                                setState(() {});
+                              });
+                            },
+                            child: const Text('삭제'),
+                          ),
+                        ],
+                      );
+                    },
+                  ).then((result) {
+                    if (result == false) {
+                      showToastMessage(
+                        context,
+                        text: '오류 발생, 문의 부탁드립니다',
+                        icon: const Icon(
+                          Icons.report_problem,
+                          color: CustomColors.whYellow,
+                        ),
+                      );
+                    }
+                  });
+                },
+              ),
+              const SizedBox(
+                height: 12,
+              ),
+              WideColoredButton(
+                buttonTitle: '돌아가기',
+                backgroundColor: Colors.transparent,
+                foregroundColor: CustomColors.whPlaceholderGrey,
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class ResolutionSingleStatisticCellWidget extends StatelessWidget {
+  const ResolutionSingleStatisticCellWidget({
+    super.key,
+    required this.primary,
+    required this.secondary,
+  });
+
+  final String primary;
+  final String secondary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        height: 90,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16.0),
+          color: CustomColors.whGrey,
+        ),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                primary,
+                style: const TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: CustomColors.whWhite,
+                  fontSize: 22,
+                ),
+              ),
+              Text(
+                secondary,
+                style: const TextStyle(
+                  fontWeight: FontWeight.w300,
+                  color: CustomColors.whPlaceholderGrey,
+                  fontSize: 14,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -2,7 +2,6 @@ import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fpdart/fpdart.dart';
 import 'package:intl/intl.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 import 'package:wehavit/common/constants/constants.dart';
@@ -314,72 +313,53 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                   ),
                 ),
                 const SizedBox(
-                  height: 16,
+                  height: 4,
                 ),
                 Column(
                   children: [
+                    Text(
+                      viewModel.selectedDateString,
+                      textAlign: TextAlign.start,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        color: CustomColors.whPlaceholderGrey,
+                        fontSize: 18,
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 8.0,
+                    ),
                     putScrollableCalendarWidget(viewModel, provider),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Stack(
-                          alignment: Alignment.centerRight,
-                          children: [
-                            UserProfileBar(
-                              futureUserEntity: Future(
-                                () => right(
-                                  UserDataEntity.dummyModel,
-                                ),
-                              ),
-                            ),
-                            if (ConfirmPostEntityDummy.dummy.hasRested == false)
-                              Text(
-                                // ignore: lines_longer_than_80_chars
-                                '${ConfirmPostEntityDummy.dummy.createdAt!.hour > 12 ? '오후' : '오전'} ${ConfirmPostEntityDummy.dummy.createdAt!.hour > 12 ? ConfirmPostEntityDummy.dummy.createdAt!.hour - 12 : ConfirmPostEntityDummy.dummy.createdAt!.hour}시 ${ConfirmPostEntityDummy.dummy.createdAt!.minute}분',
-                                style: const TextStyle(
-                                  color: CustomColors.whWhite,
-                                ),
-                              )
-                            else
-                              Container(
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(16.0),
-                                  color: CustomColors.whRed,
-                                ),
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 4.0,
-                                  horizontal: 8.0,
-                                ),
-                                child: const Text(
-                                  '오늘 실천 실패 😢',
-                                  style: TextStyle(
-                                    fontSize: 12.0,
-                                    fontWeight: FontWeight.w300,
-                                    color: CustomColors.whWhite,
-                                  ),
-                                ),
-                              ),
-                          ],
-                        ),
-                        // const SizedBox(height: 12.0),
-
-                        // ResolutionLinearGaugeWidget(
-                        //   resolutionEntity: resolutionEntity,
-                        //   futureDoneList: resolutionDoneListForWrittenWeek,
-                        // ),
-
-                        const SizedBox(height: 12.0),
-                        ConfirmPostContentWidget(
-                          confirmPostEntity: ConfirmPostEntityDummy.dummy,
-                        ),
-                      ],
+                    const SizedBox(
+                      height: 12.0,
+                    ),
+                    ConfirmPostWidget(
+                      confirmPostEntity: ConfirmPostEntityDummy.dummy,
+                      createdDate: ConfirmPostEntityDummy.dummy.createdAt!,
+                      showReactionToolbar: false,
                     ),
                   ],
                 ),
               ],
             ),
             const SizedBox(
-              height: 32.0,
+              height: 40.0,
+            ),
+            Container(
+              width: double.infinity,
+              alignment: Alignment.center,
+              child: const Text(
+                '더 많은 통계가 곧 추가됩니다!',
+                textAlign: TextAlign.start,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: CustomColors.whSemiWhite,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+            const SizedBox(
+              height: 40.0,
             ),
             WideColoredButton(
               buttonTitle: '목표 삭제하기',
@@ -389,7 +369,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
           ],
         ),
       ),
-      backgroundColor: CustomColors.whDarkBlack,
+      backgroundColor: CustomColors.whBlack,
     );
   }
 

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -2,21 +2,29 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
 import 'package:wehavit/common/constants/constants.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
+// ignore: must_be_immutable
 class ResolutionDetailView extends ConsumerStatefulWidget {
-  const ResolutionDetailView({
+  ResolutionDetailView({
     super.key,
     required this.entity,
   });
 
-  final ResolutionEntity entity;
+  ResolutionEntity entity;
   @override
   ConsumerState<ResolutionDetailView> createState() =>
       _ResolutionDetailViewState();
+}
+
+class ChartData {
+  ChartData(this.x, this.y);
+  final String x;
+  final double? y;
 }
 
 class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
@@ -32,7 +40,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
         leadingTitle: '',
         trailingTitle: '',
         trailingIcon: Icons.more_horiz,
-        trailingAction: () {
+        trailingAction: () async {
           showModifyResolutionBottomSheet(
             context,
             widget.entity,
@@ -160,16 +168,16 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                 const SizedBox(
                   height: 16.0,
                 ),
-                Row(
+                const Row(
                   children: [
-                    const ResolutionSingleStatisticCellWidget(
+                    ResolutionSingleStatisticCellWidget(
                       primary: '32회',
                       secondary: '실천 인증 횟수',
                     ),
-                    const SizedBox(
+                    SizedBox(
                       width: 16.0,
                     ),
-                    const ResolutionSingleStatisticCellWidget(
+                    ResolutionSingleStatisticCellWidget(
                       primary: '32회',
                       secondary: '실천 인증 횟수',
                     ),
@@ -178,16 +186,16 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                 const SizedBox(
                   height: 16.0,
                 ),
-                Row(
+                const Row(
                   children: [
-                    const ResolutionSingleStatisticCellWidget(
+                    ResolutionSingleStatisticCellWidget(
                       primary: '32회',
                       secondary: '실천 인증 횟수',
                     ),
-                    const SizedBox(
+                    SizedBox(
                       width: 16.0,
                     ),
-                    const ResolutionSingleStatisticCellWidget(
+                    ResolutionSingleStatisticCellWidget(
                       primary: '32회',
                       secondary: '실천 인증 횟수',
                     ),
@@ -220,6 +228,60 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                     borderRadius: BorderRadius.circular(16.0),
                     color: CustomColors.whGrey,
                   ),
+                  child: SizedBox(
+                    height: 200,
+                    child: SfCartesianChart(
+                      plotAreaBorderColor: Colors.transparent,
+                      primaryXAxis: const CategoryAxis(
+                        majorGridLines:
+                            MajorGridLines(color: Colors.transparent),
+                        majorTickLines:
+                            MajorTickLines(color: Colors.transparent),
+                        labelStyle: TextStyle(
+                          color: Colors.white, // 레이블 색상을 흰색으로 변경
+                          fontSize: 14, // 폰트 크기 (옵션)
+                          fontWeight: FontWeight.normal, // 폰트 굵기 (옵션)
+                        ),
+                      ),
+                      primaryYAxis: const NumericAxis(
+                        isVisible: false,
+                      ),
+                      series: <CartesianSeries>[
+                        // Renders bar chart
+                        ColumnSeries<ChartData, String>(
+                          animationDuration: 750,
+                          dataLabelMapper: (datum, index) =>
+                              datum.y?.toInt().toString(),
+                          dataLabelSettings: const DataLabelSettings(
+                            isVisible: true,
+                            textStyle: TextStyle(
+                              color: CustomColors.whWhite,
+                              fontSize: 14.0,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          color: PointColors
+                              .colorList[widget.entity.colorIndex ?? 0],
+                          dataSource: [
+                            ChartData('월', 35),
+                            ChartData('화', 28),
+                            ChartData('수', 34),
+                            ChartData('목', 32),
+                            ChartData('금', 40),
+                            ChartData('토', 40),
+                            ChartData('일', 40),
+                          ],
+                          xValueMapper: (ChartData data, _) => data.x,
+                          yValueMapper: (ChartData data, _) => data.y,
+                          borderRadius: const BorderRadius.only(
+                            topLeft: Radius.circular(8),
+                            topRight: Radius.circular(8),
+                          ),
+                          width: 0.5,
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ],
             ),
@@ -251,10 +313,14 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                 ),
               ],
             ),
-            SizedBox(
+            const SizedBox(
               height: 32.0,
             ),
-            WideColoredButton(buttonTitle: '목표 삭제하기'),
+            WideColoredButton(
+              buttonTitle: '목표 삭제하기',
+              foregroundColor: CustomColors.whRed,
+              onPressed: () {},
+            ),
           ],
         ),
       ),
@@ -293,6 +359,8 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                         ),
                       ),
                     ).then((newEntity) {
+                      widget.entity = newEntity;
+
                       ref
                           .watch(addResolutionDoneViewModelProvider)
                           .resolutionEntity = newEntity;

--- a/lib/presentation/my_page/view/view.dart
+++ b/lib/presentation/my_page/view/view.dart
@@ -1,3 +1,4 @@
 export 'add_resolution_screen.dart';
 export 'my_page_view.dart';
 export 'my_page_view_widget.dart';
+export 'resolution_detail_view.dart';


### PR DESCRIPTION
# 설명
마이페이지의 도전중인 목표 위젯을 눌렀을 때 이동 가능한 상세 통계페이지 설계 및 구현

Fixes #
Closes #305 
Resolves #

# 작업 내역
- 상세 통계페이지 UI 레이아웃 구현
- 상세 통계페이지 로직 구현 및 적용
- 일부 위젯 개선을 통해 통계페이지 내에서 재사용 가능하도록 수정

## 작업 결과물
![Simulator Screen Recording - 13 Pro simulator - 2024-07-09 at 15 07 22](https://github.com/cau-bootcamp/wehavit/assets/39216546/08c501c1-18b1-4a50-8ff1-caabcc00c21c)


## 참고 사항(선택)
작업을 진행하면서 참고한 사항이나 참고할 사항이 있다면 적어주세요.
(ex. 나중에 수정해야 할 부분, 참고한 사이트, 참고한 코드 등)

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
