### PR TITLE
[#368] refactor: 네비게이션탭바 프로필이미지 깜빡임 제거

### DIFF
--- a/lib/presentation/main/view/main_view.dart
+++ b/lib/presentation/main/view/main_view.dart
@@ -5,11 +5,9 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/presentation/presentation.dart';
-import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class MainView extends ConsumerStatefulWidget {
   const MainView({super.key});
@@ -39,67 +37,7 @@ class MainViewState extends ConsumerState<MainView> with TickerProviderStateMixi
   }
 
   @override
-  Future<void> didChangeDependencies() async {
-    super.didChangeDependencies();
-
-    loadUserData();
-    loadResolutionData();
-    loadFriendData();
-    loadGroupData();
-  }
-
-  Future<void> loadUserData() async {
-    ref.read(myPageViewModelProvider.notifier).loadData();
-    // ref.read(friendListViewModelProvider.notifier).getMyUserDataEntity();
-  }
-
-  Future<void> loadResolutionData() async {
-    // 인증 리스트의 목표 셀 로드
-    ref.read(resolutionListViewModelProvider.notifier).loadResolutionModelList().whenComplete(() {
-      setState(() {
-        ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-      });
-    });
-  }
-
-  Future<void> loadGroupData() async {
-    // 그룹리스트의 그룹 셀 로드
-    // ref.read(groupViewModelProvider.notifier).loadMyGroupCellList().whenComplete(() => setState(() {}));
-  }
-
-// TODO: 제거하기
-  Future<void> loadFriendData() async {
-    // 친구리스트 셀 로드
-    // ref.read(friendListViewModelProvider.notifier).getAppliedFriendList().whenComplete(() => setState(() {}));
-
-    // await ref.read(friendListViewModelProvider.notifier).getFriendList().whenComplete(() => setState(() {}));
-
-    // 그룹리스트의 친구 셀 로드
-    // final userIdList = ref.read(friendListProvider).whenData((data) => data.map((e) => e.userId).toList());
-    // final userIdList = await Future.wait(
-    //   ref.read(friendListViewModelProvider).friendFutureUserList?.map((futureFriendEntity) async {
-    //         final result = await futureFriendEntity;
-    //         return result.fold(
-    //           (failure) => null,
-    //           (entity) => entity.userId,
-    //         );
-    //       }).toList() ??
-    //       [],
-    // );
-
-    // final userIdListWithoutNull = userIdList.where((userId) => userId != null).cast<String>().toList();
-
-    // ref.watch(groupViewModelProvider).friendUidList = userIdListWithoutNull;
-
-    // await ref
-    //     .read(groupViewModelProvider.notifier)
-    //     .loadFriendCellWidgetModel(friendUidList: userIdListWithoutNull)
-    //     .whenComplete(() => setState(() {}));
-  }
-
-  @override
   Widget build(BuildContext context) {
-    // final myPageViewModel = ref.watch(myPageViewModelProvider);
     return Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: CustomColors.whDarkBlack,
@@ -121,54 +59,56 @@ class MainViewState extends ConsumerState<MainView> with TickerProviderStateMixi
                     MyPageView(3, tabController),
                   ],
                 ),
-                SizedBox(
-                  height: 64,
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      const TabBarBackgroundBlurWidget(),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: TabBar(
-                          onTap: (value) {
-                            setState(() {});
-                          },
-                          // dividerHeight: 0,
-                          indicatorColor: Colors.transparent,
-                          labelColor: CustomColors.whYellow,
-                          controller: tabController,
-                          dividerColor: Colors.transparent,
-                          tabs: [
-                            TabBarIconLabelButton(
-                              isSelected: tabController.index == 0,
-                              iconImageName: CustomIconImage.approvalIcon,
-                              label: '인증하기',
-                            ),
-                            TabBarIconLabelButton(
-                              isSelected: tabController.index == 1,
-                              iconData: Icons.outlined_flag_rounded,
-                              label: '그룹',
-                            ),
-                            TabBarIconLabelButton(
-                              isSelected: tabController.index == 2,
-                              iconData: Icons.people_alt_outlined,
-                              label: '친구',
-                            ),
-                            TabBarProfileImageButton(
-                              isSelected: tabController.index == 3,
-                              futureUserDataEntity: Future(() => right(ref.read(getMyUserDataProvider).value!)),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+                bottomTabBar(),
               ],
             ),
           ),
           ReactionAnimationWidget(
             key: ref.watch(reactionAnimationWidgetKeyProvider),
+          ),
+        ],
+      ),
+    );
+  }
+
+  SizedBox bottomTabBar() {
+    return SizedBox(
+      height: 60,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          const TabBarBackgroundBlurWidget(),
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: TabBar(
+              onTap: (value) {
+                setState(() {});
+              },
+              indicatorColor: Colors.transparent,
+              labelColor: CustomColors.whYellow,
+              controller: tabController,
+              dividerColor: Colors.transparent,
+              tabs: [
+                TabBarIconLabelButton(
+                  isSelected: tabController.index == 0,
+                  iconImageName: CustomIconImage.approvalIcon,
+                  label: '인증하기',
+                ),
+                TabBarIconLabelButton(
+                  isSelected: tabController.index == 1,
+                  iconData: Icons.outlined_flag_rounded,
+                  label: '그룹',
+                ),
+                TabBarIconLabelButton(
+                  isSelected: tabController.index == 2,
+                  iconData: Icons.people_alt_outlined,
+                  label: '친구',
+                ),
+                TabBarProfileImageButton(
+                  isSelected: tabController.index == 3,
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/presentation/main/view/main_view_widget.dart
+++ b/lib/presentation/main/view/main_view_widget.dart
@@ -1,9 +1,11 @@
 import 'dart:ui' as ui;
 
+import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
-import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
+import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class TabBarIconLabelButton extends StatelessWidget {
   const TabBarIconLabelButton({
@@ -19,8 +21,8 @@ class TabBarIconLabelButton extends StatelessWidget {
   final IconData? iconData;
   final String label;
 
-  final double iconWidth = 28;
-  final double iconHeight = 28;
+  final double iconWidth = 24;
+  final double iconHeight = 24;
 
   @override
   Widget build(BuildContext context) {
@@ -59,8 +61,7 @@ class TabBarIconLabelButton extends StatelessWidget {
         ),
         Text(
           label,
-          style: TextStyle(
-            fontSize: 12,
+          style: context.labelSmall?.bold.copyWith(
             color: isSelected ? CustomColors.whYellow : CustomColors.whWhite,
           ),
         ),
@@ -72,39 +73,58 @@ class TabBarIconLabelButton extends StatelessWidget {
 class TabBarProfileImageButton extends StatelessWidget {
   const TabBarProfileImageButton({
     required this.isSelected,
-    required this.futureUserDataEntity,
     super.key,
   });
 
   final bool isSelected;
-  final EitherFuture<UserDataEntity> futureUserDataEntity;
+  final double size = 40;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         Container(
-          width: 40,
-          height: 40,
+          width: size,
+          height: size,
           decoration: BoxDecoration(
             shape: BoxShape.circle,
             border: Border.all(
               // 테두리 스타일 설정
               color: isSelected ? CustomColors.whYellow : Colors.transparent,
-              width: 3, // 테두리 두께
+              width: 2, // 테두리 두께
               strokeAlign: BorderSide.strokeAlignOutside,
             ),
             color: CustomColors.whBrightGrey,
           ),
           clipBehavior: Clip.hardEdge,
-          child: EitherFutureBuilder<UserDataEntity>(
-            target: futureUserDataEntity,
-            forFail: Container(),
-            forWaiting: Container(),
-            mainWidgetCallback: (entity) {
-              return CircleProfileImage(
-                size: 40,
-                url: entity.userImageUrl,
+          child: Consumer(
+            builder: (context, ref, child) {
+              final asyncUserEntity = ref.watch(getMyUserDataProvider);
+
+              return asyncUserEntity.when(
+                data: (entity) {
+                  return CircleProfileImage(size: size, url: entity.userImageUrl);
+                },
+                error: (_, __) {
+                  return Container(
+                    width: size,
+                    height: size,
+                    decoration: const BoxDecoration(
+                      color: CustomColors.whGrey600,
+                      shape: BoxShape.circle,
+                    ),
+                  );
+                },
+                loading: () {
+                  return Container(
+                    width: size,
+                    height: size,
+                    decoration: const BoxDecoration(
+                      color: CustomColors.whGrey600,
+                      shape: BoxShape.circle,
+                    ),
+                  );
+                },
               );
             },
           ),

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -137,39 +137,6 @@ class MyPageScreenState extends ConsumerState<MyPageView> with AutomaticKeepAliv
                       );
                     },
                   ),
-                  // EitherFutureBuilder<List<ResolutionEntity>>(
-                  //   target: viewModel.futureMyyResolutionList,
-                  //   forWaiting: Container(),
-                  //   forFail: Container(),
-                  //   mainWidgetCallback: (resolutionList) {
-                  //     return Visibility(
-                  //       replacement: const ResolutionListPlaceholderWidget(),
-                  //       visible: resolutionList.isNotEmpty,
-                  //       child: Column(
-                  //         children: List<Widget>.generate(
-                  //           resolutionList.length,
-                  //           (index) => Container(
-                  //             margin: const EdgeInsets.only(bottom: 16.0),
-                  //             child: ResolutionListCell(
-                  //               resolutionEntity: resolutionList[index],
-                  //               showDetails: true,
-                  //               onPressed: () async {
-                  //                 Navigator.push(
-                  //                   context,
-                  //                   MaterialPageRoute(
-                  //                     builder: (context) => ResolutionDetailView(
-                  //                       entity: resolutionList[index],
-                  //                     ),
-                  //                   ),
-                  //                 );
-                  //               },
-                  //             ),
-                  //           ),
-                  //         ),
-                  //       ),
-                  //     );
-                  //   },
-                  // ),
                 ],
               ),
             ),


### PR DESCRIPTION
# 설명
네비게이션 탭바 버튼을 눌렀을 때 프로필이미지가 깜빡이는 문제를 제거하고 불필요한 코드를 제거합니다.

Fixes #
Closes #368 
Resolves #

# 작업 내역
- 네비게이션 탭바 버튼을 눌렀을 때 프로필이미지가 깜빡이는 문제 제거
- 네비게이션 탭바 UI를 디자인에 맞춰 수정

## 작업 결과물
|기존|개선|
|---|---|
|![image](https://github.com/user-attachments/assets/d5595565-53e1-4a0d-8941-3beda9fc02d6)|![image](https://github.com/user-attachments/assets/9a4900c6-3c2b-4677-8c04-d936c9a55062)|

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
