### PR TITLE
[#322] feat: 리액션 전송 후 토스트메시지 띄우기

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -993,7 +993,7 @@ PODS:
     - Firebase/Storage (= 10.25.0)
     - firebase_core
     - Flutter
-  - FirebaseAppCheckInterop (10.25.0)
+  - FirebaseAppCheckInterop (10.29.0)
   - FirebaseAuth (10.25.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
@@ -1001,14 +1001,14 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.25.0)
+  - FirebaseAuthInterop (10.29.0)
   - FirebaseCore (10.25.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreExtension (10.25.0):
+  - FirebaseCoreExtension (10.29.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.25.0):
+  - FirebaseCoreInternal (10.29.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseFirestore (10.25.0):
     - FirebaseCore (~> 10.0)
@@ -1030,7 +1030,7 @@ PODS:
     - gRPC-Core (~> 1.62.0)
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseInstallations (10.25.0):
+  - FirebaseInstallations (10.29.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -1044,7 +1044,7 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseSharedSwift (10.25.0)
+  - FirebaseSharedSwift (10.29.0)
   - FirebaseStorage (10.25.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.25)
@@ -1180,10 +1180,10 @@ PODS:
   - GTMAppAuth (4.1.1):
     - AppAuth/Core (~> 1.7)
     - GTMSessionFetcher/Core (< 4.0, >= 3.3)
-  - GTMSessionFetcher (3.4.1):
-    - GTMSessionFetcher/Full (= 3.4.1)
-  - GTMSessionFetcher/Core (3.4.1)
-  - GTMSessionFetcher/Full (3.4.1):
+  - GTMSessionFetcher (3.5.0):
+    - GTMSessionFetcher/Full (= 3.5.0)
+  - GTMSessionFetcher/Core (3.5.0)
+  - GTMSessionFetcher/Full (3.5.0):
     - GTMSessionFetcher/Core
   - image_picker_ios (0.0.1):
     - Flutter
@@ -1306,17 +1306,17 @@ SPEC CHECKSUMS:
   firebase_core: a626d00494efa398e7c54f25f1454a64c8abf197
   firebase_messaging: 06391e8f35dc65a00c56580266285263d2861f10
   firebase_storage: 5c0f552d6b27d621429d7fd16ebab4be94a3c954
-  FirebaseAppCheckInterop: 5da5ce93e8797a215e3f677fb0654b74e736c8b8
+  FirebaseAppCheckInterop: 6a1757cfd4067d8e00fccd14fcc1b8fd78cfac07
   FirebaseAuth: c0f93dcc570c9da2bffb576969d793e95c344fbb
-  FirebaseAuthInterop: 2753ef68cb3cd5aefebe0f58082671cede78350f
+  FirebaseAuthInterop: 17db81e9b198afb0f95ce48c133825727eed55d3
   FirebaseCore: 7ec4d0484817f12c3373955bc87762d96842d483
-  FirebaseCoreExtension: 8a47811d0b155501559ef05d089518152a0a1677
-  FirebaseCoreInternal: 910a81992c33715fec9263ca7381d59ab3a750b7
+  FirebaseCoreExtension: 705ca5b14bf71d2564a0ddc677df1fc86ffa600f
+  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
   FirebaseFirestore: 977ccc27a3caa5d68279f209c3b0450f85b9dc5f
   FirebaseFirestoreInternal: 04b8afa77b4e5b84e86ab5ad985193e9573239fa
-  FirebaseInstallations: 91950fe859846fff0fbd296180909dd273103b09
+  FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
   FirebaseMessaging: 88950ba9485052891ebe26f6c43a52bb62248952
-  FirebaseSharedSwift: 0274086954b1b2d5fd7e829eccc587044d72a4ba
+  FirebaseSharedSwift: 20530f495084b8d840f78a100d8c5ee613375f6e
   FirebaseStorage: 44f4e25073f6fa0d4d8c09f5bec299ee9e4eb985
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
@@ -1329,7 +1329,7 @@ SPEC CHECKSUMS:
   "gRPC-C++": e725ef63c4475d7cdb7e2cf16eb0fde84bd9ee51
   gRPC-Core: eee4be35df218649fe66d721a05a7f27a28f069b
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
-  GTMSessionFetcher: 8000756fc1c19d2e5697b90311f7832d2e33f6cd
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   images_picker: fa9364e3a7d3083c49f865fcfb2b9e7cdc574d3a
   leveldb-library: e8eadf9008a61f9e1dde3978c086d2b6d9b9dc28
@@ -1342,6 +1342,6 @@ SPEC CHECKSUMS:
   Toast: 1f5ea13423a1e6674c4abdac5be53587ae481c4e
   ZLPhotoBrowser: 4bfab86b851042e18d7f413284472aa68759626a
 
-PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 
 COCOAPODS: 1.15.2

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -298,11 +298,23 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                               await reactionCameraModelProvider
                                   .endOnCapturingArea();
 
-                          await provider.sendImageReaction(
+                          await provider
+                              .sendImageReaction(
                             entity: widget.confirmPostEntity,
                             imageFilePath: imageFilePath,
                             myUserEntity: myUserEntity,
-                          );
+                          )
+                              .whenComplete(() {
+                            showToastMessage(
+                              context,
+                              text: '친구에게 퀵샷으로 응원을 보냈어요',
+                              icon: const Icon(
+                                Icons.emoji_emotions,
+                                color: CustomColors.whWhite,
+                              ),
+                            );
+                          });
+                          ;
                         }
                       },
                       onQuickShotPointerMove: (event) async {
@@ -391,10 +403,22 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
   Future<void> sendMessageReaction(
     ConfirmPostEntity confirmPostEntity,
   ) async {
-    await ref.read(groupPostViewModelProvider.notifier).sendTextReaction(
+    await ref
+        .read(groupPostViewModelProvider.notifier)
+        .sendTextReaction(
           entity: confirmPostEntity,
           myUserEntity: myUserEntity,
-        );
+        )
+        .whenComplete(() {
+      showToastMessage(
+        context,
+        text: '친구에게 메시지로 응원을 보냈어요',
+        icon: const Icon(
+          Icons.emoji_emotions,
+          color: CustomColors.whWhite,
+        ),
+      );
+    });
   }
 
   Future<dynamic> showEmojiSheet(
@@ -527,9 +551,22 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
         );
       },
     ).whenComplete(() async {
-      await provider.sendEmojiReaction(
+      await provider
+          .sendEmojiReaction(
         entity: widget.confirmPostEntity,
         myUserEntity: myUserEntity,
+      )
+          .whenComplete(
+        () {
+          showToastMessage(
+            context,
+            text: '친구에게 이모지로 응원을 보냈어요',
+            icon: const Icon(
+              Icons.emoji_emotions,
+              color: CustomColors.whWhite,
+            ),
+          );
+        },
       );
 
       viewModel.countSend = 0;


### PR DESCRIPTION
# 설명
리액션을 전송한 뒤, 이에 대한 피드백으로 토스트메시지를 출력합니다.

Fixes #
Closes #322
Resolves #

# 작업 내역
- 리액션 전송 후 토스트메시지를 출력하도록 변경

## 작업 결과물
<img src="https://github.com/user-attachments/assets/7f2c4c7d-0844-461f-85bc-2f6caad5671c" width=300px>


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
