### PR TITLE
feat: 달력 위젯의 과거 스크롤 제한 추가

### DIFF
--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -426,6 +426,10 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
             reverse: true,
             onPageChanged: (index, reason) async {
               if (index == viewModel.calendartMondayDateList.length - 1) {
+                if (viewModel.calendartMondayDateList.first
+                    .isBefore(widget.groupEntity.groupCreatedAt)) {
+                  return;
+                }
                 // 마지막 페이지에 도달했을 때 추가 요소를 추가합니다.
                 viewModel.calendartMondayDateList.insert(
                   0,

--- a/lib/presentation/group_post/view/group_post_view.dart
+++ b/lib/presentation/group_post/view/group_post_view.dart
@@ -284,11 +284,14 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                   ),
                 );
                 final isFuture = viewModel.todayDate.isBefore(cellDate);
+                final isPast = widget.groupEntity.groupCreatedAt
+                    .subtract(const Duration(days: 1))
+                    .isAfter(cellDate);
 
                 return Expanded(
                   child: GestureDetector(
                     onTapUp: (details) async {
-                      if (!isFuture) {
+                      if (!isFuture && !isPast) {
                         provider
                             .changeSelectedDate(
                           to: cellDate,
@@ -325,7 +328,7 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                             BoxShadow(
                               offset: const Offset(0, 4),
                               blurRadius: 6,
-                              color: isFuture
+                              color: (isFuture || isPast)
                                   ? CustomColors.whGrey
                                   : cellDate == viewModel.selectedDate
                                       ? CustomColors.whYellow
@@ -346,7 +349,7 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                   style: TextStyle(
                                     fontSize: 16,
                                     fontWeight: FontWeight.w500,
-                                    color: isFuture ||
+                                    color: (isFuture || isPast) ||
                                             cellDate != viewModel.selectedDate
                                         ? CustomColors.whPlaceholderGrey
                                         : CustomColors.whBlack,
@@ -358,7 +361,7 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                               child: FittedBox(
                                 fit: BoxFit.scaleDown,
                                 child: Visibility(
-                                  visible: !isFuture,
+                                  visible: !(isFuture || isPast),
                                   replacement: Text(
                                     '-',
                                     style: TextStyle(
@@ -366,7 +369,7 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                       fontFamily: 'Giants',
                                       fontSize: 24,
                                       fontWeight: FontWeight.w700,
-                                      color: isFuture ||
+                                      color: (isFuture || isPast) ||
                                               cellDate != viewModel.selectedDate
                                           ? CustomColors.whPlaceholderGrey
                                           : CustomColors.whBlack,
@@ -395,7 +398,7 @@ class _GroupPostViewState extends ConsumerState<GroupPostView> {
                                         fontFamily: 'Giants',
                                         fontSize: 24,
                                         fontWeight: FontWeight.w700,
-                                        color: isFuture ||
+                                        color: (isFuture || isPast) ||
                                                 cellDate !=
                                                     viewModel.selectedDate
                                             ? CustomColors.whPlaceholderGrey

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -499,11 +499,15 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                 ),
               );
               final isFuture = viewModel.todayDate.isBefore(cellDate);
+              final isPast = widget.entity.startDate
+                      ?.subtract(const Duration(days: 1))
+                      .isAfter(cellDate) ??
+                  true;
 
               return Expanded(
                 child: GestureDetector(
                   onTapUp: (details) async {
-                    if (!isFuture) {
+                    if (!isFuture && !isPast) {
                       provider
                           .changeSelectedDate(
                         to: cellDate,
@@ -540,7 +544,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                           BoxShadow(
                             offset: const Offset(0, 4),
                             blurRadius: 6,
-                            color: isFuture
+                            color: (isFuture || isPast)
                                 ? CustomColors.whGrey
                                 : cellDate == viewModel.selectedDate
                                     ? CustomColors.whYellow
@@ -561,7 +565,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                                 style: TextStyle(
                                   fontSize: 16,
                                   fontWeight: FontWeight.w500,
-                                  color: isFuture ||
+                                  color: (isFuture || isPast) ||
                                           cellDate != viewModel.selectedDate
                                       ? CustomColors.whPlaceholderGrey
                                       : CustomColors.whBlack,
@@ -581,7 +585,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                                     fontFamily: 'Giants',
                                     fontSize: 24,
                                     fontWeight: FontWeight.w700,
-                                    color: isFuture ||
+                                    color: (isFuture || isPast) ||
                                             cellDate != viewModel.selectedDate
                                         ? CustomColors.whPlaceholderGrey
                                         : CustomColors.whBlack,
@@ -610,7 +614,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                                       fontFamily: 'Giants',
                                       fontSize: 24,
                                       fontWeight: FontWeight.w700,
-                                      color: isFuture ||
+                                      color: (isFuture || isPast) ||
                                               cellDate != viewModel.selectedDate
                                           ? CustomColors.whPlaceholderGrey
                                           : CustomColors.whBlack,
@@ -637,6 +641,11 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
           reverse: true,
           onPageChanged: (index, reason) async {
             if (index == viewModel.calendartMondayDateList.length - 1) {
+              if (widget.entity.startDate
+                      ?.isAfter(viewModel.calendartMondayDateList.first) ??
+                  true) {
+                return;
+              }
               // 마지막 페이지에 도달했을 때 추가 요소를 추가합니다.
               viewModel.calendartMondayDateList.insert(
                 0,


### PR DESCRIPTION
# 설명
기존에 무한히 과거로 스크롤이 가능했던 횡스크롤 달력에서
목표 / 그룹 생성일까지만 스크롤이 가능하며, 생성일 이전의 날짜는 비활성화되도록 로직을 수정합니다.

Fixes #
Closes #323
Resolves #

# 작업 내역

- 마이페이지의 목표별 횡스크롤 달력에서 로직 수정
- 그룹 횡스크롤 달력에서 로직 수정

## 작업 결과물
<img src="https://github.com/user-attachments/assets/02d27bcb-3af6-4456-b423-8f9cb04801aa" width=375>


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
