### PR TITLE
[#367] refactor: 인증글 작성하기 페이지 UI 개선 및 상태 수정

### DIFF
--- a/lib/common/constants/theme.dart
+++ b/lib/common/constants/theme.dart
@@ -102,7 +102,7 @@ class WehavitTheme {
       ),
       labelLarge: TextStyle(
         fontFamily: 'Pretendard',
-        fontSize: 16.0,
+        fontSize: 14.0,
         fontWeight: FontWeight.w600,
         height: 1.0,
         letterSpacing: 0,

--- a/lib/common/utils/image_uploader.dart
+++ b/lib/common/utils/image_uploader.dart
@@ -1,8 +1,4 @@
-import 'dart:io';
-import 'dart:math';
-
 import 'package:camera/camera.dart';
-import 'package:wehavit/common/utils/isolate_helper.dart';
 
 enum ImageUploadStatus {
   uploading,
@@ -11,21 +7,50 @@ enum ImageUploadStatus {
 }
 
 class ImageUploadEntity {
-  ImageUploadEntity({required this.imageFile, required this.index, required this.status});
+  ImageUploadEntity({required this.imageFile, required this.status});
 
   XFile imageFile;
   String resultUrl = '';
-  int index;
   ImageUploadStatus status;
 }
 
-class ImageUploader with IsolateHelperMixin {
-  Future<ImageUploadEntity> uploadFile(ImageUploadEntity entity) async {
-    return loadWithIsolate(
-      () async {
-        await Future.delayed(Duration(seconds: Random().nextInt(4)));
-        return entity..status = ImageUploadStatus.fail;
-      },
-    );
-  }
-}
+/// ImageUploader를 통해 Isolate로 이미지 업로드 로직을 분리하고자 하였으나,
+/// 기존의 방식만을 적용했을 때에도 큰 문제 없이 이미지의 업로드가 가능해, ImageUploader를 잠시 폐기합니다. 
+// class ImageUploader with IsolateHelperMixin {
+//   ImageUploader();
+
+//   Future<ImageUploadEntity> uploadFile(ImageUploadEntity entity, String uid) async {
+//     return loadWithIsolate(
+//       () async {
+//         // final result = await _upload(entity, uid);
+
+//         // return result.fold(
+//         //   (failure) {
+//         //     // return (entity..status = ImageUploadStatus.fail);
+//         //     return entity..status = ImageUploadStatus.success;
+//         //   },
+//         //   (url) {
+//         //     // return (entity
+//         //     //   ..status = ImageUploadStatus.success
+//         //     //   ..resultUrl = url);
+//         //     return entity..status = ImageUploadStatus.success;
+//         //   },
+//         // );
+
+//         return entity..status = ImageUploadStatus.success;
+//       },
+//     );
+//   }
+
+//   EitherFuture<String> _upload(ImageUploadEntity entity, String uid) async {
+//     try {
+//       String storagePath = FirebaseConfirmPostImagePathName.storagePath(uid: uid);
+//       final ref = FirebaseStorage.instance.ref(storagePath);
+//       await ref.putFile(File(entity.imageFile.path));
+
+//       return Future(() async => right(await ref.getDownloadURL()));
+//     } on Exception catch (e) {
+//       return Future(() => left(Failure(e.toString())));
+//     }
+//   }
+// }

--- a/lib/common/utils/image_uploader.dart
+++ b/lib/common/utils/image_uploader.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:camera/camera.dart';
+import 'package:wehavit/common/utils/isolate_helper.dart';
+
+enum ImageUploadStatus {
+  uploading,
+  success,
+  fail;
+}
+
+class ImageUploadEntity {
+  ImageUploadEntity({required this.imageFile, required this.index, required this.status});
+
+  XFile imageFile;
+  String resultUrl = '';
+  int index;
+  ImageUploadStatus status;
+}
+
+class ImageUploader with IsolateHelperMixin {
+  Future<ImageUploadEntity> uploadFile(ImageUploadEntity entity) async {
+    return loadWithIsolate(
+      () async {
+        await Future.delayed(Duration(seconds: Random().nextInt(4)));
+        return entity..status = ImageUploadStatus.fail;
+      },
+    );
+  }
+}

--- a/lib/common/utils/isolate_helper.dart
+++ b/lib/common/utils/isolate_helper.dart
@@ -1,0 +1,102 @@
+// 출처 : https://velog.io/@ximya_hf/flutter-isolate
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:isolate';
+import 'package:flutter/services.dart';
+
+// Isolate를 다루는 mixin 클래스
+mixin IsolateHelperMixin {
+  // 동시에 실행할 수 있는 Isolate의 최대 개수 설정
+  static const int _maxIsolates = 3;
+
+  // 현재 실행 중인 Isolate의 개수를 추적
+  int _currentIsolates = 0;
+
+  // 보류 중인 작업을 저장하는 큐
+  final Queue<Function> _taskQueue = Queue();
+
+  // Isolate를 생성하여 함수를 실행하거나, 만약 현재 실행 중인 Isolate의 개수가 최대치에 도달한 경우 큐에 작업을 추가
+  Future<T> loadWithIsolate<T>(Future<T> Function() function) async {
+    if (_currentIsolates < _maxIsolates) {
+      _currentIsolates++;
+      return _executeIsolate(function);
+    } else {
+      final completer = Completer<T>();
+      _taskQueue.add(() async {
+        final result = await _executeIsolate(function);
+        completer.complete(result);
+      });
+      return completer.future;
+    }
+  }
+
+  // 새로운 Isolate를 생성하여 주어진 함수를 실행
+  Future<T> _executeIsolate<T>(Future<T> Function() function) async {
+    final ReceivePort receivePort = ReceivePort();
+    final RootIsolateToken rootIsolateToken = RootIsolateToken.instance!;
+
+    final isolate = await Isolate.spawn(
+      _isolateEntry,
+      _IsolateEntryPayload(
+        function: function,
+        sendPort: receivePort.sendPort,
+        rootIsolateToken: rootIsolateToken,
+      ),
+    );
+
+    // Isolate의 결과를 받고, 이 Isolate를 종료한 후, 큐에서 다음 작업을 실행
+    return receivePort.first.then(
+      (dynamic data) {
+        _currentIsolates--;
+        _runNextTask();
+        if (data is T) {
+          isolate.kill(priority: Isolate.immediate);
+          return data;
+        } else {
+          isolate.kill(priority: Isolate.immediate);
+          throw data;
+        }
+      },
+    );
+  }
+
+  // 큐에서 다음 작업을 꺼내어 실행
+  void _runNextTask() {
+    if (_taskQueue.isNotEmpty) {
+      final nextTask = _taskQueue.removeFirst();
+      nextTask();
+    }
+  }
+}
+
+// Isolate에서 실행되는 함수
+Future<void> _isolateEntry(_IsolateEntryPayload payload) async {
+  final Function function = payload.function;
+
+  try {
+    BackgroundIsolateBinaryMessenger.ensureInitialized(
+      payload.rootIsolateToken,
+    );
+  } on MissingPluginException catch (e) {
+    print(e.toString());
+    return Future.error(e.toString());
+  }
+
+  // payload로 전달받은 함수 실행 후 결과를 sendPort를 통해 메인 Isolate로 보냄
+  final result = await function();
+  payload.sendPort.send(result);
+}
+
+// Isolate 생성 시 필요한 데이터를 담는 클래스
+class _IsolateEntryPayload {
+  const _IsolateEntryPayload({
+    required this.function,
+    required this.sendPort,
+    required this.rootIsolateToken,
+  });
+
+  final Future<dynamic> Function() function; // Isolate에서 실행할 함수
+  final SendPort sendPort; // 메인 Isolate로 데이터를 보내기 위한 SendPort
+  final RootIsolateToken rootIsolateToken; // Isolate간 통신을 위한 토큰
+}

--- a/lib/data/datasources/firebase_datasource_impl.dart
+++ b/lib/data/datasources/firebase_datasource_impl.dart
@@ -179,15 +179,9 @@ class FirebaseDatasourceImpl implements WehavitDatasource {
             isLessThanOrEqualTo: Timestamp.fromDate(endDate),
           )
           .where(
-            Filter.or(
-              Filter(
-                FirebaseConfirmPostFieldName.resolutionId,
-                whereIn: resolutionList,
-              ),
-              Filter(
-                FirebaseConfirmPostFieldName.owner,
-                isEqualTo: uid,
-              ),
+            Filter(
+              FirebaseConfirmPostFieldName.resolutionId,
+              whereIn: resolutionList,
             ),
           )
           .get();

--- a/lib/dependency/domain/usecase_dependency.dart
+++ b/lib/dependency/domain/usecase_dependency.dart
@@ -1,9 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/dependency/data/repository_dependency.dart';
-import 'package:wehavit/domain/usecases/get_quickshot_presets_usecase.dart';
 import 'package:wehavit/domain/usecases/get_shared_resolution_list_to_group_usecase.dart';
-import 'package:wehavit/domain/usecases/send_notification_to_shared_users_usecase.dart';
-import 'package:wehavit/domain/usecases/upload_quickshot_preset_usecase.dart';
+import 'package:wehavit/domain/usecases/upload_confirm_post_image_usecase.dart';
 
 import 'package:wehavit/domain/usecases/usecases.dart';
 
@@ -459,5 +457,12 @@ final getSharedResolutionListToGroupUsecaseProvider = Provider<GetSharedResoluti
   final resolutionRepository = ref.watch(resolutionRepositoryProvider);
   return GetSharedResolutionListToGroupUsecase(
     resolutionRepository,
+  );
+});
+
+final uploadConfirmPostImageUsecaseProvider = Provider<UploadConfirmPostImageUsecase>((ref) {
+  final confirmPostRepository = ref.watch(confirmPostRepositoryProvider);
+  return UploadConfirmPostImageUsecase(
+    confirmPostRepository,
   );
 });

--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -110,16 +110,16 @@ final resolutionListViewModelProvider =
   );
 });
 
-final writingConfirmPostViewModelProvider =
-    StateNotifierProvider.autoDispose<WritingConfirmPostViewModelProvider, WritingConfirmPostViewModel>((ref) {
-  final uploadConfirmPostUsecase = ref.watch(uploadConfirmPostUseCaseProvider);
-  final sendNotificationToSharedUsersUsecase = ref.watch(sendNotificationToSharedUsersUsecaseProvider);
-  return WritingConfirmPostViewModelProvider(
-    ref,
-    uploadConfirmPostUsecase,
-    sendNotificationToSharedUsersUsecase,
-  );
-});
+// final writingConfirmPostViewModelProvider =
+//     StateNotifierProvider.autoDispose<WritingConfirmPostViewModelProvider, WritingConfirmPostViewModel>((ref) {
+//   final uploadConfirmPostUsecase = ref.watch(uploadConfirmPostUseCaseProvider);
+//   final sendNotificationToSharedUsersUsecase = ref.watch(sendNotificationToSharedUsersUsecaseProvider);
+//   return WritingConfirmPostViewModelProvider(
+//     ref,
+//     uploadConfirmPostUsecase,
+//     sendNotificationToSharedUsersUsecase,
+//   );
+// });
 
 final groupPostViewModelProvider =
     StateNotifierProvider.autoDispose<GroupPostViewModelProvider, GroupPostViewModel>((ref) {

--- a/lib/dependency/presentation/viewmodel_dependency.dart
+++ b/lib/dependency/presentation/viewmodel_dependency.dart
@@ -192,7 +192,10 @@ final logInViewModelProvider = StateNotifierProvider.autoDispose<LogInViewModelP
 final addResolutionViewModelProvider =
     StateNotifierProvider.autoDispose<AddResolutionViewModelProvider, AddResolutionViewModel>((ref) {
   UploadResolutionUseCase uploadResolutionUseCase = ref.watch(uploadResolutionUsecaseProvider);
-  return AddResolutionViewModelProvider(uploadResolutionUseCase);
+  return AddResolutionViewModelProvider(
+    ref,
+    uploadResolutionUseCase,
+  );
 });
 
 final addResolutionDoneViewModelProvider =

--- a/lib/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart
+++ b/lib/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart
@@ -21,16 +21,4 @@ class GetTargetResolutionDoneListForWeekUsecaseParams {
 
   final String resolutionId;
   final DateTime startMonday;
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is GetTargetResolutionDoneListForWeekUsecaseParams &&
-        other.resolutionId == resolutionId &&
-        other.startMonday == startMonday;
-  }
-
-  @override
-  int get hashCode => resolutionId.hashCode ^ startMonday.hashCode;
 }

--- a/lib/domain/usecases/upload_confirm_post_image_usecase.dart
+++ b/lib/domain/usecases/upload_confirm_post_image_usecase.dart
@@ -1,0 +1,34 @@
+import 'package:fpdart/fpdart.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/domain/repositories/repositories.dart';
+
+class UploadConfirmPostImageUsecase {
+  UploadConfirmPostImageUsecase(
+    this._confirmPostRepository,
+  );
+
+  final ConfirmPostRepository _confirmPostRepository;
+
+  EitherFuture<String> call({
+    required XFile localImageFile,
+  }) async {
+    try {
+      final networkImageUrl =
+          await _confirmPostRepository.uploadConfirmPostImage(localFileUrl: localImageFile.path).then(
+                (value) => value.fold(
+                  (failure) => null,
+                  (imageUrl) => imageUrl,
+                ),
+              );
+
+      if (networkImageUrl == null) {
+        throw const Failure('cannot upload confirm post photo');
+      }
+
+      return right(networkImageUrl);
+    } on Exception catch (e) {
+      return Future(() => left(Failure(e.toString())));
+    }
+  }
+}

--- a/lib/domain/usecases/upload_confirm_post_usecase.dart
+++ b/lib/domain/usecases/upload_confirm_post_usecase.dart
@@ -17,29 +17,11 @@ class UploadConfirmPostUseCase {
     required String resolutionGoalStatement,
     required String resolutionId,
     required String content,
-    required List<String> localFileUrlList,
+    required List<String> fileUrlList,
     required bool hasRested,
     required bool isPostingForYesterday,
   }) async {
     try {
-      final networkImageUrlList = await Future.wait(
-        localFileUrlList.map((url) async {
-          final networkImageUrl = await _confirmPostRepository.uploadConfirmPostImage(localFileUrl: url).then(
-                (value) => value.fold(
-                  (failure) => null,
-                  (imageUrl) => imageUrl,
-                ),
-              );
-
-          if (networkImageUrl == null) {
-            debugPrint('cannot upload confirm post photo');
-            throw const Failure('cannot upload confirm post photo');
-          }
-
-          return networkImageUrl;
-        }).toList(),
-      );
-
       final uid = (await _userModelRepository.getMyUserId()).fold(
         (failure) => null,
         (uid) => uid,
@@ -54,9 +36,8 @@ class UploadConfirmPostUseCase {
         resolutionGoalStatement: resolutionGoalStatement,
         resolutionId: resolutionId,
         content: content,
-        imageUrlList: networkImageUrlList,
+        imageUrlList: fileUrlList,
         owner: uid,
-        recentStrike: 0,
         createdAt: DateTime.now().subtract(Duration(days: isPostingForYesterday ? 1 : 0)),
         updatedAt: DateTime.now(),
         hasRested: hasRested,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:wehavit/common/utils/shared_prefs.dart';
@@ -11,6 +12,9 @@ import 'main/app.dart';
 Future<void> main() async {
   // ignore: avoid_redundant_argument_values
   WidgetsFlutterBinding.ensureInitialized();
+
+  final RootIsolateToken rootIsolateToken = RootIsolateToken.instance!;
+  BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
 
   await initializeDateFormatting('ko');
   await Future.wait([

--- a/lib/presentation/common_components/confirm_post_list_cell.dart
+++ b/lib/presentation/common_components/confirm_post_list_cell.dart
@@ -282,7 +282,6 @@ class ConfirmPostListCellContent extends StatelessWidget {
                 ],
               ),
               onPressed: () async {
-                // TODO: 이미지 보여주는 페이지로 이동
                 final imageList = confirmPostEntity.imageUrlList.map((imageUrl) {
                   return NetworkImage(imageUrl);
                 }).toList();
@@ -320,7 +319,7 @@ class ConfirmPostListCellContent extends StatelessWidget {
                   clipBehavior: Clip.hardEdge,
                   child: Image(
                     image: NetworkImage(
-                      confirmPostEntity.imageUrlList.first,
+                      confirmPostEntity.imageUrlList[index],
                     ),
                     loadingBuilder: (context, image, loadingProgress) {
                       if (loadingProgress == null) {
@@ -341,8 +340,19 @@ class ConfirmPostListCellContent extends StatelessWidget {
                   ),
                 ),
               ),
-              onPressed: () {
-                // TODO: 이미지 보여주는 페이지로 이동
+              onPressed: () async {
+                final imageList = confirmPostEntity.imageUrlList.map((imageUrl) {
+                  return NetworkImage(imageUrl);
+                }).toList();
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => ConfirmPostPhotoView(
+                      imageProviderList: imageList,
+                      initPageIndex: index,
+                    ),
+                  ),
+                );
               },
             ),
           );

--- a/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
+++ b/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
@@ -20,7 +20,7 @@ class ResolutionLinearGaugeIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer(
       builder: (BuildContext context, WidgetRef ref, _) {
-        final param = GetTargetResolutionDoneListForWeekUsecaseParams(
+        final param = WeeklyResolutionInfoProviderParam(
           resolutionId: resolutionEntity.resolutionId,
           startMonday: targetDate.getMondayDateTime(),
         );

--- a/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
+++ b/lib/presentation/common_components/resolution_linear_gauge_indicator.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart';
 import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 class ResolutionLinearGaugeIndicator extends StatelessWidget {

--- a/lib/presentation/common_components/resolution_list_cell.dart
+++ b/lib/presentation/common_components/resolution_list_cell.dart
@@ -182,7 +182,7 @@ class ResolutionListWeeklyDoneWidget extends StatelessWidget {
 
     return Consumer(
       builder: (BuildContext context, WidgetRef ref, Widget? child) {
-        final param = GetTargetResolutionDoneListForWeekUsecaseParams(
+        final param = WeeklyResolutionInfoProviderParam(
           resolutionId: resolutionEntity.resolutionId,
           startMonday: targetDate.getMondayDateTime(),
         );

--- a/lib/presentation/common_components/resolution_list_cell.dart
+++ b/lib/presentation/common_components/resolution_list_cell.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/domain/usecases/get_target_resolution_done_list_for_week_usecase.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
 import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 

--- a/lib/presentation/common_components/upload_photo_bottom_toolbar.dart
+++ b/lib/presentation/common_components/upload_photo_bottom_toolbar.dart
@@ -28,14 +28,13 @@ class UploadPhotoBottomToolbar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        const SizedBox(width: 8),
         WhIconButton(
           onPressed: type == UploadPhotoBottomToolbarType.upload ? onIconPressed : () {},
           iconString: iconString,
           size: WHIconsize.medium,
           color: type == UploadPhotoBottomToolbarType.upload ? CustomColors.whGrey900 : CustomColors.whGrey600,
         ),
-        const SizedBox(width: 16),
+        const SizedBox(width: 12),
         Expanded(
           child: Text(
             type == UploadPhotoBottomToolbarType.upload ? '인증샷은 최대 3장까지 공유할 수 있어요' : '반성글에서는 인증샷을 공유할 수 없어요',
@@ -50,7 +49,7 @@ class UploadPhotoBottomToolbar extends StatelessWidget {
           ),
           child: Text(
             actionLabel,
-            style: context.titleSmall?.bold.copyWith(color: CustomColors.whYellow500),
+            style: context.labelLarge?.bold.copyWith(color: CustomColors.whYellow500),
           ),
         ),
       ],

--- a/lib/presentation/common_components/upload_photo_cell.dart
+++ b/lib/presentation/common_components/upload_photo_cell.dart
@@ -2,13 +2,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:wehavit/common/common.dart';
+import 'package:wehavit/common/utils/image_uploader.dart';
 import 'package:wehavit/presentation/presentation.dart';
-
-enum UploadPhotoCellState {
-  uploading,
-  failed,
-  success;
-}
 
 class UploadPhotoCell extends StatelessWidget {
   const UploadPhotoCell({
@@ -20,14 +15,14 @@ class UploadPhotoCell extends StatelessWidget {
   });
 
   final File imageFile;
-  final UploadPhotoCellState state;
+  final ImageUploadStatus state;
   final VoidCallback onCancel;
   final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
     final indicator = switch (state) {
-      UploadPhotoCellState.uploading => Container(
+      ImageUploadStatus.uploading => Container(
           width: 90,
           height: 90,
           color: CustomColors.whGrey100.withOpacity(0.4),
@@ -40,7 +35,7 @@ class UploadPhotoCell extends StatelessWidget {
             ),
           ),
         ),
-      UploadPhotoCellState.failed => Container(
+      ImageUploadStatus.fail => Container(
           width: 90,
           height: 90,
           color: CustomColors.whGrey100.withOpacity(0.6),
@@ -52,7 +47,7 @@ class UploadPhotoCell extends StatelessWidget {
             onPressed: onRetry,
           ),
         ),
-      UploadPhotoCellState.success => Container(),
+      ImageUploadStatus.success => Container(),
     };
 
     final cancelButton = WhIconButton(

--- a/lib/presentation/common_components/weekly_resolution_summary_card.dart
+++ b/lib/presentation/common_components/weekly_resolution_summary_card.dart
@@ -1,17 +1,16 @@
 import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
+import 'package:wehavit/dependency/dependency.dart';
+import 'package:wehavit/domain/usecases/usecases.dart';
 import 'package:wehavit/presentation/common_components/either_future_builder.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 class WeeklyResolutionSummaryCard extends StatelessWidget {
   const WeeklyResolutionSummaryCard({
     super.key,
-    required this.futureDoneRatio,
-    required this.futureDoneCount,
   });
-
-  final EitherFuture<int>? futureDoneCount;
-  final EitherFuture<int>? futureDoneRatio;
 
   @override
   Widget build(BuildContext context) {
@@ -23,32 +22,47 @@ class WeeklyResolutionSummaryCard extends StatelessWidget {
           Radius.circular(16.0),
         ),
       ),
-      child: Stack(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(
-              vertical: 20.0,
-              horizontal: 20.0,
-            ),
-            child: Column(
-              children: [
-                ResolutionSummaryCardTextWidget(
-                  title: '이번 주 나의 노력 인증 횟수',
-                  futureValue: futureDoneCount,
-                  unit: '회',
+      child: Consumer(
+        builder: (context, ref, widget) {
+          final asyncSuccessCount = ref.watch(myWeeklyResolutionSummaryProvider);
+
+          final asyncResolutionList = ref.watch(resolutionListNotifierProvider);
+          final asyncSuccessRatio = asyncSuccessCount.whenData((successCount) {
+            final total = asyncResolutionList.value?.map((e) => e.actionPerWeek).reduce((v, e) => v + e) ?? 0;
+
+            if (total == 0) return 0;
+
+            return ((successCount * 100) / total).ceil();
+          });
+
+          return Stack(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: 20.0,
+                  horizontal: 20.0,
                 ),
-                const SizedBox(
-                  height: 16,
+                child: Column(
+                  children: [
+                    ResolutionSummaryCardTextWidget(
+                      title: '이번 주 나의 노력 인증 횟수',
+                      asyncValue: asyncSuccessCount,
+                      unit: '회',
+                    ),
+                    const SizedBox(
+                      height: 16,
+                    ),
+                    ResolutionSummaryCardTextWidget(
+                      title: '이번 주 목표 달성 현황',
+                      asyncValue: asyncSuccessRatio,
+                      unit: '%',
+                    ),
+                  ],
                 ),
-                ResolutionSummaryCardTextWidget(
-                  title: '이번 주 목표 달성 현황',
-                  futureValue: futureDoneRatio,
-                  unit: '%',
-                ),
-              ],
-            ),
-          ),
-        ],
+              ),
+            ],
+          );
+        },
       ),
     );
   }
@@ -58,12 +72,12 @@ class ResolutionSummaryCardTextWidget extends StatefulWidget {
   const ResolutionSummaryCardTextWidget({
     super.key,
     required this.title,
-    required this.futureValue,
+    required this.asyncValue,
     required this.unit,
   });
 
   final String title;
-  final EitherFuture<int>? futureValue;
+  final AsyncValue<int> asyncValue;
   final String unit;
 
   @override
@@ -91,24 +105,27 @@ class _ResolutionSummaryCardTextWidgetState extends State<ResolutionSummaryCardT
           crossAxisAlignment: CrossAxisAlignment.baseline,
           textBaseline: TextBaseline.ideographic,
           children: [
-            EitherFutureBuilder<int>(
-              target: widget.futureValue,
-              forWaiting: Text(
-                '--',
-                style: context.displayMedium?.copyWith(
-                  color: CustomColors.whWhite,
-                ),
-              ),
-              forFail: Text(
-                '--',
-                style: context.displayMedium?.copyWith(
-                  color: CustomColors.whWhite,
-                ),
-              ),
-              mainWidgetCallback: (value) {
+            widget.asyncValue.when(
+              data: (data) {
                 return Text(
-                  value.toString(),
+                  data.toString(),
                   style: context.displayLarge?.copyWith(
+                    color: CustomColors.whWhite,
+                  ),
+                );
+              },
+              error: (_, __) {
+                return Text(
+                  '--',
+                  style: context.displayMedium?.copyWith(
+                    color: CustomColors.whWhite,
+                  ),
+                );
+              },
+              loading: () {
+                return Text(
+                  '--',
+                  style: context.displayMedium?.copyWith(
                     color: CustomColors.whWhite,
                   ),
                 );

--- a/lib/presentation/common_components/weekly_resolution_summary_card.dart
+++ b/lib/presentation/common_components/weekly_resolution_summary_card.dart
@@ -2,9 +2,6 @@ import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
-import 'package:wehavit/dependency/dependency.dart';
-import 'package:wehavit/domain/usecases/usecases.dart';
-import 'package:wehavit/presentation/common_components/either_future_builder.dart';
 import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 class WeeklyResolutionSummaryCard extends StatelessWidget {

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -10,6 +10,7 @@ import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 import 'package:wehavit/presentation/state/group_post/confirm_post_provider.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 import 'package:wehavit/presentation/state/resolution_list/resolution_provider.dart';
 import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
@@ -339,6 +340,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                       ),
                     ),
                   ).whenComplete(() {
+                    ref.invalidate(resolutionListNotifierProvider);
                     ref.invalidate(
                       resolutionProvider(
                         ResolutionProviderParam(
@@ -368,6 +370,7 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                       ),
                     ),
                   ).whenComplete(() {
+                    ref.invalidate(resolutionListNotifierProvider);
                     ref.invalidate(
                       resolutionProvider(
                         ResolutionProviderParam(

--- a/lib/presentation/my_page/view/resolution_detail_view.dart
+++ b/lib/presentation/my_page/view/resolution_detail_view.dart
@@ -246,62 +246,6 @@ class _ResolutionDetailViewState extends ConsumerState<ResolutionDetailView> {
                     style: context.labelMedium?.copyWith(color: CustomColors.whGrey700),
                   ),
                 ),
-                // const SizedBox(height: 40.0),
-                // Consumer(
-                //   builder: (context, ref, child) {
-                //     return WideOutlinedButton(
-                //       buttonTitle: '목표 삭제하기',
-                //       foregroundColor: CustomColors.whRed,
-                //       onPressed: () async {
-                //         showDialog(
-                //           context: context,
-                //           builder: (context) {
-                //             return AlertDialog(
-                //               title: const Text(
-                //                 '목표 삭제하기',
-                //                 style: TextStyle(color: CustomColors.whGrey100),
-                //               ),
-                //               content: Text(
-                //                 '${widget.entity.resolutionName} 을 비활성화 하시겠어요?\n해당 목표는 작성하기에서 숨김 처리됩니다.',
-                //                 style: const TextStyle(color: CustomColors.whGrey100),
-                //               ),
-                //               actions: [
-                //                 TextButton(
-                //                   child: const Text(
-                //                     '취소',
-                //                     style: TextStyle(color: CustomColors.whGrey300),
-                //                   ),
-                //                   onPressed: () {
-                //                     Navigator.of(context).pop();
-                //                   },
-                //                 ),
-                //                 TextButton(
-                //                   child: const Text(
-                //                     '삭제하기',
-                //                     style: TextStyle(color: CustomColors.whRed500),
-                //                   ),
-                //                   onPressed: () async {
-                //                     await ref
-                //                         .read(setResolutionDeactiveUsecaseProvider)
-                //                         .call(resolutionId: widget.entity.resolutionId, entity: widget.entity)
-                //                         .whenComplete(() {
-                //                       setState(() {
-                //                         ref.invalidate(resolutionListNotifierProvider);
-                //                       });
-                //                     });
-                //                     Navigator.of(context).pop();
-                //                     Navigator.of(context).pop();
-                //                   },
-                //                 ),
-                //               ],
-                //             );
-                //           },
-                //         );
-                //         ref.invalidate(resolutionListNotifierProvider);
-                //       },
-                //     );
-                //   },
-                // ),
                 const SizedBox(height: 20),
               ],
             ),

--- a/lib/presentation/state/group_post/friend_post_provider.dart
+++ b/lib/presentation/state/group_post/friend_post_provider.dart
@@ -20,6 +20,14 @@ final friendSharedResolutionListProvider = FutureProvider<List<String>>(
       }),
     );
 
+    // 내가 작성한 포스트도 함께 보여주기
+    final result = await ref.read(getMyResolutionListUsecaseProvider).call();
+    final list = result.fold(
+      (failure) => <String>[], // 실패 시 빈 리스트 반환
+      (list) => list.map((e) => e.resolutionId).toList(), // 성공 시 리스트 반환
+    );
+    sharedResolutionIdMap[''] = list;
+
     final List<String> sharedResolutionIdList = sharedResolutionIdMap.entries.expand((e) => e.value).toList();
 
     return sharedResolutionIdList;

--- a/lib/presentation/state/resolution_list/resolution_list_provider.dart
+++ b/lib/presentation/state/resolution_list/resolution_list_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/common/utils/datetime+.dart';
 import 'package:wehavit/dependency/dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/domain/usecases/usecases.dart';
@@ -12,9 +13,17 @@ final resolutionListNotifierProvider = FutureProvider<List<ResolutionEntity>>(
       ),
 );
 
-final weeklyResolutionInfoProvider = FutureProvider.family<List<bool>, GetTargetResolutionDoneListForWeekUsecaseParams>(
+final weeklyResolutionInfoProvider = FutureProvider.family<List<bool>, WeeklyResolutionInfoProviderParam>(
   (ref, param) async {
-    return ref.read(getTargetResolutionDoneListForWeekUsecaseProvider).call(param: param).then(
+    return ref
+        .read(getTargetResolutionDoneListForWeekUsecaseProvider)
+        .call(
+          param: GetTargetResolutionDoneListForWeekUsecaseParams(
+            resolutionId: param.resolutionId,
+            startMonday: param.startMonday,
+          ),
+        )
+        .then(
           (value) => value.fold(
             (failure) => Future.error(failure.message),
             (success) => success,
@@ -22,3 +31,42 @@ final weeklyResolutionInfoProvider = FutureProvider.family<List<bool>, GetTarget
         );
   },
 );
+
+class WeeklyResolutionInfoProviderParam {
+  WeeklyResolutionInfoProviderParam({required this.resolutionId, required this.startMonday});
+
+  final String resolutionId;
+  final DateTime startMonday;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is WeeklyResolutionInfoProviderParam &&
+        other.resolutionId == resolutionId &&
+        other.startMonday == startMonday;
+  }
+
+  @override
+  int get hashCode => resolutionId.hashCode ^ startMonday.hashCode;
+}
+
+final myWeeklyResolutionSummaryProvider = FutureProvider<int>((ref) async {
+  final resolutionEntityList = await ref.watch(resolutionListNotifierProvider.future);
+
+  final successCount = await Future.wait(
+    resolutionEntityList.map((entity) async {
+      return await ref
+          .read(getTargetResolutionDoneListForWeekUsecaseProvider)
+          .call(
+            param: GetTargetResolutionDoneListForWeekUsecaseParams(
+              resolutionId: entity.resolutionId,
+              startMonday: DateTime.now().getMondayDateTime(),
+            ),
+          )
+          .then((result) => result.fold((failure) => 0, (success) => success.where((e) => e == true).length));
+    }),
+  );
+
+  return successCount.reduce((v, e) => v + e);
+});

--- a/lib/presentation/write_post/model/writing_confirm_post_view_model.dart
+++ b/lib/presentation/write_post/model/writing_confirm_post_view_model.dart
@@ -1,12 +1,16 @@
 import 'package:image_picker/image_picker.dart';
+import 'package:wehavit/common/utils/image_uploader.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 
 class WritingConfirmPostViewModel {
-  ResolutionEntity? entity;
+  WritingConfirmPostViewModel(this.entity);
+
+  ResolutionEntity entity;
   DateTime todayDate = DateTime.now();
   bool isWritingYesterdayPost = false;
   String postContent = '';
 
-  List<XFile> imageMediaList = [];
+  List<ImageUploadEntity> imageMediaList = [];
+
   bool isUploading = false;
 }

--- a/lib/presentation/write_post/model/writing_confirm_post_view_model.dart
+++ b/lib/presentation/write_post/model/writing_confirm_post_view_model.dart
@@ -1,4 +1,3 @@
-import 'package:image_picker/image_picker.dart';
 import 'package:wehavit/common/utils/image_uploader.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 
@@ -6,11 +5,12 @@ class WritingConfirmPostViewModel {
   WritingConfirmPostViewModel(this.entity);
 
   ResolutionEntity entity;
-  DateTime todayDate = DateTime.now();
-  bool isWritingYesterdayPost = false;
-  String postContent = '';
 
-  List<ImageUploadEntity> imageMediaList = [];
+  DateTime todayDate = DateTime.now();
 
   bool isUploading = false;
+  bool isWritingYesterdayPost = false;
+
+  String postContent = '';
+  List<ImageUploadEntity> imageMediaList = [];
 }

--- a/lib/presentation/write_post/provider/add_resolution_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/add_resolution_view_model_provider.dart
@@ -5,9 +5,11 @@ import 'package:wehavit/presentation/write_post/write_post.dart';
 
 class AddResolutionViewModelProvider extends StateNotifier<AddResolutionViewModel> {
   AddResolutionViewModelProvider(
+    this.ref,
     this.uploadResolutionUseCase,
   ) : super(AddResolutionViewModel());
 
+  Ref ref;
   UploadResolutionUseCase uploadResolutionUseCase;
 
   void setTimes(double value) {
@@ -61,10 +63,12 @@ class AddResolutionViewModelProvider extends StateNotifier<AddResolutionViewMode
   void checkIsMovableToNextStep() {
     state.isMovableToNextStep =
         state.inputConditions.sublist(0, state.currentStep + 1).reduce((value, element) => value & element);
+    ref.notifyListeners();
   }
 
   void setFocusedStep(int value) {
     state.focusedStep = value;
+    ref.notifyListeners();
   }
 
   Future<ResolutionEntity?> uploadResolution() async {

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
+import 'package:wehavit/domain/entities/resolution_entity/resolution_entity.dart';
 import 'package:wehavit/domain/usecases/usecases.dart';
 import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 import 'package:wehavit/presentation/write_post/write_post.dart';
@@ -90,11 +91,11 @@ class ResolutionListViewModelProvider extends StateNotifier<ResolutionListViewMo
   }
 
   Future<void> uploadPostWithoutContents({
-    required ResolutionListCellWidgetModel model,
+    required ResolutionEntity entity,
   }) async {
     _uploadConfirmPostUseCase(
-      resolutionGoalStatement: model.entity.goalStatement,
-      resolutionId: model.entity.resolutionId,
+      resolutionGoalStatement: entity.goalStatement,
+      resolutionId: entity.resolutionId,
       content: '',
       localFileUrlList: [],
       hasRested: false,
@@ -105,8 +106,8 @@ class ResolutionListViewModelProvider extends StateNotifier<ResolutionListViewMo
       if (isPostingSuccess) {
         ref.invalidate(
           weeklyResolutionInfoProvider.call(
-            GetTargetResolutionDoneListForWeekUsecaseParams(
-              resolutionId: model.entity.resolutionId,
+            WeeklyResolutionInfoProviderParam(
+              resolutionId: entity.resolutionId,
               startMonday: DateTime.now().getMondayDateTime(),
             ),
           ),

--- a/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/resolution_list_view_model_provider.dart
@@ -97,7 +97,7 @@ class ResolutionListViewModelProvider extends StateNotifier<ResolutionListViewMo
       resolutionGoalStatement: entity.goalStatement,
       resolutionId: entity.resolutionId,
       content: '',
-      localFileUrlList: [],
+      fileUrlList: [],
       hasRested: false,
       isPostingForYesterday: false,
     ).then((result) {

--- a/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
@@ -47,7 +47,7 @@ class WritingConfirmPostViewModelProvider extends StateNotifier<WritingConfirmPo
         if (isPostingSuccess) {
           ref.invalidate(
             weeklyResolutionInfoProvider.call(
-              GetTargetResolutionDoneListForWeekUsecaseParams(
+              WeeklyResolutionInfoProviderParam(
                 resolutionId: state.entity!.resolutionId,
                 startMonday: DateTime.now().getMondayDateTime(),
               ),

--- a/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
+++ b/lib/presentation/write_post/provider/writing_confirm_post_view_model_provider.dart
@@ -1,23 +1,30 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:wehavit/common/utils/datetime+.dart';
+import 'package:wehavit/common/utils/image_uploader.dart';
+import 'package:wehavit/data/datasources/auth_social_datasource_impl.dart';
+import 'package:wehavit/dependency/dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
-import 'package:wehavit/domain/usecases/usecases.dart';
 import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
 import 'package:wehavit/presentation/write_post/write_post.dart';
 
+final writingConfirmPostViewModelProvider = StateNotifierProvider.autoDispose
+    .family<WritingConfirmPostViewModelProvider, WritingConfirmPostViewModel, ResolutionEntity>((ref, entity) {
+  return WritingConfirmPostViewModelProvider(ref, entity);
+});
+
 class WritingConfirmPostViewModelProvider extends StateNotifier<WritingConfirmPostViewModel> {
   WritingConfirmPostViewModelProvider(
     this.ref,
-    this._uploadConfirmPostUseCase,
-    this._sendNotificationToSharedUsersUsecase,
-  ) : super(WritingConfirmPostViewModel());
+    resolutionEntity,
+  ) : super(WritingConfirmPostViewModel(resolutionEntity));
+
+  final Ref ref;
 
   final int maxImagesCount = 3;
-  final Ref ref;
-  final UploadConfirmPostUseCase _uploadConfirmPostUseCase;
-  final SendNotificationToSharedUsersUsecase _sendNotificationToSharedUsersUsecase;
 
   Future<void> pickPhotos() async {
     final ImagePicker picker = ImagePicker();
@@ -26,21 +33,42 @@ class WritingConfirmPostViewModelProvider extends StateNotifier<WritingConfirmPo
       requestFullMetadata: false,
     );
 
-    state.imageMediaList = imageList;
+    final uploader = ImageUploader();
+
+    state.imageMediaList = imageList.asMap().entries.map((entry) {
+      return ImageUploadEntity(
+        imageFile: entry.value,
+        index: entry.key,
+        status: ImageUploadStatus.uploading,
+      );
+    }).toList();
+
+    ref.notifyListeners();
+
+    for (ImageUploadEntity entity in state.imageMediaList) {
+      uploader.uploadFile(entity).then((result) {
+        state.imageMediaList[result.index].resultUrl = result.resultUrl;
+        state.imageMediaList[result.index].status = result.status;
+        ref.notifyListeners();
+      });
+    }
   }
 
   Future<void> uploadPost({
     required bool hasRested,
     required UserDataEntity? myUserEntity,
   }) async {
-    _uploadConfirmPostUseCase(
-      resolutionGoalStatement: state.entity?.goalStatement ?? '',
-      resolutionId: state.entity?.resolutionId ?? '',
-      content: state.postContent,
-      localFileUrlList: state.imageMediaList.map((media) => media.path.toString()).toList(),
-      hasRested: hasRested,
-      isPostingForYesterday: state.isWritingYesterdayPost,
-    ).then(
+    ref
+        .read(uploadConfirmPostUseCaseProvider)
+        .call(
+          resolutionGoalStatement: state.entity.goalStatement,
+          resolutionId: state.entity.resolutionId,
+          content: state.postContent,
+          localFileUrlList: state.imageMediaList.map((media) => media.imageFile.path.toString()).toList(),
+          hasRested: hasRested,
+          isPostingForYesterday: state.isWritingYesterdayPost,
+        )
+        .then(
       (result) {
         final isPostingSuccess = result.fold((failure) => false, (value) => value);
 
@@ -48,7 +76,7 @@ class WritingConfirmPostViewModelProvider extends StateNotifier<WritingConfirmPo
           ref.invalidate(
             weeklyResolutionInfoProvider.call(
               WeeklyResolutionInfoProviderParam(
-                resolutionId: state.entity!.resolutionId,
+                resolutionId: state.entity.resolutionId,
                 startMonday: DateTime.now().getMondayDateTime(),
               ),
             ),
@@ -60,16 +88,21 @@ class WritingConfirmPostViewModelProvider extends StateNotifier<WritingConfirmPo
     );
   }
 
+  void toggleYesterdayOption() {
+    state.isWritingYesterdayPost = !state.isWritingYesterdayPost;
+    ref.notifyListeners();
+  }
+
   Future<void> sendNotiToSharedUsers({
     required UserDataEntity? myUserEntity,
   }) async {
-    if (state.entity == null || myUserEntity == null) {
+    if (myUserEntity == null) {
       return;
     }
 
-    _sendNotificationToSharedUsersUsecase(
-      myUserEntity: myUserEntity,
-      resolutionEntity: state.entity!,
-    );
+    ref.read(sendNotificationToSharedUsersUsecaseProvider).call(
+          myUserEntity: myUserEntity,
+          resolutionEntity: state.entity,
+        );
   }
 }

--- a/lib/presentation/write_post/view/add_resolution_done_view.dart
+++ b/lib/presentation/write_post/view/add_resolution_done_view.dart
@@ -1,11 +1,8 @@
-import 'dart:async';
-
 import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/domain/usecase_dependency.dart';
-import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/group_entity/group_entity.dart';
 import 'package:wehavit/domain/entities/resolution_entity/resolution_entity.dart';
 import 'package:wehavit/presentation/presentation.dart';
@@ -16,7 +13,9 @@ import 'package:wehavit/presentation/state/resolution_list/resolution_provider.d
 import 'package:wehavit/presentation/state/user_data/my_user_data_provider.dart';
 
 class AddResolutionDoneView extends ConsumerStatefulWidget {
-  const AddResolutionDoneView({super.key});
+  const AddResolutionDoneView({required this.resolutionEntity, super.key});
+
+  final ResolutionEntity resolutionEntity;
 
   @override
   ConsumerState<AddResolutionDoneView> createState() => _AddResolutionDoneViewState();
@@ -24,22 +23,8 @@ class AddResolutionDoneView extends ConsumerStatefulWidget {
 
 class _AddResolutionDoneViewState extends ConsumerState<AddResolutionDoneView> {
   @override
-  void initState() {
-    super.initState();
-
-    unawaited(
-      ref.read(addResolutionDoneViewModelProvider.notifier).loadFriendList(),
-    );
-    // unawaited(
-    //   ref.read(addResolutionDoneViewModelProvider.notifier).loadGroupList(),
-    // );
-  }
-
   @override
   Widget build(BuildContext context) {
-    final viewmodel = ref.watch(addResolutionDoneViewModelProvider);
-    // final provider = ref.watch(addResolutionDoneViewModelProvider.notifier);
-
     return Scaffold(
       resizeToAvoidBottomInset: true,
       backgroundColor: CustomColors.whDarkBlack,
@@ -71,7 +56,7 @@ class _AddResolutionDoneViewState extends ConsumerState<AddResolutionDoneView> {
                     borderRadius: BorderRadius.circular(16.0),
                   ),
                   child: ResolutionListCell(
-                    resolutionEntity: viewmodel.resolutionEntity!,
+                    resolutionEntity: widget.resolutionEntity,
                     showDetails: true,
                     onPressed: () {},
                   ),
@@ -80,11 +65,18 @@ class _AddResolutionDoneViewState extends ConsumerState<AddResolutionDoneView> {
               Expanded(
                 child: Container(),
               ),
+              Text(
+                '인증글을 공유하지 않고, 혼자서도 인증글을 남기고 확인할 수 있어요.\n다만, 조금 외로울 뿐!',
+                textAlign: TextAlign.center,
+                style: context.labelSmall?.copyWith(
+                  color: CustomColors.whGrey700,
+                ),
+              ),
               Container(
                 margin: const EdgeInsets.only(
-                  top: 12.0,
+                  top: 16.0,
                 ),
-                child: WideColoredButton(
+                child: WideOutlinedButton(
                   onPressed: () async {
                     // provider.resetTempFriendList();
                     showModalBottomSheet(
@@ -94,7 +86,7 @@ class _AddResolutionDoneViewState extends ConsumerState<AddResolutionDoneView> {
                         SizedBox(
                           height: MediaQuery.of(context).size.height * 0.82,
                           child: ShareResolutionToFriendBottomSheetWidget(
-                            resolutionEntity: viewmodel.resolutionEntity!,
+                            resolutionEntity: widget.resolutionEntity,
                           ),
                         ),
                       ),
@@ -103,21 +95,21 @@ class _AddResolutionDoneViewState extends ConsumerState<AddResolutionDoneView> {
                         resolutionProvider(
                           ResolutionProviderParam(
                             userId: ref.read(getMyUserDataProvider).value!.userId,
-                            resolutionId: viewmodel.resolutionEntity!.resolutionId,
+                            resolutionId: widget.resolutionEntity.resolutionId,
                           ),
                         ),
                       );
                     });
                   },
-                  buttonTitle: '친구에게 공유하기',
+                  buttonTitle: '공유할 친구 선택하기',
                   iconString: WHIcons.friend,
                 ),
               ),
               Container(
                 margin: const EdgeInsets.only(
-                  top: 12.0,
+                  top: 16.0,
                 ),
-                child: WideColoredButton(
+                child: WideOutlinedButton(
                   onPressed: () async {
                     // await provider.resetTempGroupList();
 
@@ -128,12 +120,12 @@ class _AddResolutionDoneViewState extends ConsumerState<AddResolutionDoneView> {
                       builder: (context) => GradientBottomSheet(
                         SizedBox(
                           height: MediaQuery.of(context).size.height * 0.82,
-                          child: ShareResolutionToGroupBottomSheetWidget(resolutionEntity: viewmodel.resolutionEntity!),
+                          child: ShareResolutionToGroupBottomSheetWidget(resolutionEntity: widget.resolutionEntity),
                         ),
                       ),
                     );
                   },
-                  buttonTitle: '그룹에게 공유하기',
+                  buttonTitle: '공유할 그룹 선택하기',
                   iconString: WHIcons.group,
                 ),
               ),
@@ -166,9 +158,6 @@ class _ShareResolutionToFriendBottomSheetWidgetState extends ConsumerState<Share
           trailingAction: () {
             Navigator.pop(context);
           },
-        ),
-        const SizedBox(
-          height: 16.0,
         ),
         Consumer(
           builder: (context, ref, child) {
@@ -429,9 +418,6 @@ class _ShareResolutionToGroupBottomSheetWidgetState extends ConsumerState<ShareR
           trailingAction: () {
             Navigator.pop(context);
           },
-        ),
-        const SizedBox(
-          height: 16.0,
         ),
         Consumer(
           builder: (context, ref, child) {

--- a/lib/presentation/write_post/view/add_resolution_view.dart
+++ b/lib/presentation/write_post/view/add_resolution_view.dart
@@ -1,3 +1,4 @@
+import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
@@ -15,17 +16,32 @@ class AddResolutionView extends ConsumerStatefulWidget {
 
 class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
   List<FocusNode> focuseNodeList = [FocusNode(), FocusNode(), FocusNode()];
+  TextEditingController nameTextEditingController = TextEditingController();
+  TextEditingController goalTextEditingController = TextEditingController();
+  TextEditingController actionTextEditingController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     final viewmodel = ref.watch(addResolutionViewModelProvider);
     final provider = ref.read(addResolutionViewModelProvider.notifier);
 
+    nameTextEditingController.addListener(() {
+      provider.setNameString(nameTextEditingController.text);
+    });
+
+    goalTextEditingController.addListener(() {
+      provider.setGoalString(goalTextEditingController.text);
+    });
+
+    actionTextEditingController.addListener(() {
+      provider.setActionString(actionTextEditingController.text);
+    });
+
     return Scaffold(
       resizeToAvoidBottomInset: true,
       backgroundColor: CustomColors.whDarkBlack,
       appBar: WehavitAppBar(
-        titleLabel: '도전 추가하기',
+        titleLabel: '목표 추가하기',
         leadingTitle: '취소',
         leadingAction: () async {
           Navigator.pop(context);
@@ -49,58 +65,20 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Visibility(
-                          visible: viewmodel.focusedStep == 0,
-                          child: Container(
-                            margin: const EdgeInsets.only(bottom: 8),
-                            child: const Text(
-                              '도전의 이름을 지어주세요',
-                              style: TextStyle(
-                                fontWeight: FontWeight.w600,
-                                color: CustomColors.whWhite,
-                                fontSize: 20,
-                              ),
-                            ),
-                          ),
-                        ),
-                        TextFormField(
-                          focusNode: focuseNodeList[0],
-                          onChanged: (value) {
-                            setState(() {
-                              provider.setNameString(value);
-                            });
-                          },
-                          cursorColor: CustomColors.whWhite,
-                          textAlignVertical: TextAlignVertical.center,
-                          style: const TextStyle(
-                            color: CustomColors.whWhite,
-                            fontSize: 16.0,
-                          ),
-                          autofocus: true,
-                          decoration: InputDecoration(
-                            hintText: '나의 새로운 도전',
-                            hintStyle: const TextStyle(
-                              fontSize: 16,
-                              color: CustomColors.whPlaceholderGrey,
-                            ),
-                            filled: true,
-                            fillColor: CustomColors.whGrey,
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(10),
-                              borderSide: const BorderSide(
-                                width: 0,
-                                style: BorderStyle.none,
-                              ),
-                            ),
-                            isCollapsed: true,
-                            contentPadding: const EdgeInsets.symmetric(
-                              vertical: 12.0,
-                              horizontal: 16.0,
-                            ),
-                          ),
+                        Text(
+                          '도전명',
+                          style: context.titleSmall,
                         ),
                         Container(
-                          height: 24.0,
+                          height: 12.0,
+                        ),
+                        InputFormField(
+                          textEditingController: nameTextEditingController,
+                          focusNode: focuseNodeList[0],
+                          placeholder: '나의 도전에 멋진 이름을 붙여주세요',
+                        ),
+                        Container(
+                          height: 16.0,
                         ),
                       ],
                     ),
@@ -111,57 +89,20 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Visibility(
-                          visible: viewmodel.focusedStep == 1,
-                          child: Container(
-                            margin: const EdgeInsets.only(bottom: 8),
-                            child: const Text(
-                              '달성하려는 목표는 무엇인가요?',
-                              style: TextStyle(
-                                fontWeight: FontWeight.w600,
-                                color: CustomColors.whWhite,
-                                fontSize: 20,
-                              ),
-                            ),
-                          ),
-                        ),
-                        TextFormField(
-                          focusNode: focuseNodeList[1],
-                          onChanged: (value) {
-                            setState(() {
-                              provider.setGoalString(value);
-                            });
-                          },
-                          cursorColor: CustomColors.whWhite,
-                          textAlignVertical: TextAlignVertical.center,
-                          style: const TextStyle(
-                            color: CustomColors.whWhite,
-                            fontSize: 16.0,
-                          ),
-                          decoration: InputDecoration(
-                            hintText: '좇으려는 목표',
-                            hintStyle: const TextStyle(
-                              fontSize: 16,
-                              color: CustomColors.whPlaceholderGrey,
-                            ),
-                            filled: true,
-                            fillColor: CustomColors.whGrey,
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(10),
-                              borderSide: const BorderSide(
-                                width: 0,
-                                style: BorderStyle.none,
-                              ),
-                            ),
-                            isCollapsed: true,
-                            contentPadding: const EdgeInsets.symmetric(
-                              vertical: 12.0,
-                              horizontal: 16.0,
-                            ),
-                          ),
+                        Text(
+                          '목표',
+                          style: context.titleSmall,
                         ),
                         Container(
-                          height: 24.0,
+                          height: 12.0,
+                        ),
+                        InputFormField(
+                          textEditingController: goalTextEditingController,
+                          focusNode: focuseNodeList[1],
+                          placeholder: '도전으로 이루고싶은 바를 알려주세요',
+                        ),
+                        Container(
+                          height: 16.0,
                         ),
                       ],
                     ),
@@ -172,57 +113,20 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Visibility(
-                          visible: viewmodel.focusedStep == 2,
-                          child: Container(
-                            margin: const EdgeInsets.only(bottom: 8),
-                            child: const Text(
-                              '어떤 노력을 지속하실 건가요?',
-                              style: TextStyle(
-                                fontWeight: FontWeight.w600,
-                                color: CustomColors.whWhite,
-                                fontSize: 20,
-                              ),
-                            ),
-                          ),
-                        ),
-                        TextFormField(
-                          focusNode: focuseNodeList[2],
-                          onChanged: (value) {
-                            setState(() {
-                              provider.setActionString(value);
-                            });
-                          },
-                          cursorColor: CustomColors.whWhite,
-                          textAlignVertical: TextAlignVertical.center,
-                          style: const TextStyle(
-                            color: CustomColors.whWhite,
-                            fontSize: 16.0,
-                          ),
-                          decoration: InputDecoration(
-                            hintText: '내가 실천할 행동',
-                            hintStyle: const TextStyle(
-                              fontSize: 16,
-                              color: CustomColors.whPlaceholderGrey,
-                            ),
-                            filled: true,
-                            fillColor: CustomColors.whGrey,
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(10),
-                              borderSide: const BorderSide(
-                                width: 0,
-                                style: BorderStyle.none,
-                              ),
-                            ),
-                            isCollapsed: true,
-                            contentPadding: const EdgeInsets.symmetric(
-                              vertical: 12.0,
-                              horizontal: 16.0,
-                            ),
-                          ),
+                        Text(
+                          '실천할 액션',
+                          style: context.titleSmall,
                         ),
                         Container(
-                          height: 24.0,
+                          height: 12.0,
+                        ),
+                        InputFormField(
+                          textEditingController: actionTextEditingController,
+                          focusNode: focuseNodeList[2],
+                          placeholder: '내가 실천하고 인증할 노력이에요',
+                        ),
+                        Container(
+                          height: 16.0,
                         ),
                       ],
                     ),
@@ -232,16 +136,9 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Visibility(
-                          visible: viewmodel.focusedStep == 3,
-                          child: const Text(
-                            '일주일에 몇 번 실천하실건가요?',
-                            style: TextStyle(
-                              fontWeight: FontWeight.w600,
-                              color: CustomColors.whWhite,
-                              fontSize: 20,
-                            ),
-                          ),
+                        Text(
+                          '일주일에 몇 번 실천하실건가요?',
+                          style: context.titleSmall,
                         ),
                         Container(
                           height: 24.0,
@@ -266,9 +163,9 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                             trackHeight: 2,
                           ),
                           child: Slider(
-                            inactiveColor: CustomColors.whGrey,
-                            activeColor: CustomColors.whYellow,
-                            secondaryActiveColor: CustomColors.whYellow,
+                            inactiveColor: CustomColors.whGrey400,
+                            activeColor: CustomColors.whYellow500,
+                            secondaryActiveColor: CustomColors.whYellow500,
                             min: 1,
                             max: 7,
                             value: viewmodel.timesTemp,
@@ -288,7 +185,7 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                           ),
                         ),
                         Container(
-                          height: 24.0,
+                          height: 16.0,
                         ),
                       ],
                     ),
@@ -298,19 +195,12 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Visibility(
-                          visible: viewmodel.focusedStep == 4,
-                          child: const Text(
-                            '도전의 색상을 골라주세요',
-                            style: TextStyle(
-                              fontWeight: FontWeight.w600,
-                              color: CustomColors.whWhite,
-                              fontSize: 20,
-                            ),
-                          ),
+                        Text(
+                          '도전의 색상을 골라주세요',
+                          style: context.titleSmall,
                         ),
                         Container(
-                          height: 16.0,
+                          height: 12.0,
                         ),
                         SingleChildScrollView(
                           child: Row(
@@ -355,7 +245,7 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                           ),
                         ),
                         Container(
-                          height: 40,
+                          height: 16.0,
                         ),
                       ],
                     ),
@@ -365,19 +255,12 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Visibility(
-                          visible: viewmodel.focusedStep == 5,
-                          child: const Text(
-                            '도전을 나타낼 아이콘을 골라주세요',
-                            style: TextStyle(
-                              fontWeight: FontWeight.w600,
-                              color: CustomColors.whWhite,
-                              fontSize: 20,
-                            ),
-                          ),
+                        Text(
+                          '도전을 나타낼 아이콘을 골라주세요',
+                          style: context.titleSmall,
                         ),
                         Container(
-                          height: 16.0,
+                          height: 12.0,
                         ),
                         SingleChildScrollView(
                           scrollDirection: Axis.horizontal,
@@ -405,12 +288,14 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                                   decoration: BoxDecoration(
                                     borderRadius: BorderRadius.circular(12.0),
                                     border: Border.all(
-                                      color:
-                                          viewmodel.iconIndex == index ? CustomColors.whYellow : CustomColors.whWhite,
+                                      color: viewmodel.iconIndex == index
+                                          ? CustomColors.whYellow500
+                                          : CustomColors.whWhite,
                                       width: 2.0,
                                     ),
-                                    color:
-                                        viewmodel.iconIndex == index ? CustomColors.whYellowDark : CustomColors.whGrey,
+                                    color: viewmodel.iconIndex == index
+                                        ? CustomColors.whYellow300
+                                        : CustomColors.whGrey600,
                                   ),
                                   child: Image.asset(
                                     CustomIconImage.resolutionIcons[index],
@@ -464,7 +349,7 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
                           Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (context) => const AddResolutionDoneView(),
+                              builder: (context) => AddResolutionDoneView(resolutionEntity: resolutionEntity),
                             ),
                           );
                         });
@@ -509,6 +394,7 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
     focuseNodeList[0].dispose();
     focuseNodeList[1].dispose();
     focuseNodeList[2].dispose();
+
     super.dispose();
   }
 

--- a/lib/presentation/write_post/view/add_resolution_view.dart
+++ b/lib/presentation/write_post/view/add_resolution_view.dart
@@ -41,7 +41,7 @@ class _AddResolutionViewState extends ConsumerState<AddResolutionView> {
       resizeToAvoidBottomInset: true,
       backgroundColor: CustomColors.whDarkBlack,
       appBar: WehavitAppBar(
-        titleLabel: '목표 추가하기',
+        titleLabel: '도전 추가하기',
         leadingTitle: '취소',
         leadingAction: () async {
           Navigator.pop(context);

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -8,6 +8,7 @@ import 'package:wehavit/common/constants/app_colors.dart';
 import 'package:wehavit/common/utils/datetime+.dart';
 import 'package:wehavit/common/utils/preference_key.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
+import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 
@@ -23,8 +24,7 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    final viewModel = ref.watch(resolutionListViewModelProvider);
-    final provider = ref.read(resolutionListViewModelProvider.notifier);
+    // final provider = ref.read(resolutionListViewModelProvider.notifier);
 
     return Scaffold(
       backgroundColor: CustomColors.whDarkBlack,
@@ -35,21 +35,14 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
         minimum: const EdgeInsets.symmetric(horizontal: 16.0),
         child: RefreshIndicator(
           onRefresh: () async {
-            provider.loadResolutionModelList().whenComplete(() {
-              setState(() {
-                ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-              });
-            });
+            ref.invalidate(myWeeklyResolutionSummaryProvider);
+            ref.invalidate(resolutionListNotifierProvider);
+            ref.invalidate(weeklyResolutionInfoProvider);
           },
           child: ListView(
             children: [
-              WeeklyResolutionSummaryCard(
-                futureDoneRatio: viewModel.futureDoneRatio,
-                futureDoneCount: viewModel.futureDoneCount,
-              ),
-              const SizedBox(
-                height: 16.0,
-              ),
+              const WeeklyResolutionSummaryCard(),
+              const SizedBox(height: 16.0),
               Consumer(
                 builder: (context, ref, child) {
                   final asyncResolutionList = ref.watch(resolutionListNotifierProvider);
@@ -79,35 +72,15 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                                     showWritingOptionBottomSheet(
                                       // ignore: use_build_context_synchronously
                                       context,
-                                      viewModel,
-                                      provider,
-                                      index,
-                                    ).then((returnValue) async {
-                                      if (returnValue == true) {
-                                        await provider.loadResolutionModelList().whenComplete(() {
-                                          ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                                        });
-                                      } else {
-                                        //
-                                      }
-                                    });
+                                      resolutionList[index],
+                                    );
                                   });
                                 } else {
                                   showWritingOptionBottomSheet(
                                     // ignore: use_build_context_synchronously
                                     context,
-                                    viewModel,
-                                    provider,
-                                    index,
-                                  ).then((returnValue) async {
-                                    if (returnValue == true) {
-                                      await provider.loadResolutionModelList().whenComplete(() {
-                                        ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                                      });
-                                    } else {
-                                      //
-                                    }
-                                  });
+                                    resolutionList[index],
+                                  );
                                 }
                               },
                               resolutionEntity: ref.watch(resolutionListNotifierProvider).value![index],
@@ -126,12 +99,8 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                                       builder: (context) => const AddResolutionView(),
                                     ),
                                   ).whenComplete(() async {
-                                    await ref.watch(myPageViewModelProvider.notifier).getMyResolutionListUsecase();
-                                    await provider.loadResolutionModelList().whenComplete(() {
-                                      setState(() {
-                                        ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                                      });
-                                    });
+                                    ref.invalidate(myWeeklyResolutionSummaryProvider);
+                                    ref.invalidate(resolutionListNotifierProvider);
                                   });
                                 },
                               ),
@@ -147,89 +116,6 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                     },
                   );
                 },
-                // child:
-                // Column(
-                //   children: List<Widget>.generate(
-                //     ref.read(resolutionListNotifierProvider).value?.length ?? 0,
-                //     (index) => Container(
-                //       margin: const EdgeInsets.only(bottom: 16.0),
-                //       child: ResolutionListCell(
-                //         onPressed: () async {
-                //           final isGuideShown = await SharedPreferences.getInstance().then((instance) {
-                //             return instance.getBool(PreferenceKey.isWritingPostGuideShown);
-                //           });
-
-                //           if (isGuideShown == null || isGuideShown == false) {
-                //             // ignore: use_build_context_synchronously
-                //             showGuideBottomSheet(context).whenComplete(() async {
-                //               await SharedPreferences.getInstance().then((instance) {
-                //                 instance.setBool(
-                //                   PreferenceKey.isWritingPostGuideShown,
-                //                   true,
-                //                 );
-                //               });
-                //               showWritingOptionBottomSheet(
-                //                 // ignore: use_build_context_synchronously
-                //                 context,
-                //                 viewModel,
-                //                 provider,
-                //                 index,
-                //               ).then((returnValue) async {
-                //                 if (returnValue == true) {
-                //                   await provider.loadResolutionModelList().whenComplete(() {
-                //                     ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                //                   });
-                //                 } else {
-                //                   //
-                //                 }
-                //               });
-                //             });
-                //           } else {
-                //             showWritingOptionBottomSheet(
-                //               // ignore: use_build_context_synchronously
-                //               context,
-                //               viewModel,
-                //               provider,
-                //               index,
-                //             ).then((returnValue) async {
-                //               if (returnValue == true) {
-                //                 await provider.loadResolutionModelList().whenComplete(() {
-                //                   ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                //                 });
-                //               } else {
-                //                 //
-                //               }
-                //             });
-                //           }
-                //         },
-                //         resolutionEntity: ref.read(resolutionListNotifierProvider).value![index],
-                //         showDetails: false,
-                //       ),
-                //     ),
-                //   )
-                //       .append(
-                //         ListDashOutlinedCell(
-                //           buttonLabel: '새로운 목표 추가하기',
-                //           onPressed: () async {
-                //             Navigator.push(
-                //               context,
-                //               MaterialPageRoute(
-                //                 fullscreenDialog: true,
-                //                 builder: (context) => const AddResolutionView(),
-                //               ),
-                //             ).whenComplete(() async {
-                //               await ref.watch(myPageViewModelProvider.notifier).getMyResolutionListUsecase();
-                //               await provider.loadResolutionModelList().whenComplete(() {
-                //                 setState(() {
-                //                   ref.watch(resolutionListViewModelProvider).isLoadingView = false;
-                //                 });
-                //               });
-                //             });
-                //           },
-                //         ),
-                //       )
-                //       .toList(),
-                // ),
               ),
               Container(
                 height: 80,
@@ -243,18 +129,14 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
 
   Future<dynamic> showWritingOptionBottomSheet(
     BuildContext context,
-    ResolutionListViewModel viewModel,
-    ResolutionListViewModelProvider provider,
-    int index,
+    ResolutionEntity resolutionEntity,
   ) async {
     return showModalBottomSheet(
       isScrollControlled: true,
       // ignore: use_build_context_synchronously
       context: context,
       builder: (context) => WritingResolutionBottomSheetWidget(
-        viewModel: viewModel,
-        provider: provider,
-        index: index,
+        resolutionEntity: resolutionEntity,
       ),
     );
   }
@@ -279,14 +161,10 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
 class WritingResolutionBottomSheetWidget extends StatelessWidget {
   const WritingResolutionBottomSheetWidget({
     super.key,
-    required this.viewModel,
-    required this.provider,
-    required this.index,
+    required this.resolutionEntity,
   });
 
-  final ResolutionListViewModel viewModel;
-  final ResolutionListViewModelProvider provider;
-  final int index;
+  final ResolutionEntity resolutionEntity;
 
   @override
   Widget build(BuildContext context) {
@@ -297,17 +175,17 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
           Column(
             children: [
               Text(
-                viewModel.resolutionModelList![index].entity.resolutionName,
+                resolutionEntity.resolutionName,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  color: CustomColors.pointColorList[viewModel.resolutionModelList![index].entity.colorIndex],
+                  color: CustomColors.pointColorList[resolutionEntity.colorIndex],
                   fontSize: 18.0,
                   fontWeight: FontWeight.w600,
                 ),
               ),
               const SizedBox(height: 4.0),
               Text(
-                viewModel.resolutionModelList![index].entity.goalStatement,
+                resolutionEntity.goalStatement,
                 textAlign: TextAlign.center,
                 style: const TextStyle(
                   color: CustomColors.whWhite,
@@ -319,8 +197,7 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
                 height: 16,
               ),
               ResolutionLinearGaugeIndicator(
-                resolutionEntity: viewModel.resolutionModelList![index].entity,
-                // TODO: edit
+                resolutionEntity: resolutionEntity,
                 targetDate: DateTime.now().getMondayDateTime(),
                 // weeklyDoneList: viewModel.resolutionModelList![index].doneList,
               ),
@@ -329,31 +206,35 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
           const SizedBox(
             height: 40.0,
           ),
-          WideColoredButton(
-            buttonTitle: '인증글 작성하기',
-            foregroundColor: CustomColors.whBlack,
-            onPressed: () async {
-              final bool result = await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) {
-                    return WritingConfirmPostView(
-                      entity: viewModel.resolutionModelList![index].entity,
-                      hasRested: false,
-                    );
-                  },
-                ),
-              );
-              if (result == true) {
-                // ignore: use_build_context_synchronously
-                Navigator.of(context).pop(true);
+          Consumer(
+            builder: (context, ref, _) {
+              return WideColoredButton(
+                buttonTitle: '인증글 작성하기',
+                foregroundColor: CustomColors.whBlack,
+                onPressed: () async {
+                  final bool result = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return WritingConfirmPostView(
+                          entity: resolutionEntity,
+                          hasRested: false,
+                        );
+                      },
+                    ),
+                  );
+                  if (result == true) {
+                    // ignore: use_build_context_synchronously
+                    Navigator.of(context).pop(true);
 
-                showToastMessage(
-                  // ignore: use_build_context_synchronously
-                  context,
-                  text: '성공적으로 인증글을 공유했어요',
-                );
-              }
+                    showToastMessage(
+                      // ignore: use_build_context_synchronously
+                      context,
+                      text: '성공적으로 인증글을 공유했어요',
+                    );
+                  }
+                },
+              );
             },
           ),
           const SizedBox(
@@ -363,28 +244,32 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Expanded(
-                child: WideColoredButton(
-                  buttonTitle: '반성 남기기',
-                  foregroundColor: Colors.red,
-                  onPressed: () async {
-                    final result = await Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) {
-                          return WritingConfirmPostView(
-                            entity: viewModel.resolutionModelList![index].entity,
-                            hasRested: true,
+                child: Consumer(
+                  builder: (context, ref, _) {
+                    return WideColoredButton(
+                      buttonTitle: '반성 남기기',
+                      foregroundColor: Colors.red,
+                      onPressed: () async {
+                        final result = await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) {
+                              return WritingConfirmPostView(
+                                entity: resolutionEntity,
+                                hasRested: true,
+                              );
+                            },
+                          ),
+                        );
+                        if (result == true) {
+                          showToastMessage(
+                            // ignore: use_build_context_synchronously
+                            context,
+                            text: '성공적으로 반성글을 공유했어요',
                           );
-                        },
-                      ),
+                        }
+                      },
                     );
-                    if (result == true) {
-                      showToastMessage(
-                        // ignore: use_build_context_synchronously
-                        context,
-                        text: '성공적으로 반성글을 공유했어요',
-                      );
-                    }
                   },
                 ),
               ),
@@ -394,20 +279,25 @@ class WritingResolutionBottomSheetWidget extends StatelessWidget {
               Expanded(
                 child: SizedBox(
                   width: 150,
-                  child: WideColoredButton(
-                    buttonTitle: '완료 표시만 하기',
-                    onPressed: () async {
-                      provider
-                          .uploadPostWithoutContents(
-                        model: viewModel.resolutionModelList![index],
-                      )
-                          .whenComplete(() {
-                        Navigator.pop(context, true);
-                        showToastMessage(
-                          context,
-                          text: '성공적으로 인증을 남겼어요',
-                        );
-                      });
+                  child: Consumer(
+                    builder: (context, ref, _) {
+                      return WideColoredButton(
+                        buttonTitle: '완료 표시만 하기',
+                        onPressed: () async {
+                          ref
+                              .read(resolutionListViewModelProvider.notifier)
+                              .uploadPostWithoutContents(
+                                entity: resolutionEntity,
+                              )
+                              .whenComplete(() {
+                            Navigator.pop(context, true);
+                            showToastMessage(
+                              context,
+                              text: '성공적으로 인증을 남겼어요',
+                            );
+                          });
+                        },
+                      );
                     },
                   ),
                 ),

--- a/lib/presentation/write_post/view/resolution_list_view.dart
+++ b/lib/presentation/write_post/view/resolution_list_view.dart
@@ -88,7 +88,7 @@ class _ResolutionListViewState extends ConsumerState<ResolutionListView>
                         )
                             .append(
                               ListDashOutlinedCell(
-                                buttonLabel: '새로운 목표 추가하기',
+                                buttonLabel: '새로운 도전 추가하기',
                                 onPressed: () async {
                                   Navigator.push(
                                     context,

--- a/lib/presentation/write_post/view/resolution_list_view_widget.dart
+++ b/lib/presentation/write_post/view/resolution_list_view_widget.dart
@@ -1,0 +1,165 @@
+import 'package:awesome_extensions/awesome_extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wehavit/common/common.dart';
+import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
+import 'package:wehavit/domain/entities/entities.dart';
+import 'package:wehavit/presentation/common_components/common_components.dart';
+import 'package:wehavit/presentation/entrance/view/edit_user_detail_view.dart';
+import 'package:wehavit/presentation/write_post/write_post.dart';
+
+class ResolutionWritingMenuBottomSheet extends StatelessWidget {
+  const ResolutionWritingMenuBottomSheet({
+    super.key,
+    required this.resolutionEntity,
+  });
+
+  final ResolutionEntity resolutionEntity;
+
+  @override
+  Widget build(BuildContext context) {
+    return GradientBottomSheet(
+      Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Column(
+            children: [
+              Text(
+                resolutionEntity.resolutionName,
+                textAlign: TextAlign.center,
+                maxLines: 3,
+                style: context.titleMedium?.copyWith(color: CustomColors.pointColorList[resolutionEntity.colorIndex]),
+              ),
+              const SizedBox(height: 12.0),
+              Text(
+                resolutionEntity.goalStatement,
+                textAlign: TextAlign.center,
+                maxLines: 3,
+                style: context.bodyMedium,
+              ),
+              const SizedBox(
+                height: 24,
+              ),
+              ResolutionLinearGaugeIndicator(
+                resolutionEntity: resolutionEntity,
+                targetDate: DateTime.now().getMondayDateTime(),
+              ),
+            ],
+          ),
+          const SizedBox(
+            height: 40.0,
+          ),
+          Consumer(
+            builder: (context, ref, _) {
+              return WideColoredButton(
+                buttonTitle: '인증글 작성하기',
+                foregroundColor: CustomColors.whBlack,
+                onPressed: () async {
+                  final bool result = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return WritingConfirmPostView(
+                          entity: resolutionEntity,
+                          hasRested: false,
+                        );
+                      },
+                    ),
+                  );
+                  if (result == true) {
+                    // ignore: use_build_context_synchronously
+                    Navigator.of(context).pop(true);
+
+                    showToastMessage(
+                      // ignore: use_build_context_synchronously
+                      context,
+                      text: '성공적으로 인증글을 공유했어요',
+                    );
+                  }
+                },
+              );
+            },
+          ),
+          const SizedBox(
+            height: 16.0,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Consumer(
+                  builder: (context, ref, _) {
+                    return WideOutlinedButton(
+                      buttonTitle: '반성 남기기',
+                      foregroundColor: Colors.red,
+                      onPressed: () async {
+                        final result = await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) {
+                              return WritingConfirmPostView(
+                                entity: resolutionEntity,
+                                hasRested: true,
+                              );
+                            },
+                          ),
+                        );
+                        if (result == true) {
+                          showToastMessage(
+                            // ignore: use_build_context_synchronously
+                            context,
+                            text: '성공적으로 반성글을 공유했어요',
+                          );
+                        }
+                      },
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(
+                width: 8,
+              ),
+              Expanded(
+                child: SizedBox(
+                  width: 150,
+                  child: Consumer(
+                    builder: (context, ref, _) {
+                      return WideOutlinedButton(
+                        buttonTitle: '완료 표시만 하기',
+                        onPressed: () async {
+                          ref
+                              .read(resolutionListViewModelProvider.notifier)
+                              .uploadPostWithoutContents(
+                                entity: resolutionEntity,
+                              )
+                              .whenComplete(() {
+                            Navigator.pop(context, true);
+                            showToastMessage(
+                              context,
+                              text: '성공적으로 인증을 남겼어요',
+                            );
+                          });
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(
+            height: 16.0,
+          ),
+          WideColoredButton(
+            buttonTitle: '돌아가기',
+            backgroundColor: Colors.transparent,
+            foregroundColor: CustomColors.whPlaceholderGrey,
+            onPressed: () {
+              Navigator.pop(context, false);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/write_post/view/resolution_list_view_widget.dart
+++ b/lib/presentation/write_post/view/resolution_list_view_widget.dart
@@ -5,7 +5,6 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
-import 'package:wehavit/presentation/entrance/view/edit_user_detail_view.dart';
 import 'package:wehavit/presentation/write_post/write_post.dart';
 
 class ResolutionWritingMenuBottomSheet extends StatelessWidget {

--- a/lib/presentation/write_post/view/writing_confirm_post_view.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view.dart
@@ -176,7 +176,7 @@ class _WritingConfirmPostViewState extends ConsumerState<WritingConfirmPostView>
                       .read(writingConfirmPostViewModelProvider(widget.entity))
                       .imageMediaList
                       .every((entity) => entity.status == ImageUploadStatus.success)) {
-                    showToastMessage(context, text: '이미지 업로드 상태를 확인해주세요');
+                    showToastMessage(context, text: '아직 업로드 중이거나 업로드에 실패한 사진이 있어요');
                     return;
                   }
 
@@ -188,7 +188,6 @@ class _WritingConfirmPostViewState extends ConsumerState<WritingConfirmPostView>
                     myUserEntity: myUserEntity,
                   )
                       .whenComplete(() {
-                    // ignore: use_build_context_synchronously
                     if (context.mounted) {
                       Navigator.of(context).pop(true);
                     }
@@ -198,47 +197,11 @@ class _WritingConfirmPostViewState extends ConsumerState<WritingConfirmPostView>
             ],
           ),
         ),
-        Visibility(
-          visible: viewModel.isUploading,
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              Container(
-                width: double.infinity,
-                height: double.infinity,
-                color: CustomColors.whDarkBlack.withAlpha(100),
-              ),
-              const Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  SizedBox(
-                    width: 80,
-                    height: 80,
-                    child: CircularProgressIndicator(
-                      color: CustomColors.whYellow,
-                    ),
-                  ),
-                  SizedBox(
-                    height: 16.0,
-                  ),
-                  Text(
-                    '업로드 중입니다',
-                    style: TextStyle(
-                      color: CustomColors.whWhite,
-                      fontSize: 16.0,
-                      decoration: TextDecoration.none,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
       ],
     );
   }
 
-  void showShareTargetBottomSheet(BuildContext context) {
+  Future<void> showShareTargetBottomSheet(BuildContext context) async {
     showModalBottomSheet(
       isScrollControlled: true,
       context: context,

--- a/lib/presentation/write_post/view/writing_confirm_post_view.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view.dart
@@ -155,6 +155,7 @@ class _WritingConfirmPostViewState extends ConsumerState<WritingConfirmPostView>
                 ),
               ),
               UploadPhotoBottomToolbar(
+                type: widget.hasRested ? UploadPhotoBottomToolbarType.regret : UploadPhotoBottomToolbarType.upload,
                 onIconPressed: () async {
                   if (!widget.hasRested) {
                     FocusScope.of(context).unfocus();

--- a/lib/presentation/write_post/view/writing_confirm_post_view_widget.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/presentation/write_post/view/writing_confirm_post_view_widget.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view_widget.dart
@@ -1,10 +1,7 @@
-import 'dart:async';
-
+import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:fpdart/fpdart.dart';
 import 'package:wehavit/common/common.dart';
-import 'package:wehavit/dependency/domain/usecase_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/presentation.dart';
 
@@ -21,246 +18,78 @@ class ShareTargetGroupCellWidget extends ConsumerStatefulWidget {
 }
 
 class _ShareTargetGroupCellWidgetState extends ConsumerState<ShareTargetGroupCellWidget> {
-  List<GroupListViewCellWidgetModel>? sharingTargetGroupModelList;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(
-      loadEntityList().whenComplete(
-        () => setState(() {}),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Center(
-            child: Text(
-              '공유 대상',
-              style: TextStyle(
-                color: CustomColors.whWhite,
-                fontSize: 20.0,
-                fontWeight: FontWeight.w700,
+          const WehavitAppBar(
+            titleLabel: '공유 대상',
+            leadingTitle: ' ',
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '그룹',
+                style: context.titleSmall,
               ),
-            ),
-          ),
-          const SizedBox(
-            height: 24,
-          ),
-          const Text(
-            '그룹',
-            style: TextStyle(
-              color: CustomColors.whWhite,
-              fontSize: 20.0,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          if (sharingTargetGroupModelList != null)
-            Column(
-              children: List<Widget>.generate(
-                sharingTargetGroupModelList!.length,
-                (index) => Padding(
-                  padding: const EdgeInsets.only(bottom: 16.0),
-                  child: ShareTargetGroupListCellWidget(
-                    sharingTargetGroupModelList![index],
+              if (widget.entity.shareGroupEntityList.isEmpty)
+                Container(
+                  height: 60,
+                  alignment: Alignment.center,
+                  child: Text(
+                    '아직 목표를 공유하는 그룹이 없어요',
+                    style: context.labelMedium?.copyWith(color: CustomColors.whGrey600),
                   ),
                 ),
+              Column(
+                children: List<Widget>.generate(widget.entity.shareGroupEntityList.length, (index) {
+                  final groupEntity = widget.entity.shareGroupEntityList[index];
+
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: GroupListCell(groupEntity: groupEntity),
+                  );
+                }),
               ),
-            ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '친구',
+                style: context.titleSmall,
+              ),
+              if (widget.entity.shareFriendEntityList.isEmpty)
+                Container(
+                  height: 60,
+                  alignment: Alignment.center,
+                  child: Text(
+                    '아직 목표를 공유하는 친구가 없어요',
+                    style: context.labelMedium?.copyWith(color: CustomColors.whGrey600),
+                  ),
+                ),
+              Column(
+                children: List<Widget>.generate(widget.entity.shareFriendEntityList.length, (index) {
+                  final friendEntity = widget.entity.shareFriendEntityList[index];
+
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: UserProfileCell(
+                      friendEntity.userId,
+                      type: UserProfileCellType.normal,
+                    ),
+                  );
+                }),
+              ),
+            ],
+          ),
+          const SizedBox(height: 40),
         ],
       ),
     );
   }
-
-  Future<void> loadEntityList() async {
-    final entityList = await ref
-        .read(getToWhomResolutionWillBeSharedUsecaseProvider)
-        .call(resolutionId: widget.entity.resolutionId)
-        .then(
-          (result) => result.fold(
-            (failure) => null,
-            (entityList) => entityList,
-          ),
-        );
-
-    if (entityList == null) {
-      sharingTargetGroupModelList = null;
-      return;
-    }
-
-    // sharingTargetGroupModelList = (await Future.wait(
-    //   entityList.map(
-    //     (entity) => ref.read(getGroupListViewCellWidgetModelUsecaseProvider).call(groupEntity: entity).then(
-    //           (result) => result.fold(
-    //             (failure) => null,
-    //             (model) => model,
-    //           ),
-    //         ),
-    //   ),
-    // ))
-    //     .nonNulls
-    //     .toList();
-  }
 }
-
-class ShareTargetGroupListCellWidget extends StatelessWidget {
-  const ShareTargetGroupListCellWidget(
-    this.groupModel, {
-    super.key,
-  });
-
-  final GroupListViewCellWidgetModel groupModel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          groupModel.groupEntity.groupName,
-          style: TextStyle(
-            color: CustomColors.pointColorList[groupModel.groupEntity.groupColor],
-            fontSize: 16.0,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        Row(
-          textBaseline: TextBaseline.alphabetic,
-          crossAxisAlignment: CrossAxisAlignment.baseline,
-          children: [
-            const Text(
-              '멤버 수',
-              style: TextStyle(
-                color: CustomColors.whWhite,
-                fontSize: 12.0,
-                fontWeight: FontWeight.w300,
-                height: 1,
-              ),
-            ),
-            const SizedBox(
-              width: 4,
-            ),
-            Text(
-              groupModel.groupEntity.groupMemberUidList.length.toString(),
-              style: const TextStyle(
-                color: CustomColors.whWhite,
-                fontSize: 16.0,
-                fontWeight: FontWeight.w600,
-                height: 1.0,
-              ),
-            ),
-          ],
-        ),
-        Row(
-          textBaseline: TextBaseline.alphabetic,
-          crossAxisAlignment: CrossAxisAlignment.baseline,
-          children: [
-            const Text(
-              '함께 도전중인 목표 수',
-              style: TextStyle(
-                color: CustomColors.whWhite,
-                fontSize: 12.0,
-                fontWeight: FontWeight.w300,
-                height: 1,
-              ),
-            ),
-            const SizedBox(
-              width: 4,
-            ),
-            FutureBuilder(
-              future: groupModel.sharedResolutionCount,
-              builder: (
-                BuildContext context,
-                AsyncSnapshot<Either<Failure, int>> snapshot,
-              ) {
-                if (snapshot.hasData) {
-                  return snapshot.data!.fold(
-                    (failure) => const Text(
-                      '0',
-                      style: TextStyle(
-                        color: Colors.transparent,
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.w600,
-                        height: 1.0,
-                      ),
-                    ),
-                    (value) => Text(
-                      value.toString(),
-                      style: const TextStyle(
-                        color: CustomColors.whWhite,
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.w600,
-                        height: 1.0,
-                      ),
-                    ),
-                  );
-                } else {
-                  return const Text(
-                    '0',
-                    style: TextStyle(
-                      color: Colors.transparent,
-                      fontSize: 16.0,
-                      fontWeight: FontWeight.w600,
-                      height: 1.0,
-                    ),
-                  );
-                }
-              },
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-}
-
-// class PhotoThumbnailWidget extends StatelessWidget {
-//   const PhotoThumbnailWidget({
-//     super.key,
-//     required this.viewModel,
-//     required this.index,
-//     required this.onRemove,
-//   });
-
-//   final WritingConfirmPostViewModel viewModel;
-//   final int index;
-//   final Function onRemove;
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return Padding(
-//       padding: const EdgeInsets.only(right: 8.0),
-//       child: Stack(
-//         alignment: Alignment.topRight,
-//         children: [
-//           SizedBox(
-//             width: 90,
-//             height: 90,
-//             child: Image.file(
-//               File(viewModel.imageMediaList[index].imageFile.path),
-//               fit: BoxFit.cover,
-//             ),
-//           ),
-//           GestureDetector(
-//             child: const Padding(
-//               padding: EdgeInsets.all(4.0),
-//               child: Icon(
-//                 Icons.cancel,
-//                 size: 20,
-//                 color: CustomColors.whWhite,
-//               ),
-//             ),
-//             onTapUp: (details) {
-//               onRemove();
-//             },
-//           ),
-//         ],
-//       ),
-//     );
-//   }
-// }

--- a/lib/presentation/write_post/view/writing_confirm_post_view_widget.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view_widget.dart
@@ -220,48 +220,48 @@ class ShareTargetGroupListCellWidget extends StatelessWidget {
   }
 }
 
-class PhotoThumbnailWidget extends StatelessWidget {
-  const PhotoThumbnailWidget({
-    super.key,
-    required this.viewModel,
-    required this.index,
-    required this.onRemove,
-  });
+// class PhotoThumbnailWidget extends StatelessWidget {
+//   const PhotoThumbnailWidget({
+//     super.key,
+//     required this.viewModel,
+//     required this.index,
+//     required this.onRemove,
+//   });
 
-  final WritingConfirmPostViewModel viewModel;
-  final int index;
-  final Function onRemove;
+//   final WritingConfirmPostViewModel viewModel;
+//   final int index;
+//   final Function onRemove;
 
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 8.0),
-      child: Stack(
-        alignment: Alignment.topRight,
-        children: [
-          SizedBox(
-            width: 90,
-            height: 90,
-            child: Image.file(
-              File(viewModel.imageMediaList[index].path),
-              fit: BoxFit.cover,
-            ),
-          ),
-          GestureDetector(
-            child: const Padding(
-              padding: EdgeInsets.all(4.0),
-              child: Icon(
-                Icons.cancel,
-                size: 20,
-                color: CustomColors.whWhite,
-              ),
-            ),
-            onTapUp: (details) {
-              onRemove();
-            },
-          ),
-        ],
-      ),
-    );
-  }
-}
+//   @override
+//   Widget build(BuildContext context) {
+//     return Padding(
+//       padding: const EdgeInsets.only(right: 8.0),
+//       child: Stack(
+//         alignment: Alignment.topRight,
+//         children: [
+//           SizedBox(
+//             width: 90,
+//             height: 90,
+//             child: Image.file(
+//               File(viewModel.imageMediaList[index].imageFile.path),
+//               fit: BoxFit.cover,
+//             ),
+//           ),
+//           GestureDetector(
+//             child: const Padding(
+//               padding: EdgeInsets.all(4.0),
+//               child: Icon(
+//                 Icons.cancel,
+//                 size: 20,
+//                 color: CustomColors.whWhite,
+//               ),
+//             ),
+//             onTapUp: (details) {
+//               onRemove();
+//             },
+//           ),
+//         ],
+//       ),
+//     );
+//   }
+// }


### PR DESCRIPTION
# 설명
인증글 작성하기 페이지의 상태를 분리하고, UI를 리디자인으로 개선합니다.

Fixes #
Closes #367 
Resolves #

# 작업 내역
- 인증글 작성하기 메뉴 UI 개선
- 인증글 작성 페이지 UI 및 사진 업로드 로직 개선
- 공유 대상 확인 페이지 UI 및 상태 개선
- 도전 추가하기 UI 변경 및 로직 개선
- 기타 다른 페이지의 동작 이상 개선
  - 목표상세 페이지의 내가 쓴 인증글 목록 제대로 보여주도록 개선
  - 새로고침 시 상태 초기화 로직 추가

## 작업 결과물

|인증글 작성 메뉴|인증글 작성 페이지|공유 대상|도전 추가|
|---|---|---|---|
|![Screenshot_20250214_104219](https://github.com/user-attachments/assets/2ffeec86-eb95-4abb-8949-0eb4563c79fc)|![Screenshot_20250214_104450](https://github.com/user-attachments/assets/1fe235f7-1928-4bd1-be50-80e02f728bfc)|![Screenshot_20250214_104457](https://github.com/user-attachments/assets/ac56e657-45fa-4d84-aa5a-53bf8d5728f4)|![Screenshot_20250214_104726](https://github.com/user-attachments/assets/72d0c3e6-6d8f-4250-938f-1ddc2617843e)|

## 참고 사항(선택)
화이팅!

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
