### PR TITLE
[#348] HOTFIX: 내 친구들 페이지 리액션카메라뷰 로드 조건 변경 및 버전업

### DIFF
--- a/lib/presentation/group_post/view/friend_post_view.dart
+++ b/lib/presentation/group_post/view/friend_post_view.dart
@@ -91,7 +91,7 @@ class _FriendPostViewState extends ConsumerState<FriendPostView> {
   Widget build(BuildContext context) {
     final viewModel = ref.watch(friendPostViewModelProvider);
     final provider = ref.read(friendPostViewModelProvider.notifier);
-    final reactionCameraViewModel = ref.watch(reactionCameraWidgetModelProvider);
+    // final reactionCameraViewModel = ref.watch(reactionCameraWidgetModelProvider);
 
     return Stack(
       children: [
@@ -227,9 +227,9 @@ class _FriendPostViewState extends ConsumerState<FriendPostView> {
                         ),
                         child: SingleChildScrollView(
                           padding: const EdgeInsets.only(bottom: 20.0),
-                          physics: reactionCameraViewModel.isFocusingMode
-                              ? const NeverScrollableScrollPhysics()
-                              : const AlwaysScrollableScrollPhysics(),
+                          // physics: reactionCameraViewModel.isFocusingMode
+                          //     ? const NeverScrollableScrollPhysics()
+                          //     : const AlwaysScrollableScrollPhysics(),
                           child: Column(
                             children: List<Widget>.generate(
                               entityList.length,
@@ -251,7 +251,16 @@ class _FriendPostViewState extends ConsumerState<FriendPostView> {
             ),
           ),
         ),
-        const ReactionCameraWidget(),
+        ValueListenableBuilder(
+          valueListenable: reactionCameraWidgetModeNotifier,
+          builder: (context, value, child) {
+            if (value != ReactionCameraWidgetMode.none) {
+              return const ReactionCameraWidget();
+            } else {
+              return Container();
+            }
+          },
+        ),
       ],
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: wehavit
 description: A new Havit tracking app without the comparing others.
 publish_to: "none"
 
-version: 1.0.10+10
+version: 1.0.11+11
 
 environment:
   sdk: ">=3.4.3 <4.0.0"


### PR DESCRIPTION
# 설명
ReactionCameraView의 로직 및 GroupPostView에서의 카메라뷰의 렌더링 조건을 변경하는 과정에서, 내 친구들 페이지의 카메라 렌더 조건을 변경하지 않아 사용에 문제가 발생하고 있었습니다. 본 PR로 해당 문제를 수정하였습니다. 

Fixes #
Closes #348 
Resolves #

# 작업 내역
- 내 친구들 페이지의 ReactionCameraView의 렌더링 조건을 변경하여, 정상적으로 작동할 수 있도록 수정하였습니다.
- v1.0.11으로 버전 정보를 변경하였습니다.

## 작업 결과물
release 빌드 및 abb 파일 play console에 업로드 완료

## 참고 사항(선택)
작업을 진행하면서 참고한 사항이나 참고할 사항이 있다면 적어주세요.
(ex. 나중에 수정해야 할 부분, 참고한 사이트, 참고한 코드 등)

# 체크 리스트
- [ ] 이해하기 어려운 부분은 주석을 달았습니다.
- [ ] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [ ] 내 코드에 불필요한 print 등이 없습니다.
