### PR TITLE
[#320] feat: 토스트메시지 컴포넌트 디자인 수정

### DIFF
--- a/lib/presentation/common_components/show_toast_message.dart
+++ b/lib/presentation/common_components/show_toast_message.dart
@@ -11,7 +11,7 @@ void showToastMessage(
   fToast.init(context);
   Widget toast = Container(
     width: MediaQuery.of(context).size.width - 64,
-    padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 20.0),
+    padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 14),
     decoration: BoxDecoration(
       borderRadius: BorderRadius.circular(16.0),
       gradient: CustomColors.toastMessageGradient,

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -310,11 +310,10 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
                               text: '친구에게 퀵샷으로 응원을 보냈어요',
                               icon: const Icon(
                                 Icons.emoji_emotions,
-                                color: CustomColors.whWhite,
+                                color: CustomColors.whYellow,
                               ),
                             );
                           });
-                          ;
                         }
                       },
                       onQuickShotPointerMove: (event) async {
@@ -415,7 +414,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
         text: '친구에게 메시지로 응원을 보냈어요',
         icon: const Icon(
           Icons.emoji_emotions,
-          color: CustomColors.whWhite,
+          color: CustomColors.whYellow,
         ),
       );
     });
@@ -563,7 +562,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget>
             text: '친구에게 이모지로 응원을 보냈어요',
             icon: const Icon(
               Icons.emoji_emotions,
-              color: CustomColors.whWhite,
+              color: CustomColors.whYellow,
             ),
           );
         },


### PR DESCRIPTION
# 설명
토스트메시지의 컴포넌트 디자인을 수정합니다.

Fixes #
Closes #320 
Resolves #

# 작업 내역
- 토스트메시지 vertical padding 값 조정

## 작업 결과물
|변경 후|
|---|
|<img src="https://github.com/user-attachments/assets/62e20506-54c6-4d32-8b0f-eb284b30c92a" width=350>|

## 참고 사항(선택)
세로 높이를 직접 조정하는 대신 세로 padding 값을 줄여, 이후 변경으로 글자가 짤릴 가능성을 제거하였음

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
