### PR TITLE
[#353] feat: 나의 UserEntity 를 공용 State로 변경

### DIFF
--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -42,7 +42,6 @@ final addFriendProvider = StateNotifierProvider.autoDispose<AddFriendNotifier, S
 final friendListViewModelProvider = StateNotifierProvider<FriendListViewModelProvider, FriendListViewModel>((ref) {
   final getFriendListUsecase = ref.read(getFriendListUseCaseProvider);
   final searchUserDataListByHandleUsecase = ref.read(searchUserDataListByHandleUsecaseProvider);
-  final getMyUserDataUsecase = ref.read(getMyUserDataUsecaseProvider);
   final getAppliedUserListForFriendUsecase = ref.read(getAppliedUserListForFriendUsecaseProvider);
   final AcceptApplyingForFriendUsecase acceptApplyingForFriendUsecase =
       ref.read(acceptApplyingForFriendUsecaseProvider);
@@ -54,7 +53,6 @@ final friendListViewModelProvider = StateNotifierProvider<FriendListViewModelPro
   return FriendListViewModelProvider(
     getFriendListUsecase,
     searchUserDataListByHandleUsecase,
-    getMyUserDataUsecase,
     getAppliedUserListForFriendUsecase,
     acceptApplyingForFriendUsecase,
     rejectApplyingForFriendUsecase,

--- a/lib/domain/usecases/send_comment_reaction_to_confirm_post_usecase.dart
+++ b/lib/domain/usecases/send_comment_reaction_to_confirm_post_usecase.dart
@@ -40,7 +40,7 @@ class SendCommentReactionToConfirmPostUsecase extends FutureUseCase<void, (Confi
         type: UserIncrementalDataType.reaction,
       );
       _resolutionRepository.incrementReceivedReactionCount(
-        targetResolutionId: params.$1.resolutionId ?? '',
+        targetResolutionId: params.$1.resolutionId,
       );
     });
   }

--- a/lib/domain/usecases/send_emoji_reaction_to_confirm_post_usercase.dart
+++ b/lib/domain/usecases/send_emoji_reaction_to_confirm_post_usercase.dart
@@ -44,7 +44,7 @@ class SendEmojiReactionToConfirmPostUsecase extends FutureUseCase<void, (Confirm
         type: UserIncrementalDataType.reaction,
       );
       _resolutionRepository.incrementReceivedReactionCount(
-        targetResolutionId: params.$1.resolutionId ?? '',
+        targetResolutionId: params.$1.resolutionId,
       );
     });
   }

--- a/lib/domain/usecases/send_quickshot_reaction_to_confirm_post_usecase.dart
+++ b/lib/domain/usecases/send_quickshot_reaction_to_confirm_post_usecase.dart
@@ -58,7 +58,7 @@ class SendQuickShotReactionToConfirmPostUsecase extends FutureUseCase<void, (Con
         type: UserIncrementalDataType.reaction,
       );
       _resolutionRepository.incrementReceivedReactionCount(
-        targetResolutionId: params.$1.resolutionId ?? '',
+        targetResolutionId: params.$1.resolutionId,
       );
     });
   }

--- a/lib/presentation/common_components/my_profile_block.dart
+++ b/lib/presentation/common_components/my_profile_block.dart
@@ -30,8 +30,9 @@ class MyProfileBlock extends StatelessWidget {
         padding: const EdgeInsets.all(12),
         child: EitherFutureBuilder<UserDataEntity>(
           target: futureUserEntity,
-          forWaiting: const UserProfileCell(
-            type: UserProfileCellType.loading,
+          forWaiting: UserProfileCell(
+            futureUserEntity,
+            type: UserProfileCellType.profile,
           ),
           forFail: Container(
             alignment: Alignment.center,
@@ -43,7 +44,7 @@ class MyProfileBlock extends StatelessWidget {
           mainWidgetCallback: (userEntity) {
             return Row(
               children: [
-                const Expanded(child: UserProfileCell(type: UserProfileCellType.profile)),
+                Expanded(child: UserProfileCell(futureUserEntity, type: UserProfileCellType.profile)),
                 Column(
                   children: [
                     Image.asset(

--- a/lib/presentation/common_components/my_wehavit_summary.dart
+++ b/lib/presentation/common_components/my_wehavit_summary.dart
@@ -34,7 +34,8 @@ class MyWehavitSummary extends StatelessWidget {
             ),
             child: Column(
               children: [
-                const UserProfileCell(
+                UserProfileCell(
+                  futureUserEntity,
                   type: UserProfileCellType.profile,
                 ),
                 const SizedBox(

--- a/lib/presentation/common_components/user_profile_cell.dart
+++ b/lib/presentation/common_components/user_profile_cell.dart
@@ -1,7 +1,7 @@
 import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:wehavit/common/constants/app_colors.dart';
-import 'package:wehavit/common/utils/datetime+.dart';
+import 'package:wehavit/common/utils/utils.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
@@ -10,21 +10,20 @@ enum UserProfileCellType {
   deleteMode,
   invited,
   inviting,
-  loading,
   profile;
 }
 
 class UserProfileCell extends StatelessWidget {
-  const UserProfileCell({required this.type, super.key});
+  const UserProfileCell(this.futureUserEntity, {required this.type, super.key});
 
   final UserProfileCellType type;
+  final EitherFuture<UserDataEntity> futureUserEntity;
 
   @override
   Widget build(BuildContext context) {
     final actions = switch (type) {
       UserProfileCellType.normal => Container(),
       UserProfileCellType.profile => Container(),
-      UserProfileCellType.loading => Container(),
       UserProfileCellType.deleteMode =>
         SmallColoredButton(buttonLabel: '친구 삭제', onPressed: () {}, backgroundColor: CustomColors.whGrey600),
       UserProfileCellType.inviting => SmallColoredButton(buttonLabel: '친구 요청', onPressed: () {}),
@@ -37,8 +36,9 @@ class UserProfileCell extends StatelessWidget {
         ),
     };
 
-    if (type == UserProfileCellType.loading) {
-      return Row(
+    return EitherFutureBuilder<UserDataEntity>(
+      target: futureUserEntity,
+      forWaiting: Row(
         children: [
           Container(
             width: 40,
@@ -73,47 +73,162 @@ class UserProfileCell extends StatelessWidget {
           ),
           actions,
         ],
-      );
-    }
-
-    return Row(
-      children: [
-        const CircleProfileImage(size: 40, url: 'https://cdn.sisain.co.kr/news/photo/202405/53124_99734_5711.jpg'),
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Text(
-                      '닉네임',
-                      style: context.bodyMedium?.bold,
-                    ),
-                    const SizedBox(width: 4),
-                    // profile 유형이 아닐 때에만 아이디를 노출
-                    if (type != UserProfileCellType.profile)
-                      Text(
-                        '아이디',
-                        overflow: TextOverflow.ellipsis,
-                        style: context.bodySmall,
+      ),
+      forFail: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: const BoxDecoration(shape: BoxShape.circle, color: CustomColors.whGrey400),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Container(
+                        width: 90,
+                        height: 18,
+                        decoration:
+                            BoxDecoration(color: CustomColors.whGrey400, borderRadius: BorderRadius.circular(4)),
                       ),
-                  ],
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  '상태 메시지',
-                  style: context.labelSmall?.copyWith(color: CustomColors.whGrey800),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  Container(
+                    width: 140,
+                    height: 14,
+                    decoration: BoxDecoration(color: CustomColors.whGrey400, borderRadius: BorderRadius.circular(4)),
+                  ),
+                ],
+              ),
             ),
           ),
-        ),
-        actions,
-      ],
+          actions,
+        ],
+      ),
+      mainWidgetCallback: (entity) {
+        return Row(
+          children: [
+            CircleProfileImage(size: 40, url: entity.userImageUrl),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          entity.userName,
+                          style: context.bodyMedium?.bold,
+                        ),
+                        const SizedBox(width: 4),
+                        // profile 유형이 아닐 때에만 아이디를 노출
+                        if (type != UserProfileCellType.profile)
+                          Text(
+                            entity.handle,
+                            overflow: TextOverflow.ellipsis,
+                            style: context.bodySmall,
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      entity.aboutMe,
+                      style: context.labelSmall?.copyWith(color: CustomColors.whGrey800),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            actions,
+          ],
+        );
+      },
     );
+
+    // if (type == UserProfileCellType.loading) {
+    //   return Row(
+    //     children: [
+    //       Container(
+    //         width: 40,
+    //         height: 40,
+    //         decoration: const BoxDecoration(shape: BoxShape.circle, color: CustomColors.whGrey400),
+    //       ),
+    //       Expanded(
+    //         child: Padding(
+    //           padding: const EdgeInsets.symmetric(horizontal: 8),
+    //           child: Column(
+    //             crossAxisAlignment: CrossAxisAlignment.start,
+    //             children: [
+    //               Row(
+    //                 children: [
+    //                   Container(
+    //                     width: 90,
+    //                     height: 18,
+    //                     decoration:
+    //                         BoxDecoration(color: CustomColors.whGrey400, borderRadius: BorderRadius.circular(4)),
+    //                   ),
+    //                 ],
+    //               ),
+    //               const SizedBox(height: 2),
+    //               Container(
+    //                 width: 140,
+    //                 height: 14,
+    //                 decoration: BoxDecoration(color: CustomColors.whGrey400, borderRadius: BorderRadius.circular(4)),
+    //               ),
+    //             ],
+    //           ),
+    //         ),
+    //       ),
+    //       actions,
+    //     ],
+    //   );
+    // }
+
+    // return Row(
+    //   children: [
+    //     const CircleProfileImage(size: 40, url: 'https://cdn.sisain.co.kr/news/photo/202405/53124_99734_5711.jpg'),
+    //     Expanded(
+    //       child: Padding(
+    //         padding: const EdgeInsets.symmetric(horizontal: 8),
+    //         child: Column(
+    //           crossAxisAlignment: CrossAxisAlignment.start,
+    //           children: [
+    //             Row(
+    //               children: [
+    //                 Text(
+    //                   '닉네임',
+    //                   style: context.bodyMedium?.bold,
+    //                 ),
+    //                 const SizedBox(width: 4),
+    //                 // profile 유형이 아닐 때에만 아이디를 노출
+    //                 if (type != UserProfileCellType.profile)
+    //                   Text(
+    //                     '아이디',
+    //                     overflow: TextOverflow.ellipsis,
+    //                     style: context.bodySmall,
+    //                   ),
+    //               ],
+    //             ),
+    //             const SizedBox(height: 2),
+    //             Text(
+    //               '상태 메시지',
+    //               style: context.labelSmall?.copyWith(color: CustomColors.whGrey800),
+    //               overflow: TextOverflow.ellipsis,
+    //             ),
+    //           ],
+    //         ),
+    //       ),
+    //     ),
+    //     actions,
+    //   ],
+    // );
   }
 }
 

--- a/lib/presentation/friend_list/model/friend_list_view_model.dart
+++ b/lib/presentation/friend_list/model/friend_list_view_model.dart
@@ -2,7 +2,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 
 class FriendListViewModel {
-  EitherFuture<UserDataEntity>? futureMyUserDataEntity;
+  // EitherFuture<UserDataEntity>? futureMyUserDataEntity;
 
   List<EitherFuture<UserDataEntity>>? friendFutureUserList;
 

--- a/lib/presentation/friend_list/provider/friend_list_view_model_provider.dart
+++ b/lib/presentation/friend_list/provider/friend_list_view_model_provider.dart
@@ -8,7 +8,6 @@ class FriendListViewModelProvider extends StateNotifier<FriendListViewModel> {
   FriendListViewModelProvider(
     this._getFriendListUsecase,
     this._searchUserDataListByHandleUsecase,
-    this._getMyUserDataUsecase,
     this._getAppliedUserListForFriendUsecase,
     this._acceptApplyingForFriendUsecase,
     this._rejectApplyingForFriendUsecase,
@@ -20,7 +19,6 @@ class FriendListViewModelProvider extends StateNotifier<FriendListViewModel> {
   final GetFriendListUsecase _getFriendListUsecase;
   final GetAppliedUserListForFriendUsecase _getAppliedUserListForFriendUsecase;
   final SearchUserDataListByHandleUsecase _searchUserDataListByHandleUsecase;
-  final GetMyUserDataUsecase _getMyUserDataUsecase;
   final AcceptApplyingForFriendUsecase _acceptApplyingForFriendUsecase;
   final RejectApplyingForFriendUsecase _rejectApplyingForFriendUsecase;
   final RemoveFriendUsecase _removeFriendUsecase;
@@ -54,10 +52,6 @@ class FriendListViewModelProvider extends StateNotifier<FriendListViewModel> {
         (list) => list,
       ),
     );
-  }
-
-  Future<void> getMyUserDataEntity() async {
-    state.futureMyUserDataEntity = _getMyUserDataUsecase();
   }
 
   Future<void> rejectToBeFriendWith({required String targetUid}) async {

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -6,6 +6,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/common_components/user_profile_cell.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class FriendListView extends ConsumerStatefulWidget {
   const FriendListView({super.key});
@@ -45,7 +46,8 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
           replacement: Column(
             children: [
               MyProfileBlock(
-                futureUserEntity: viewModel.futureMyUserDataEntity!,
+                // futureUserEntity: viewModel.futureMyUserDataEntity!,
+                futureUserEntity: ref.read(getMyUserDataProvider).value!,
               ),
               const SizedBox(
                 height: 32.0,

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
-import 'package:wehavit/presentation/common_components/user_profile_cell.dart';
 import 'package:wehavit/presentation/presentation.dart';
 import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
@@ -82,7 +81,7 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                               unawaited(
                                 ref
                                     .read(friendListViewModelProvider.notifier)
-                                    .getAppliedFriendList()
+                                    .getFriendList()
                                     .whenComplete(() => setState(() {})),
                               );
                             },
@@ -90,11 +89,13 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                               padding: const EdgeInsets.only(bottom: 64),
                               itemCount: viewModel.friendFutureUserList!.length,
                               itemBuilder: (context, index) {
-                                // return FriendListCellWidget(
-                                //   futureUserEntity: viewModel.friendFutureUserList![index],
-                                //   cellState: FriendListCellState.normal,
-                                // );
-                                return UserProfileCell(type: UserProfileCellType.loading);
+                                return Container(
+                                  padding: const EdgeInsets.only(bottom: 12.0),
+                                  child: UserProfileCell(
+                                    viewModel.friendFutureUserList![index],
+                                    type: UserProfileCellType.normal,
+                                  ),
+                                );
                               },
                             ),
                           ),

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -12,6 +12,7 @@ import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 import 'package:wehavit/presentation/effects/effects.dart';
 import 'package:wehavit/presentation/group_post/group_post.dart';
+import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class ConfirmPostWidget extends ConsumerStatefulWidget {
   const ConfirmPostWidget({
@@ -58,7 +59,7 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget> with Tick
       targetResolutionId: widget.confirmPostEntity.resolutionId,
     );
 
-    myUserEntity = await ref.read(myPageViewModelProvider).futureMyUserDataEntity?.then(
+    myUserEntity = await ref.read(getMyUserDataProvider).value!.then(
           (result) => result.fold(
             (failure) => null,
             (entity) => entity,

--- a/lib/presentation/main/view/main_view.dart
+++ b/lib/presentation/main/view/main_view.dart
@@ -49,7 +49,7 @@ class MainViewState extends ConsumerState<MainView> with TickerProviderStateMixi
 
   Future<void> loadUserData() async {
     ref.read(myPageViewModelProvider.notifier).loadData();
-    ref.read(friendListViewModelProvider.notifier).getMyUserDataEntity();
+    // ref.read(friendListViewModelProvider.notifier).getMyUserDataEntity();
   }
 
   Future<void> loadResolutionData() async {

--- a/lib/presentation/main/view/main_view.dart
+++ b/lib/presentation/main/view/main_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class MainView extends ConsumerStatefulWidget {
   const MainView({super.key});
@@ -95,7 +96,7 @@ class MainViewState extends ConsumerState<MainView> with TickerProviderStateMixi
 
   @override
   Widget build(BuildContext context) {
-    final myPageViewModel = ref.watch(myPageViewModelProvider);
+    // final myPageViewModel = ref.watch(myPageViewModelProvider);
     return Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: CustomColors.whDarkBlack,
@@ -152,7 +153,7 @@ class MainViewState extends ConsumerState<MainView> with TickerProviderStateMixi
                             ),
                             TabBarProfileImageButton(
                               isSelected: tabController.index == 3,
-                              futureUserDataEntity: myPageViewModel.futureMyUserDataEntity!,
+                              futureUserDataEntity: ref.read(getMyUserDataProvider).value!,
                             ),
                           ],
                         ),

--- a/lib/presentation/my_page/model/my_page_view_model.dart
+++ b/lib/presentation/my_page/model/my_page_view_model.dart
@@ -3,5 +3,4 @@ import 'package:wehavit/domain/entities/entities.dart';
 
 class MyPageViewModel {
   EitherFuture<List<ResolutionEntity>>? futureMyyResolutionList;
-  EitherFuture<UserDataEntity>? futureMyUserDataEntity;
 }

--- a/lib/presentation/my_page/provider/my_page_view_model_provider.dart
+++ b/lib/presentation/my_page/provider/my_page_view_model_provider.dart
@@ -20,15 +20,10 @@ class MyPageViewModelProvider extends StateNotifier<MyPageViewModel> {
 
   Future<void> loadData() async {
     getResolutionList();
-    getMyUserData();
   }
 
   Future<void> getResolutionList() async {
     state.futureMyyResolutionList = getMyResolutionListUsecase();
-  }
-
-  Future<void> getMyUserData() async {
-    state.futureMyUserDataEntity = getMyUserDataUsecase();
   }
 
   Future<bool> revokeAppleSignIn() async {

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -6,8 +6,8 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/presentation/common_components/my_wehavit_summary.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class MyPageView extends ConsumerStatefulWidget {
   const MyPageView(this.index, this.tabController, {super.key});
@@ -68,8 +68,6 @@ class MyPageScreenState extends ConsumerState<MyPageView> with AutomaticKeepAliv
                 mainViewState,
                 deleteAccount,
               );
-              //   showToastMessage(context,
-              //       text: '안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요');
             },
           ),
           body: Container(
@@ -84,12 +82,12 @@ class MyPageScreenState extends ConsumerState<MyPageView> with AutomaticKeepAliv
                 padding: const EdgeInsets.only(bottom: 64.0),
                 children: [
                   // 내 프로필
-                  // MyPageWehavitSummaryWidget(
-                  //   futureUserEntity: viewModel.futureMyUserDataEntity,
-                  // ),
-                  MyWehavitSummary(
-                    futureUserEntity: viewModel.futureMyUserDataEntity!,
+                  MyPageWehavitSummaryWidget(
+                    futureUserEntity: ref.read(getMyUserDataProvider).value,
                   ),
+                  // MyWehavitSummary(
+                  //   futureUserEntity: ref.read(getMyUserDataProvider).value!,
+                  // ),
                   const SizedBox(
                     height: 16,
                   ),
@@ -187,10 +185,6 @@ class MyPageScreenState extends ConsumerState<MyPageView> with AutomaticKeepAliv
                     ).then((result) {
                       if (result == true) {
                         mainViewState?.setState(() {});
-
-                        ref.read(myPageViewModelProvider.notifier).getMyUserData().whenComplete(() {
-                          setState(() {});
-                        });
                       }
 
                       Navigator.pop(context);

--- a/lib/presentation/state/user_data/my_user_data_provider.dart
+++ b/lib/presentation/state/user_data/my_user_data_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/dependency/dependency.dart';
+import 'package:wehavit/domain/domain.dart';
+
+class MyUserDataNotifier extends StateNotifier<UserDataEntity> {
+  MyUserDataNotifier({
+    required this.getMyUserDataUsecase,
+  }) : super(UserDataEntity.dummyModel);
+
+  final GetMyUserDataUsecase getMyUserDataUsecase;
+}
+
+final myUserDataStateProvider = StateNotifierProvider<MyUserDataNotifier, UserDataEntity>(
+  (ref) => MyUserDataNotifier(
+    getMyUserDataUsecase: ref.read(getMyUserDataUsecaseProvider),
+  ),
+);
+
+final getMyUserDataProvider = FutureProvider<EitherFuture<UserDataEntity>>(
+  (ref) => ref.read(getMyUserDataUsecaseProvider).call(),
+);

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -326,7 +326,6 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
                       )
                           .whenComplete(() {
                         Navigator.pop(context, true);
-
                         showToastMessage(
                           context,
                           text: '성공적으로 인증을 남겼어요',

--- a/lib/presentation/write_post/view/writing_confirm_post_view.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view.dart
@@ -7,6 +7,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class WritingConfirmPostView extends ConsumerStatefulWidget {
   const WritingConfirmPostView({
@@ -207,7 +208,7 @@ class _WritingConfirmPostViewState extends ConsumerState<WritingConfirmPostView>
                   viewModel.isUploading = true;
                   setState(() {});
 
-                  final myUserEntity = await ref.read(myPageViewModelProvider).futureMyUserDataEntity?.then(
+                  final myUserEntity = await ref.read(getMyUserDataProvider).value!.then(
                         (result) => result.fold(
                           (failure) => null,
                           (entity) => entity,


### PR DESCRIPTION
# 설명
내 사용자 정보(UserEntity)를 공용 상태로 관리하며, 화면에서 하나의 State를 공유하도록 변경합니다.

Fixes #
Closes #353 
Resolves #

# 작업 내역
- 사용자 정보를 공용 State (myUserDataStateProvider) 에서 관리
- 탭바, 친구목록, 마이페이지에서 해당 State에 접근해 사용하도록 변경

## 작업 결과물
공용 State 추가 및 화면 전환을 하더라도 내 정보를 가져오는 Usecase는 한 번만 호출하도록 구현하였음

## 참고 사항(선택)
내 사용자정보 State를 AutoDispose 로 설정하는 경우, 탭 전환 시 마다 새로 UserState를 불러오는 Usecase를 호출하면서, 안하느니만 못하는 문제가 발생함. (watch로 구독하는 화면이 하나도 없어서 이렇게 되는 것 같다.)
그래서 앱 실행하는 동안 계속 유지되어야 하는 상태이기에 AutoDispose 처리를 해주지 않았음. 

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
