### PR TITLE
[#321] feat: 리액션 버블에 테두리 추가

### DIFF
--- a/lib/presentation/effects/emojis/balloon_animation/balloon_manager.dart
+++ b/lib/presentation/effects/emojis/balloon_animation/balloon_manager.dart
@@ -187,16 +187,23 @@ class BalloonParticleWidget extends StatelessWidget {
           notifyWidgetIsDisposed();
         },
         child: Container(
-          clipBehavior: Clip.hardEdge,
-          width: radius,
-          height: radius,
+          padding: const EdgeInsets.all(2),
           decoration: const BoxDecoration(
-            color: Colors.grey,
+            color: Colors.white,
             shape: BoxShape.circle,
           ),
-          child: Image(
-            fit: BoxFit.cover,
-            image: NetworkImage(imageUrl),
+          child: Container(
+            clipBehavior: Clip.hardEdge,
+            width: radius,
+            height: radius,
+            decoration: const BoxDecoration(
+              color: Colors.grey,
+              shape: BoxShape.circle,
+            ),
+            child: Image(
+              fit: BoxFit.cover,
+              image: NetworkImage(imageUrl),
+            ),
           ),
         ),
       ),

--- a/lib/presentation/effects/emojis/text_animation/text_bubble_widget.dart
+++ b/lib/presentation/effects/emojis/text_animation/text_bubble_widget.dart
@@ -225,10 +225,18 @@ class _TextBubbleWidgetState extends State<TextBubbleWidget>
                             _disappearAnimationController.value,
                         child: Padding(
                           padding: const EdgeInsets.only(left: 8.0),
-                          child: CircleAvatar(
-                            radius: 30,
-                            backgroundColor: Colors.grey,
-                            foregroundImage: NetworkImage(widget.userImageUrl),
+                          child: Container(
+                            padding: const EdgeInsets.all(2),
+                            decoration: const BoxDecoration(
+                              color: Colors.white,
+                              shape: BoxShape.circle,
+                            ),
+                            child: CircleAvatar(
+                              radius: 30,
+                              backgroundColor: Colors.grey,
+                              foregroundImage:
+                                  NetworkImage(widget.userImageUrl),
+                            ),
                           ),
                         ),
                       ),


### PR DESCRIPTION
# 설명
리액션을 위한 ImageBubble의 시안성 향상을 위해, 버블 주위에 흰색 테두리를 추가합니다.

Fixes #
Closes #321 
Resolves #

# 작업 내역
- TextBubble에 테두리 추가
- ReactionBubbleImage에 테두리 추가

## 작업 결과물
<img src="https://github.com/user-attachments/assets/949c0085-a75d-446d-a324-0bfd18fda9c3" width=375>


## 참고 사항(선택)
작업을 진행하면서 참고한 사항이나 참고할 사항이 있다면 적어주세요.
(ex. 나중에 수정해야 할 부분, 참고한 사이트, 참고한 코드 등)

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
