### PR TITLE
[#357] refactor: 목표 목록을 공용 State로 변환 및 컴포넌트 수정

### DIFF
--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -110,6 +110,7 @@ final resolutionListViewModelProvider =
   final getTargetResolutionDoneCountForWeekUsecase = ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider);
   final uploadConfirmPostUsecase = ref.watch(uploadConfirmPostUseCaseProvider);
   return ResolutionListViewModelProvider(
+    ref,
     getMyResolutionListUsecase,
     getTargetResolutionDoneCountForWeekUsecase,
     uploadConfirmPostUsecase,
@@ -121,6 +122,7 @@ final writingConfirmPostViewModelProvider =
   final uploadConfirmPostUsecase = ref.watch(uploadConfirmPostUseCaseProvider);
   final sendNotificationToSharedUsersUsecase = ref.watch(sendNotificationToSharedUsersUsecaseProvider);
   return WritingConfirmPostViewModelProvider(
+    ref,
     uploadConfirmPostUsecase,
     sendNotificationToSharedUsersUsecase,
   );

--- a/lib/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart
+++ b/lib/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart
@@ -19,6 +19,18 @@ class GetTargetResolutionDoneListForWeekUsecase {
 class GetTargetResolutionDoneListForWeekUsecaseParams {
   GetTargetResolutionDoneListForWeekUsecaseParams({required this.resolutionId, required this.startMonday});
 
-  String resolutionId;
-  DateTime startMonday;
+  final String resolutionId;
+  final DateTime startMonday;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is GetTargetResolutionDoneListForWeekUsecaseParams &&
+        other.resolutionId == resolutionId &&
+        other.startMonday == startMonday;
+  }
+
+  @override
+  int get hashCode => resolutionId.hashCode ^ startMonday.hashCode;
 }

--- a/lib/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart
+++ b/lib/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart
@@ -1,4 +1,3 @@
-import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/repositories/repositories.dart';
 
@@ -9,16 +8,17 @@ class GetTargetResolutionDoneListForWeekUsecase {
 
   final ResolutionRepository _resolutionRepository;
 
-  EitherFuture<List<bool>> call({
-    required String? resolutionId,
-    required DateTime startMonday,
-  }) {
-    if (resolutionId == null) {
-      return Future(() => left(const Failure('resolution id is null')));
-    }
+  EitherFuture<List<bool>> call({required GetTargetResolutionDoneListForWeekUsecaseParams param}) {
     return _resolutionRepository.getResolutionDoneListForWeek(
-      resolutionId: resolutionId,
-      startMonday: startMonday,
+      resolutionId: param.resolutionId,
+      startMonday: param.startMonday,
     );
   }
+}
+
+class GetTargetResolutionDoneListForWeekUsecaseParams {
+  GetTargetResolutionDoneListForWeekUsecaseParams({required this.resolutionId, required this.startMonday});
+
+  String resolutionId;
+  DateTime startMonday;
 }

--- a/lib/presentation/common_components/circular_status_indicator.dart
+++ b/lib/presentation/common_components/circular_status_indicator.dart
@@ -27,18 +27,18 @@ class CircularStatusIndicator extends StatelessWidget {
           width: isDone ? 0 : 1,
         ),
       ),
-      width: 25,
-      height: 25,
+      width: 20,
+      height: 20,
       alignment: Alignment.center,
       child: isDone
           ? WHIcon(
-              size: WHIconsize.small,
+              size: WHIconsize.extraSmall,
               iconString: WHIcons.checkMark,
               iconColor: isDone ? CustomColors.whGrey900 : CustomColors.whGrey600,
             )
           : Text(
               innerLabel,
-              style: context.labelLarge?.copyWith(
+              style: context.labelMedium?.copyWith(
                 color: isDone ? CustomColors.whGrey900 : CustomColors.whGrey600,
                 fontWeight: FontWeight.w400,
                 height: 0.8,

--- a/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
+++ b/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
@@ -19,7 +19,7 @@ class ResolutionLinearGaugeIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Consumer(
-      builder: (BuildContext context, WidgetRef ref, Widget? child) {
+      builder: (BuildContext context, WidgetRef ref, _) {
         final param = GetTargetResolutionDoneListForWeekUsecaseParams(
           resolutionId: resolutionEntity.resolutionId,
           startMonday: targetDate.getMondayDateTime(),

--- a/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
+++ b/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
@@ -1,130 +1,144 @@
 import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/presentation/common_components/common_components.dart';
+import 'package:wehavit/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 class ResolutionLinearGaugeIndicator extends StatelessWidget {
   const ResolutionLinearGaugeIndicator({
     required this.resolutionEntity,
-    required this.futureDoneList,
+    required this.targetDate,
     super.key,
   });
 
   final ResolutionEntity resolutionEntity;
-  final EitherFuture<List<bool>> futureDoneList;
+  final DateTime targetDate;
 
   @override
   Widget build(BuildContext context) {
-    return EitherFutureBuilder<List<bool>>(
-      target: futureDoneList,
-      forWaiting: Column(
-        children: [
-          Row(
+    return Consumer(
+      builder: (BuildContext context, WidgetRef ref, Widget? child) {
+        final param = GetTargetResolutionDoneListForWeekUsecaseParams(
+          resolutionId: resolutionEntity.resolutionId,
+          startMonday: targetDate.getMondayDateTime(),
+        );
+
+        final weeklyDoneList = ref.watch(
+          weeklyResolutionInfoProvider(param),
+        );
+
+        return weeklyDoneList.when(
+          data: (successList) {
+            final successCount = successList.where((element) => element == true).length;
+
+            return Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        resolutionEntity.actionStatement,
+                        style: context.bodyMedium?.copyWith(
+                          color: CustomColors.whGrey900,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(
+                      width: 4.0,
+                    ),
+                    Text(
+                      '주 ${resolutionEntity.actionPerWeek}회 중 $successCount회 실천',
+                      style: context.bodySmall?.copyWith(
+                        color: CustomColors.whGrey900,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 4,
+                ),
+                Container(
+                  clipBehavior: Clip.hardEdge,
+                  decoration: const BoxDecoration(),
+                  child: Stack(
+                    alignment: Alignment.centerLeft,
+                    children: [
+                      Container(
+                        height: 8,
+                        width: double.infinity,
+                        color: CustomColors.whDarkBlack,
+                      ),
+                      Flex(
+                        direction: Axis.horizontal,
+                        children: [
+                          Flexible(
+                            flex: successCount,
+                            child: Container(
+                              height: 8,
+                              color: CustomColors.pointColorList[resolutionEntity.colorIndex],
+                            ),
+                          ),
+                          Flexible(
+                            flex: (resolutionEntity.actionPerWeek) - successCount,
+                            child: Container(
+                              height: 8,
+                              color: Colors.transparent,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+          error: (e, _) => Column(
             children: [
               Text(
-                resolutionEntity.actionStatement,
-                textAlign: TextAlign.left,
+                '정보를 가져오는데 실패했어요',
                 style: context.bodyMedium?.copyWith(
                   color: CustomColors.whGrey900,
-                  overflow: TextOverflow.ellipsis,
                 ),
+              ),
+              const SizedBox(
+                height: 4,
+              ),
+              Container(
+                height: 8,
+                color: CustomColors.whGrey600,
               ),
             ],
           ),
-          const SizedBox(
-            height: 4,
-          ),
-          LinearProgressIndicator(
-            minHeight: 8,
-            color: CustomColors.pointColorList[resolutionEntity.colorIndex],
-            backgroundColor: CustomColors.whGrey100,
-          ),
-        ],
-      ),
-      forFail: Column(
-        children: [
-          Text(
-            '정보를 가져오는데 실패했어요',
-            style: context.bodyMedium?.copyWith(
-              color: CustomColors.whGrey900,
-            ),
-          ),
-          const SizedBox(
-            height: 4,
-          ),
-          Container(
-            height: 8,
-            color: CustomColors.whGrey600,
-          ),
-        ],
-      ),
-      mainWidgetCallback: (successList) {
-        final successCount = successList.where((element) => element == true).length;
-
-        return Column(
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: Text(
+          loading: () => Column(
+            children: [
+              Row(
+                children: [
+                  Text(
                     resolutionEntity.actionStatement,
+                    textAlign: TextAlign.left,
                     style: context.bodyMedium?.copyWith(
                       color: CustomColors.whGrey900,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                ),
-                const SizedBox(
-                  width: 4.0,
-                ),
-                Text(
-                  '주 ${resolutionEntity.actionPerWeek}회 중 $successCount회 실천',
-                  style: context.bodySmall?.copyWith(
-                    color: CustomColors.whGrey900,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(
-              height: 4,
-            ),
-            Container(
-              clipBehavior: Clip.hardEdge,
-              decoration: const BoxDecoration(),
-              child: Stack(
-                alignment: Alignment.centerLeft,
-                children: [
-                  Container(
-                    height: 8,
-                    width: double.infinity,
-                    color: CustomColors.whDarkBlack,
-                  ),
-                  Flex(
-                    direction: Axis.horizontal,
-                    children: [
-                      Flexible(
-                        flex: successCount,
-                        child: Container(
-                          height: 8,
-                          color: CustomColors.pointColorList[resolutionEntity.colorIndex],
-                        ),
-                      ),
-                      Flexible(
-                        flex: (resolutionEntity.actionPerWeek) - successCount,
-                        child: Container(
-                          height: 8,
-                          color: Colors.transparent,
-                        ),
-                      ),
-                    ],
-                  ),
                 ],
               ),
-            ),
-          ],
+              const SizedBox(
+                height: 4,
+              ),
+              LinearProgressIndicator(
+                minHeight: 8,
+                color: CustomColors.pointColorList[resolutionEntity.colorIndex],
+                backgroundColor: CustomColors.whGrey100,
+              ),
+            ],
+          ),
         );
       },
     );

--- a/lib/presentation/common_components/resolution_list_cell.dart
+++ b/lib/presentation/common_components/resolution_list_cell.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 
 class ResolutionListCell extends ConsumerStatefulWidget {
@@ -25,10 +26,12 @@ class ResolutionListCell extends ConsumerStatefulWidget {
 class _ResolutionListCellWidgetState extends ConsumerState<ResolutionListCell> {
   @override
   Widget build(BuildContext context) {
-    EitherFuture<List<bool>> futureDoneList = ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
-      resolutionId: widget.resolutionEntity.resolutionId,
-      startMonday: DateTime.now().getMondayDateTime(),
-    );
+    // EitherFuture<List<bool>> futureDoneList = ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
+    //   param: GetTargetResolutionDoneListForWeekUsecaseParams(
+    //     resolutionId: widget.resolutionEntity.resolutionId,
+    //     startMonday: DateTime.now().getMondayDateTime(),
+    //   ),
+    // );
 
     final daysSinceFirstDay = DateTime.now().difference(widget.resolutionEntity.startDate).inDays + 1;
 
@@ -59,9 +62,18 @@ class _ResolutionListCellWidgetState extends ConsumerState<ResolutionListCell> {
               iconIndex: widget.resolutionEntity.iconIndex,
             ),
             const SizedBox(height: 20),
-            ResolutionLinearGaugeIndicator(
-              resolutionEntity: widget.resolutionEntity,
-              futureDoneList: futureDoneList,
+            Consumer(
+              builder: (context, ref, _) {
+                return ResolutionLinearGaugeIndicator(
+                  resolutionEntity: widget.resolutionEntity,
+                  futureDoneList: ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
+                    param: GetTargetResolutionDoneListForWeekUsecaseParams(
+                      resolutionId: widget.resolutionEntity.resolutionId,
+                      startMonday: DateTime.now().getMondayDateTime(),
+                    ),
+                  ),
+                );
+              },
             ),
             if (widget.showDetails)
               Column(
@@ -76,9 +88,18 @@ class _ResolutionListCellWidgetState extends ConsumerState<ResolutionListCell> {
                           color: CustomColors.whGrey700,
                         ),
                       ),
-                      ResolutionListWeeklyDoneWidget(
-                        futureDoneList: futureDoneList,
-                        pointColor: CustomColors.pointColorList[widget.resolutionEntity.colorIndex],
+                      Consumer(
+                        builder: (context, ref, _) {
+                          return ResolutionListWeeklyDoneWidget(
+                            futureDoneList: ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
+                              param: GetTargetResolutionDoneListForWeekUsecaseParams(
+                                resolutionId: widget.resolutionEntity.resolutionId,
+                                startMonday: DateTime.now().getMondayDateTime(),
+                              ),
+                            ),
+                            pointColor: CustomColors.pointColorList[widget.resolutionEntity.colorIndex],
+                          );
+                        },
                       ),
                     ],
                   ),

--- a/lib/presentation/common_components/resolution_list_cell.dart
+++ b/lib/presentation/common_components/resolution_list_cell.dart
@@ -1,13 +1,15 @@
 import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
-class ResolutionListCell extends ConsumerStatefulWidget {
+class ResolutionListCell extends ConsumerWidget {
   const ResolutionListCell({
     super.key,
     required this.resolutionEntity,
@@ -20,33 +22,21 @@ class ResolutionListCell extends ConsumerStatefulWidget {
   final VoidCallback onPressed;
 
   @override
-  ConsumerState<ResolutionListCell> createState() => _ResolutionListCellWidgetState();
-}
-
-class _ResolutionListCellWidgetState extends ConsumerState<ResolutionListCell> {
-  @override
-  Widget build(BuildContext context) {
-    // EitherFuture<List<bool>> futureDoneList = ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
-    //   param: GetTargetResolutionDoneListForWeekUsecaseParams(
-    //     resolutionId: widget.resolutionEntity.resolutionId,
-    //     startMonday: DateTime.now().getMondayDateTime(),
-    //   ),
-    // );
-
-    final daysSinceFirstDay = DateTime.now().difference(widget.resolutionEntity.startDate).inDays + 1;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final daysSinceFirstDay = DateTime.now().difference(resolutionEntity.startDate).inDays + 1;
 
     return TextButton(
       style: TextButton.styleFrom(
         shadowColor: Colors.transparent,
         surfaceTintColor: Colors.transparent,
         backgroundColor: CustomColors.whGrey300,
-        overlayColor: CustomColors.pointColorList[widget.resolutionEntity.colorIndex],
+        overlayColor: CustomColors.pointColorList[resolutionEntity.colorIndex],
         padding: const EdgeInsets.all(0),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16.0),
         ),
       ),
-      onPressed: widget.onPressed,
+      onPressed: onPressed,
       child: Container(
         width: double.infinity,
         padding: const EdgeInsets.all(20),
@@ -56,26 +46,33 @@ class _ResolutionListCellWidgetState extends ConsumerState<ResolutionListCell> {
         child: Column(
           children: [
             ResolutionListCellHeadWidget(
-              goalStatement: widget.resolutionEntity.goalStatement,
-              resolutionName: widget.resolutionEntity.resolutionName,
-              pointColor: CustomColors.pointColorList[widget.resolutionEntity.colorIndex],
-              iconIndex: widget.resolutionEntity.iconIndex,
+              goalStatement: resolutionEntity.goalStatement,
+              resolutionName: resolutionEntity.resolutionName,
+              pointColor: CustomColors.pointColorList[resolutionEntity.colorIndex],
+              iconIndex: resolutionEntity.iconIndex,
             ),
             const SizedBox(height: 20),
             Consumer(
-              builder: (context, ref, _) {
+              builder: (_, ref, __) {
+                // final weeklySuccessList = ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider).call(
+                //       param: GetTargetResolutionDoneListForWeekUsecaseParams(
+                // resolutionId: resolutionEntity.resolutionId,
+                // startMonday: DateTime.now().getMondayDateTime(),
+                //       ),
+                //     );
+
+                // return ResolutionLinearGaugeIndicator(
+                //   resolutionEntity: resolutionEntity,
+                //   futureDoneList: weeklySuccessList,
+                // );
+
                 return ResolutionLinearGaugeIndicator(
-                  resolutionEntity: widget.resolutionEntity,
-                  futureDoneList: ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
-                    param: GetTargetResolutionDoneListForWeekUsecaseParams(
-                      resolutionId: widget.resolutionEntity.resolutionId,
-                      startMonday: DateTime.now().getMondayDateTime(),
-                    ),
-                  ),
+                  resolutionEntity: resolutionEntity,
+                  targetDate: DateTime(2025, 1, 14).getMondayDateTime(),
                 );
               },
             ),
-            if (widget.showDetails)
+            if (showDetails)
               Column(
                 children: [
                   const SizedBox(height: 20),
@@ -93,11 +90,11 @@ class _ResolutionListCellWidgetState extends ConsumerState<ResolutionListCell> {
                           return ResolutionListWeeklyDoneWidget(
                             futureDoneList: ref.watch(getTargetResolutionDoneListForWeekUsecaseProvider)(
                               param: GetTargetResolutionDoneListForWeekUsecaseParams(
-                                resolutionId: widget.resolutionEntity.resolutionId,
+                                resolutionId: resolutionEntity.resolutionId,
                                 startMonday: DateTime.now().getMondayDateTime(),
                               ),
                             ),
-                            pointColor: CustomColors.pointColorList[widget.resolutionEntity.colorIndex],
+                            pointColor: CustomColors.pointColorList[resolutionEntity.colorIndex],
                           );
                         },
                       ),

--- a/lib/presentation/common_components/wh_icon.dart
+++ b/lib/presentation/common_components/wh_icon.dart
@@ -5,7 +5,8 @@ import 'package:wehavit/common/constants/constants.dart';
 enum WHIconsize {
   large,
   medium,
-  small;
+  small,
+  extraSmall;
 }
 
 class WHIcon extends StatelessWidget {
@@ -28,6 +29,7 @@ class WHIcon extends StatelessWidget {
       WHIconsize.large => 28.0,
       WHIconsize.medium => 22.0,
       WHIconsize.small => 16.0,
+      WHIconsize.extraSmall => 13.0,
     };
 
     return SizedBox(
@@ -70,21 +72,25 @@ class WhIconButton extends StatelessWidget {
       WHIconsize.large => context.labelLarge?.copyWith(color: color),
       WHIconsize.medium => context.labelLarge?.copyWith(color: color),
       WHIconsize.small => context.labelMedium?.copyWith(color: color),
+      WHIconsize.extraSmall => context.labelSmall?.copyWith(color: color),
     };
     final contentGap = switch (size) {
       WHIconsize.large => 16.0,
       WHIconsize.medium => 14.0,
       WHIconsize.small => 10.0,
+      WHIconsize.extraSmall => 8.0,
     };
     final badgeTextStyle = switch (size) {
       WHIconsize.large => context.labelMedium?.bold,
       WHIconsize.medium => context.labelSmall?.bold,
       WHIconsize.small => context.labelSmall?.copyWith(fontSize: 9.0).bold,
+      WHIconsize.extraSmall => context.labelSmall,
     };
     final badgePadding = switch (size) {
       WHIconsize.large => 4.0,
       WHIconsize.medium => 3.0,
       WHIconsize.small => 2.0,
+      WHIconsize.extraSmall => 2.0,
     };
     final whIcon = Stack(
       children: [

--- a/lib/presentation/group_post/view/friend_list_bottom_sheet_widget.dart
+++ b/lib/presentation/group_post/view/friend_list_bottom_sheet_widget.dart
@@ -197,8 +197,8 @@ class _FriendListCellWidgetState extends ConsumerState<FriendListBottomSheetCell
   }
 
   Future<void> loadAchievePercentage() async {
-    GetTargetResolutionDoneListForWeekUsecase getTargetResolutionDoneListForWeekUsecase =
-        ref.read(getTargetResolutionDoneListForWeekUsecaseProvider);
+    // GetTargetResolutionDoneListForWeekUsecase getTargetResolutionDoneListForWeekUsecase =
+    //     ref.read(getTargetResolutionDoneListForWeekUsecaseProvider);
 
     GetTargetResolutionEntityUsecase getTargetResolutionEntityUsecase =
         ref.read(getTargetResolutionEntityUsecaseProvider);
@@ -222,19 +222,19 @@ class _FriendListCellWidgetState extends ConsumerState<FriendListBottomSheetCell
             );
 
         if (resolutionEntity != null) {
-          final doneList = await getTargetResolutionDoneListForWeekUsecase(
-              param: GetTargetResolutionDoneListForWeekUsecaseParams(
-            resolutionId: id,
-            startMonday: DateTime.now().getMondayDateTime(),
-          )).then(
-            (result) => result.fold(
-              (failure) => [] as List<bool>,
-              (doneList) => doneList,
-            ),
-          );
+          // final doneList = await getTargetResolutionDoneListForWeekUsecase(
+          //     param: GetTargetResolutionDoneListForWeekUsecaseParams(
+          //   resolutionId: id,
+          //   startMonday: DateTime.now().getMondayDateTime(),
+          // )).then(
+          //   (result) => result.fold(
+          //     (failure) => [] as List<bool>,
+          //     (doneList) => doneList,
+          //   ),
+          // );
 
-          totalPostCount += resolutionEntity.actionPerWeek;
-          donePostCount += doneList.where((element) => element == true).length;
+          // totalPostCount += resolutionEntity.actionPerWeek;
+          // donePostCount += doneList.where((element) => element == true).length;
         }
       }),
     );

--- a/lib/presentation/group_post/view/friend_list_bottom_sheet_widget.dart
+++ b/lib/presentation/group_post/view/friend_list_bottom_sheet_widget.dart
@@ -223,9 +223,10 @@ class _FriendListCellWidgetState extends ConsumerState<FriendListBottomSheetCell
 
         if (resolutionEntity != null) {
           final doneList = await getTargetResolutionDoneListForWeekUsecase(
+              param: GetTargetResolutionDoneListForWeekUsecaseParams(
             resolutionId: id,
             startMonday: DateTime.now().getMondayDateTime(),
-          ).then(
+          )).then(
             (result) => result.fold(
               (failure) => [] as List<bool>,
               (doneList) => doneList,

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -9,6 +9,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 import 'package:wehavit/presentation/effects/effects.dart';
 import 'package:wehavit/presentation/group_post/group_post.dart';
@@ -50,8 +51,10 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget> with Tick
     );
 
     resolutionDoneListForWrittenWeek = ref.read(getTargetResolutionDoneListForWeekUsecaseProvider).call(
-          resolutionId: widget.confirmPostEntity.resolutionId,
-          startMonday: widget.createdDate.getMondayDateTime(),
+          param: GetTargetResolutionDoneListForWeekUsecaseParams(
+            resolutionId: widget.confirmPostEntity.resolutionId,
+            startMonday: widget.createdDate.getMondayDateTime(),
+          ),
         );
 
     futureResolutionEntity = ref.read(getTargetResolutionEntityUsecaseProvider)(

--- a/lib/presentation/group_post/view/group_post_view_widget.dart
+++ b/lib/presentation/group_post/view/group_post_view_widget.dart
@@ -198,7 +198,9 @@ class _ConfirmPostWidgetState extends ConsumerState<ConfirmPostWidget> with Tick
                             ),
                             ResolutionLinearGaugeIndicator(
                               resolutionEntity: resolutionEntity,
-                              futureDoneList: resolutionDoneListForWrittenWeek,
+                              // weeklyDoneList: resolutionDoneListForWrittenWeek,
+                              // TODO: edit
+                              targetDate: DateTime.now(),
                             ),
                             const SizedBox(height: 12.0),
                             ConfirmPostContentWidget(confirmPostEntity: widget.confirmPostEntity),

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -5,8 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
-import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class MyPageView extends ConsumerStatefulWidget {
@@ -50,7 +50,7 @@ class MyPageScreenState extends ConsumerState<MyPageView> with AutomaticKeepAliv
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    final viewModel = ref.watch(myPageViewModelProvider);
+    // final viewModel = ref.watch(myPageViewModelProvider);
     final provider = ref.watch(myPageViewModelProvider.notifier);
 
     return Stack(
@@ -102,39 +102,77 @@ class MyPageScreenState extends ConsumerState<MyPageView> with AutomaticKeepAliv
                   const SizedBox(
                     height: 16,
                   ),
-                  EitherFutureBuilder<List<ResolutionEntity>>(
-                    target: viewModel.futureMyyResolutionList,
-                    forWaiting: Container(),
-                    forFail: Container(),
-                    mainWidgetCallback: (resolutionList) {
-                      return Visibility(
-                        replacement: const ResolutionListPlaceholderWidget(),
-                        visible: resolutionList.isNotEmpty,
-                        child: Column(
-                          children: List<Widget>.generate(
-                            resolutionList.length,
-                            (index) => Container(
-                              margin: const EdgeInsets.only(bottom: 16.0),
-                              child: ResolutionListCell(
-                                resolutionEntity: resolutionList[index],
-                                showDetails: true,
-                                onPressed: () async {
-                                  Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (context) => ResolutionDetailView(
-                                        entity: resolutionList[index],
-                                      ),
-                                    ),
-                                  );
-                                },
+                  Consumer(
+                    builder: (context, ref, child) {
+                      final asyncResolutionList = ref.watch(resolutionListNotifierProvider);
+
+                      return asyncResolutionList.when(
+                        data: (resolutionList) {
+                          return Visibility(
+                            replacement: const ResolutionListPlaceholderWidget(),
+                            visible: resolutionList.isNotEmpty,
+                            child: Column(
+                              children: List<Widget>.generate(
+                                resolutionList.length,
+                                (index) => Container(
+                                  margin: const EdgeInsets.only(bottom: 16.0),
+                                  child: ResolutionListCell(
+                                    resolutionEntity: resolutionList[index],
+                                    showDetails: true,
+                                    onPressed: () async {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) => ResolutionDetailView(
+                                            entity: resolutionList[index],
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                ),
                               ),
                             ),
-                          ),
-                        ),
+                          );
+                        },
+                        error: (_, __) => Container(),
+                        loading: () => Container(),
                       );
                     },
                   ),
+                  // EitherFutureBuilder<List<ResolutionEntity>>(
+                  //   target: viewModel.futureMyyResolutionList,
+                  //   forWaiting: Container(),
+                  //   forFail: Container(),
+                  //   mainWidgetCallback: (resolutionList) {
+                  //     return Visibility(
+                  //       replacement: const ResolutionListPlaceholderWidget(),
+                  //       visible: resolutionList.isNotEmpty,
+                  //       child: Column(
+                  //         children: List<Widget>.generate(
+                  //           resolutionList.length,
+                  //           (index) => Container(
+                  //             margin: const EdgeInsets.only(bottom: 16.0),
+                  //             child: ResolutionListCell(
+                  //               resolutionEntity: resolutionList[index],
+                  //               showDetails: true,
+                  //               onPressed: () async {
+                  //                 Navigator.push(
+                  //                   context,
+                  //                   MaterialPageRoute(
+                  //                     builder: (context) => ResolutionDetailView(
+                  //                       entity: resolutionList[index],
+                  //                     ),
+                  //                   ),
+                  //                 );
+                  //               },
+                  //             ),
+                  //           ),
+                  //         ),
+                  //       ),
+                  //     );
+                  //   },
+                  // ),
                 ],
               ),
             ),

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -6,9 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 import 'package:wehavit/common/constants/constants.dart';
+import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 // ignore: must_be_immutable
 class ResolutionDetailView extends ConsumerStatefulWidget {
@@ -372,7 +374,54 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
             WideColoredButton(
               buttonTitle: '목표 삭제하기',
               foregroundColor: CustomColors.whRed,
-              onPressed: () {},
+              onPressed: () async {
+                showDialog(
+                  context: context,
+                  builder: (context) {
+                    return AlertDialog(
+                      title: const Text(
+                        '목표 삭제하기',
+                        style: TextStyle(color: CustomColors.whGrey100),
+                      ),
+                      content: Text(
+                        '${widget.entity.resolutionName} 을 비활성화 하시겠어요?\n해당 목표는 작성하기에서 숨김 처리됩니다.',
+                        style: const TextStyle(color: CustomColors.whGrey100),
+                      ),
+                      actions: [
+                        TextButton(
+                          child: const Text(
+                            '취소',
+                            style: TextStyle(color: CustomColors.whGrey300),
+                          ),
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                          },
+                        ),
+                        TextButton(
+                          child: const Text(
+                            '삭제하기',
+                            style: TextStyle(color: CustomColors.whRed500),
+                          ),
+                          onPressed: () async {
+                            // TODO: 삭제하기 로직 정리하기
+                            await ref
+                                .read(setResolutionDeactiveUsecaseProvider)
+                                .call(resolutionId: widget.entity.resolutionId, entity: widget.entity)
+                                .whenComplete(() {
+                              setState(() {
+                                ref.invalidate(resolutionListNotifierProvider);
+                              });
+                            });
+                            Navigator.of(context).pop();
+                            Navigator.of(context).pop();
+                          },
+                        ),
+                      ],
+                    );
+                  },
+                );
+                ref.invalidate(resolutionListNotifierProvider);
+              },
             ),
           ],
         ),

--- a/lib/presentation/state/resolution_list/resolution_list_provider.dart
+++ b/lib/presentation/state/resolution_list/resolution_list_provider.dart
@@ -15,8 +15,8 @@ final resolutionListNotifierProvider = FutureProvider<List<ResolutionEntity>>(
 final weeklyResolutionInfoProvider = FutureProvider.family<List<bool>, GetTargetResolutionDoneListForWeekUsecaseParams>(
   (ref, param) async {
     return ref.read(getTargetResolutionDoneListForWeekUsecaseProvider).call(param: param).then(
-          (result) => result.fold(
-            (failure) => Future.error(Exception('실천 정보를 조회하는데 실패했습니다')),
+          (value) => value.fold(
+            (failure) => Future.error(failure.message),
             (success) => success,
           ),
         );

--- a/lib/presentation/state/resolution_list/resolution_list_provider.dart
+++ b/lib/presentation/state/resolution_list/resolution_list_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/dependency/dependency.dart';
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/domain/usecases/usecases.dart';
+
+final resolutionListNotifierProvider = FutureProvider<List<ResolutionEntity>>(
+  (ref) => ref.read(getMyResolutionListUsecaseProvider).call().then(
+        (result) => result.fold(
+          (failure) => [],
+          (success) => success,
+        ),
+      ),
+);
+
+final weeklyResolutionInfoProvider = FutureProvider.family<List<bool>, GetTargetResolutionDoneListForWeekUsecaseParams>(
+  (ref, param) async {
+    return ref.read(getTargetResolutionDoneListForWeekUsecaseProvider).call(param: param).then(
+          (result) => result.fold(
+            (failure) => Future.error(Exception('실천 정보를 조회하는데 실패했습니다')),
+            (success) => success,
+          ),
+        );
+  },
+);

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -2,15 +2,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/usecases/usecases.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 import 'package:wehavit/presentation/write_post/write_post.dart';
 
 class ResolutionListViewModelProvider extends StateNotifier<ResolutionListViewModel> {
   ResolutionListViewModelProvider(
+    this.ref,
     this._getMyResolutionListUsecase,
     this._getTargetResolutionDoneListForWeekUsecase,
     this._uploadConfirmPostUseCase,
   ) : super(ResolutionListViewModel());
 
+  final Ref ref;
   final GetMyResolutionListUsecase _getMyResolutionListUsecase;
   final GetTargetResolutionDoneListForWeekUsecase _getTargetResolutionDoneListForWeekUsecase;
   final UploadConfirmPostUseCase _uploadConfirmPostUseCase;
@@ -96,6 +99,19 @@ class ResolutionListViewModelProvider extends StateNotifier<ResolutionListViewMo
       localFileUrlList: [],
       hasRested: false,
       isPostingForYesterday: false,
-    );
+    ).then((result) {
+      final isPostingSuccess = result.fold((failure) => false, (value) => value);
+
+      if (isPostingSuccess) {
+        ref.invalidate(
+          weeklyResolutionInfoProvider.call(
+            GetTargetResolutionDoneListForWeekUsecaseParams(
+              resolutionId: model.entity.resolutionId,
+              startMonday: DateTime.now().getMondayDateTime(),
+            ),
+          ),
+        );
+      }
+    });
   }
 }

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -35,8 +35,10 @@ class ResolutionListViewModelProvider extends StateNotifier<ResolutionListViewMo
     final List<ResolutionListCellWidgetModel> modelList = await Future.wait(
       resolutionList.map((entity) async {
         doneList = _getTargetResolutionDoneListForWeekUsecase(
-          resolutionId: entity.resolutionId,
-          startMonday: DateTime.now().getMondayDateTime(),
+          param: GetTargetResolutionDoneListForWeekUsecaseParams(
+            resolutionId: entity.resolutionId,
+            startMonday: DateTime.now().getMondayDateTime(),
+          ),
         );
 
         return ResolutionListCellWidgetModel(

--- a/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
@@ -1,18 +1,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:wehavit/common/utils/datetime+.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/domain/usecases/send_notification_to_shared_users_usecase.dart';
 import 'package:wehavit/domain/usecases/usecases.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 import 'package:wehavit/presentation/write_post/write_post.dart';
 
 class WritingConfirmPostViewModelProvider extends StateNotifier<WritingConfirmPostViewModel> {
   WritingConfirmPostViewModelProvider(
+    this.ref,
     this._uploadConfirmPostUseCase,
     this._sendNotificationToSharedUsersUsecase,
   ) : super(WritingConfirmPostViewModel());
 
   final int maxImagesCount = 3;
+  final Ref ref;
   final UploadConfirmPostUseCase _uploadConfirmPostUseCase;
   final SendNotificationToSharedUsersUsecase _sendNotificationToSharedUsersUsecase;
 
@@ -42,6 +45,15 @@ class WritingConfirmPostViewModelProvider extends StateNotifier<WritingConfirmPo
         final isPostingSuccess = result.fold((failure) => false, (value) => value);
 
         if (isPostingSuccess) {
+          ref.invalidate(
+            weeklyResolutionInfoProvider.call(
+              GetTargetResolutionDoneListForWeekUsecaseParams(
+                resolutionId: state.entity!.resolutionId,
+                startMonday: DateTime.now().getMondayDateTime(),
+              ),
+            ),
+          );
+
           sendNotiToSharedUsers(myUserEntity: myUserEntity);
         }
       },

--- a/lib/presentation/write_post/view/add_resolution_done_view.dart
+++ b/lib/presentation/write_post/view/add_resolution_done_view.dart
@@ -6,6 +6,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 class AddResolutionDoneView extends ConsumerStatefulWidget {
   const AddResolutionDoneView({super.key});
@@ -37,9 +38,9 @@ class _AddResolutionDoneViewState extends ConsumerState<AddResolutionDoneView> {
       backgroundColor: CustomColors.whDarkBlack,
       appBar: WehavitAppBar(
         titleLabel: '도전 추가하기 완료',
-        leadingTitle: '',
         trailingTitle: '닫기',
         trailingAction: () {
+          ref.invalidate(resolutionListNotifierProvider);
           Navigator.pop(context);
           Navigator.pop(context);
         },

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wehavit/common/constants/app_colors.dart';
+import 'package:wehavit/common/routers/route_provider.dart';
+import 'package:wehavit/common/utils/datetime+.dart';
 import 'package:wehavit/common/utils/preference_key.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
@@ -235,7 +237,9 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
               ),
               ResolutionLinearGaugeIndicator(
                 resolutionEntity: viewModel.resolutionModelList![index].entity,
-                futureDoneList: viewModel.resolutionModelList![index].doneList,
+                // TODO: edit
+                targetDate: DateTime.now().getMondayDateTime(),
+                // weeklyDoneList: viewModel.resolutionModelList![index].doneList,
               ),
             ],
           ),

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wehavit/common/constants/app_colors.dart';
-import 'package:wehavit/common/routers/route_provider.dart';
 import 'package:wehavit/common/utils/datetime+.dart';
 import 'package:wehavit/common/utils/preference_key.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
@@ -65,87 +64,186 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                     ),
                   ),
                 ),
-                child: Column(
-                  children: List<Widget>.generate(
-                    ref.read(resolutionListNotifierProvider).value?.length ?? 0,
-                    (index) => Container(
-                      margin: const EdgeInsets.only(bottom: 16.0),
-                      child: ResolutionListCell(
-                        onPressed: () async {
-                          final isGuideShown = await SharedPreferences.getInstance().then((instance) {
-                            return instance.getBool(PreferenceKey.isWritingPostGuideShown);
-                          });
+                child: Consumer(
+                  builder: (context, ref, child) {
+                    final asyncResolutionList = ref.watch(resolutionListNotifierProvider);
 
-                          if (isGuideShown == null || isGuideShown == false) {
-                            // ignore: use_build_context_synchronously
-                            showGuideBottomSheet(context).whenComplete(() async {
-                              await SharedPreferences.getInstance().then((instance) {
-                                instance.setBool(
-                                  PreferenceKey.isWritingPostGuideShown,
-                                  true,
-                                );
-                              });
-                              showWritingOptionBottomSheet(
-                                // ignore: use_build_context_synchronously
-                                context,
-                                viewModel,
-                                provider,
-                                index,
-                              ).then((returnValue) async {
-                                if (returnValue == true) {
-                                  await provider.loadResolutionModelList().whenComplete(() {
-                                    ref.watch(resolutionListViewModelProvider).isLoadingView = false;
+                    return asyncResolutionList.when(
+                      data: (resolutionList) {
+                        return Column(
+                          children: List<Widget>.generate(
+                            resolutionList.length,
+                            (index) => Container(
+                              margin: const EdgeInsets.only(bottom: 16.0),
+                              child: ResolutionListCell(
+                                onPressed: () async {
+                                  final isGuideShown = await SharedPreferences.getInstance().then((instance) {
+                                    return instance.getBool(PreferenceKey.isWritingPostGuideShown);
                                   });
-                                } else {
-                                  //
-                                }
-                              });
-                            });
-                          } else {
-                            showWritingOptionBottomSheet(
-                              // ignore: use_build_context_synchronously
-                              context,
-                              viewModel,
-                              provider,
-                              index,
-                            ).then((returnValue) async {
-                              if (returnValue == true) {
-                                await provider.loadResolutionModelList().whenComplete(() {
-                                  ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                                });
-                              } else {
-                                //
-                              }
-                            });
-                          }
-                        },
-                        resolutionEntity: ref.read(resolutionListNotifierProvider).value![index],
-                        showDetails: false,
-                      ),
-                    ),
-                  )
-                      .append(
-                        ListDashOutlinedCell(
-                          buttonLabel: '새로운 목표 추가하기',
-                          onPressed: () async {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                fullscreenDialog: true,
-                                builder: (context) => const AddResolutionView(),
+
+                                  if (isGuideShown == null || isGuideShown == false) {
+                                    // ignore: use_build_context_synchronously
+                                    showGuideBottomSheet(context).whenComplete(() async {
+                                      await SharedPreferences.getInstance().then((instance) {
+                                        instance.setBool(
+                                          PreferenceKey.isWritingPostGuideShown,
+                                          true,
+                                        );
+                                      });
+                                      showWritingOptionBottomSheet(
+                                        // ignore: use_build_context_synchronously
+                                        context,
+                                        viewModel,
+                                        provider,
+                                        index,
+                                      ).then((returnValue) async {
+                                        if (returnValue == true) {
+                                          await provider.loadResolutionModelList().whenComplete(() {
+                                            ref.watch(resolutionListViewModelProvider).isLoadingView = false;
+                                          });
+                                        } else {
+                                          //
+                                        }
+                                      });
+                                    });
+                                  } else {
+                                    showWritingOptionBottomSheet(
+                                      // ignore: use_build_context_synchronously
+                                      context,
+                                      viewModel,
+                                      provider,
+                                      index,
+                                    ).then((returnValue) async {
+                                      if (returnValue == true) {
+                                        await provider.loadResolutionModelList().whenComplete(() {
+                                          ref.watch(resolutionListViewModelProvider).isLoadingView = false;
+                                        });
+                                      } else {
+                                        //
+                                      }
+                                    });
+                                  }
+                                },
+                                resolutionEntity: ref.watch(resolutionListNotifierProvider).value![index],
+                                showDetails: false,
                               ),
-                            ).whenComplete(() async {
-                              await ref.watch(myPageViewModelProvider.notifier).getMyResolutionListUsecase();
-                              await provider.loadResolutionModelList().whenComplete(() {
-                                setState(() {
-                                  ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                                });
-                              });
-                            });
-                          },
-                        ),
-                      )
-                      .toList(),
+                            ),
+                          )
+                              .append(
+                                ListDashOutlinedCell(
+                                  buttonLabel: '새로운 목표 추가하기',
+                                  onPressed: () async {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        fullscreenDialog: true,
+                                        builder: (context) => const AddResolutionView(),
+                                      ),
+                                    ).whenComplete(() async {
+                                      await ref.watch(myPageViewModelProvider.notifier).getMyResolutionListUsecase();
+                                      await provider.loadResolutionModelList().whenComplete(() {
+                                        setState(() {
+                                          ref.watch(resolutionListViewModelProvider).isLoadingView = false;
+                                        });
+                                      });
+                                    });
+                                  },
+                                ),
+                              )
+                              .toList(),
+                        );
+                      },
+                      error: (_, __) {
+                        return Container();
+                      },
+                      loading: () {
+                        return Container();
+                      },
+                    );
+                  },
+                  // child:
+                  // Column(
+                  //   children: List<Widget>.generate(
+                  //     ref.read(resolutionListNotifierProvider).value?.length ?? 0,
+                  //     (index) => Container(
+                  //       margin: const EdgeInsets.only(bottom: 16.0),
+                  //       child: ResolutionListCell(
+                  //         onPressed: () async {
+                  //           final isGuideShown = await SharedPreferences.getInstance().then((instance) {
+                  //             return instance.getBool(PreferenceKey.isWritingPostGuideShown);
+                  //           });
+
+                  //           if (isGuideShown == null || isGuideShown == false) {
+                  //             // ignore: use_build_context_synchronously
+                  //             showGuideBottomSheet(context).whenComplete(() async {
+                  //               await SharedPreferences.getInstance().then((instance) {
+                  //                 instance.setBool(
+                  //                   PreferenceKey.isWritingPostGuideShown,
+                  //                   true,
+                  //                 );
+                  //               });
+                  //               showWritingOptionBottomSheet(
+                  //                 // ignore: use_build_context_synchronously
+                  //                 context,
+                  //                 viewModel,
+                  //                 provider,
+                  //                 index,
+                  //               ).then((returnValue) async {
+                  //                 if (returnValue == true) {
+                  //                   await provider.loadResolutionModelList().whenComplete(() {
+                  //                     ref.watch(resolutionListViewModelProvider).isLoadingView = false;
+                  //                   });
+                  //                 } else {
+                  //                   //
+                  //                 }
+                  //               });
+                  //             });
+                  //           } else {
+                  //             showWritingOptionBottomSheet(
+                  //               // ignore: use_build_context_synchronously
+                  //               context,
+                  //               viewModel,
+                  //               provider,
+                  //               index,
+                  //             ).then((returnValue) async {
+                  //               if (returnValue == true) {
+                  //                 await provider.loadResolutionModelList().whenComplete(() {
+                  //                   ref.watch(resolutionListViewModelProvider).isLoadingView = false;
+                  //                 });
+                  //               } else {
+                  //                 //
+                  //               }
+                  //             });
+                  //           }
+                  //         },
+                  //         resolutionEntity: ref.read(resolutionListNotifierProvider).value![index],
+                  //         showDetails: false,
+                  //       ),
+                  //     ),
+                  //   )
+                  //       .append(
+                  //         ListDashOutlinedCell(
+                  //           buttonLabel: '새로운 목표 추가하기',
+                  //           onPressed: () async {
+                  //             Navigator.push(
+                  //               context,
+                  //               MaterialPageRoute(
+                  //                 fullscreenDialog: true,
+                  //                 builder: (context) => const AddResolutionView(),
+                  //               ),
+                  //             ).whenComplete(() async {
+                  //               await ref.watch(myPageViewModelProvider.notifier).getMyResolutionListUsecase();
+                  //               await provider.loadResolutionModelList().whenComplete(() {
+                  //                 setState(() {
+                  //                   ref.watch(resolutionListViewModelProvider).isLoadingView = false;
+                  //                 });
+                  //               });
+                  //             });
+                  //           },
+                  //         ),
+                  //       )
+                  //       .toList(),
+                  // ),
                 ),
               ),
               Container(

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -8,6 +8,7 @@ import 'package:wehavit/common/constants/app_colors.dart';
 import 'package:wehavit/common/utils/preference_key.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 class ResolutionListView extends ConsumerStatefulWidget {
   const ResolutionListView({super.key});
@@ -64,21 +65,10 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                 ),
                 child: Column(
                   children: List<Widget>.generate(
-                    viewModel.resolutionModelList?.length ?? 0,
+                    ref.read(resolutionListNotifierProvider).value?.length ?? 0,
                     (index) => Container(
                       margin: const EdgeInsets.only(bottom: 16.0),
                       child: ResolutionListCell(
-                        // style: TextButton.styleFrom(
-                        //   backgroundColor: CustomColors.whSemiBlack,
-                        //   shadowColor: Colors.transparent,
-                        //   surfaceTintColor: Colors.transparent,
-                        //   overlayColor:
-                        //       CustomColors.pointColorList[viewModel.resolutionModelList![index].entity.colorIndex ?? 0],
-                        //   padding: const EdgeInsets.all(0),
-                        //   shape: RoundedRectangleBorder(
-                        //     borderRadius: BorderRadius.circular(16.0),
-                        //   ),
-                        // ),
                         onPressed: () async {
                           final isGuideShown = await SharedPreferences.getInstance().then((instance) {
                             return instance.getBool(PreferenceKey.isWritingPostGuideShown);
@@ -127,7 +117,7 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                             });
                           }
                         },
-                        resolutionEntity: viewModel.resolutionModelList![index].entity,
+                        resolutionEntity: ref.read(resolutionListNotifierProvider).value![index],
                         showDetails: false,
                       ),
                     ),


### PR DESCRIPTION
# 설명
목표 목록을 공용 State로 분리해, 상태를 더욱 효율적으로 관리하고 유지할 수 있도록 변경합니다. 

Fixes #
Closes #357
Resolves #

# 작업 내역
- 목표 목록을 관리하는 State, Provider 추가
- 주간 목표 컴포넌트 수정
  - Linear Gauge
  - Weekly Status 
- 목표 추가 / 제거 시 상태 invalidate 코드 추가

## 작업 결과물
작업 결과물을 첨부합니다. (ex. 스크린샷, gif, 다른 사람이 사용할 수 있는 ㅇㅇAPI 등)

## 참고 사항(선택)
기존의 EitherFuture 타입을 다루기 위해 사용했던 EitherFutureBuilder 위젯 대신에,
FutureProvider 의 결과인 비동기 데이터 타입 AsyncValue 를 이용하는 코드로 변경하고 있습니다. 

`AsyncValue.when`을 호출했을 때 로딩중, 에러, 완료 3가지 상태에 대해 각자 로직을 작성할 수 있어 동일한 효과를 줍니다. 

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
