### PR TITLE
[#377, #380, #383, #384] fix: QA 리포트 1차 반영

### DIFF
--- a/lib/presentation/common_components/weekly_swipe_calendar.dart
+++ b/lib/presentation/common_components/weekly_swipe_calendar.dart
@@ -59,7 +59,7 @@ class _WeeklyPostSwipeCalendarState extends State<WeeklyPostSwipeCalendar> {
           height: isShowingCarousel ? 64 : 0,
           child: WeeklySwipeCalendarCarousel(
             resolutionList: widget.resolutionList,
-            firstDate: widget.firstDate,
+            firstDate: widget.firstDate.parseDateOnly(),
             calendartMondayDateList: calendartMondayDateList,
             onChangeDate: (newDate) {
               setState(() {

--- a/lib/presentation/write_post/view/resolution_list_view_widget.dart
+++ b/lib/presentation/write_post/view/resolution_list_view_widget.dart
@@ -1,4 +1,5 @@
 import 'package:awesome_extensions/awesome_extensions.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
@@ -55,29 +56,31 @@ class ResolutionWritingMenuBottomSheet extends StatelessWidget {
                 buttonTitle: '인증글 작성하기',
                 foregroundColor: CustomColors.whBlack,
                 onPressed: () async {
-                  final bool result = await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) {
-                        return WritingConfirmPostView(
-                          entity: resolutionEntity,
-                          hasRested: false,
-                        );
-                      },
-                    ),
-                  );
-                  if (result == true) {
-                    // ignore: use_build_context_synchronously
-                    Navigator.of(context).pop(true);
-                    ref.invalidate(myWeeklyResolutionSummaryProvider);
-                    ref.invalidate(resolutionListNotifierProvider);
-                    ref.invalidate(weeklyResolutionInfoProvider);
-                    showToastMessage(
-                      // ignore: use_build_context_synchronously
+                  showConfirmPostExistAlert(context, ref, () async {
+                    final bool result = await Navigator.push(
                       context,
-                      text: '성공적으로 인증글을 공유했어요',
+                      MaterialPageRoute(
+                        builder: (context) {
+                          return WritingConfirmPostView(
+                            entity: resolutionEntity,
+                            hasRested: false,
+                          );
+                        },
+                      ),
                     );
-                  }
+                    if (result == true) {
+                      // ignore: use_build_context_synchronously
+                      Navigator.of(context).pop(true);
+                      ref.invalidate(myWeeklyResolutionSummaryProvider);
+                      ref.invalidate(resolutionListNotifierProvider);
+                      ref.invalidate(weeklyResolutionInfoProvider);
+                      showToastMessage(
+                        // ignore: use_build_context_synchronously
+                        context,
+                        text: '성공적으로 인증글을 공유했어요',
+                      );
+                    }
+                  });
                 },
               );
             },
@@ -95,27 +98,29 @@ class ResolutionWritingMenuBottomSheet extends StatelessWidget {
                       buttonTitle: '반성 남기기',
                       foregroundColor: Colors.red,
                       onPressed: () async {
-                        final result = await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) {
-                              return WritingConfirmPostView(
-                                entity: resolutionEntity,
-                                hasRested: true,
-                              );
-                            },
-                          ),
-                        );
-                        if (result == true) {
-                          ref.invalidate(myWeeklyResolutionSummaryProvider);
-                          ref.invalidate(resolutionListNotifierProvider);
-                          ref.invalidate(weeklyResolutionInfoProvider);
-                          showToastMessage(
-                            // ignore: use_build_context_synchronously
+                        showConfirmPostExistAlert(context, ref, () async {
+                          final result = await Navigator.push(
                             context,
-                            text: '성공적으로 반성글을 공유했어요',
+                            MaterialPageRoute(
+                              builder: (context) {
+                                return WritingConfirmPostView(
+                                  entity: resolutionEntity,
+                                  hasRested: true,
+                                );
+                              },
+                            ),
                           );
-                        }
+                          if (result == true) {
+                            ref.invalidate(myWeeklyResolutionSummaryProvider);
+                            ref.invalidate(resolutionListNotifierProvider);
+                            ref.invalidate(weeklyResolutionInfoProvider);
+                            showToastMessage(
+                              // ignore: use_build_context_synchronously
+                              context,
+                              text: '성공적으로 반성글을 공유했어요',
+                            );
+                          }
+                        });
                       },
                     );
                   },
@@ -132,20 +137,22 @@ class ResolutionWritingMenuBottomSheet extends StatelessWidget {
                       return WideOutlinedButton(
                         buttonTitle: '완료 표시만 하기',
                         onPressed: () async {
-                          ref
-                              .read(resolutionListViewModelProvider.notifier)
-                              .uploadPostWithoutContents(
-                                entity: resolutionEntity,
-                              )
-                              .whenComplete(() {
-                            ref.invalidate(myWeeklyResolutionSummaryProvider);
-                            ref.invalidate(resolutionListNotifierProvider);
-                            ref.invalidate(weeklyResolutionInfoProvider);
-                            Navigator.pop(context, true);
-                            showToastMessage(
-                              context,
-                              text: '성공적으로 인증을 남겼어요',
-                            );
+                          showConfirmPostExistAlert(context, ref, () async {
+                            ref
+                                .read(resolutionListViewModelProvider.notifier)
+                                .uploadPostWithoutContents(
+                                  entity: resolutionEntity,
+                                )
+                                .whenComplete(() {
+                              ref.invalidate(myWeeklyResolutionSummaryProvider);
+                              ref.invalidate(resolutionListNotifierProvider);
+                              ref.invalidate(weeklyResolutionInfoProvider);
+                              Navigator.pop(context, true);
+                              showToastMessage(
+                                context,
+                                text: '성공적으로 인증을 남겼어요',
+                              );
+                            });
                           });
                         },
                       );
@@ -169,5 +176,58 @@ class ResolutionWritingMenuBottomSheet extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  Future<void> showConfirmPostExistAlert(
+    BuildContext context,
+    WidgetRef ref,
+    Function callback,
+  ) async {
+    //오늘 이미 작성된 글이 있는지 검사
+    final param = WeeklyResolutionInfoProviderParam(
+      resolutionId: resolutionEntity.resolutionId,
+      startMonday: DateTime.now().getMondayDateTime(),
+    );
+
+    final weeklyDoneList = ref.read(
+      weeklyResolutionInfoProvider(param),
+    );
+
+    if (weeklyDoneList.hasValue && weeklyDoneList.value![DateTime.now().weekday - 1]) {
+      showCupertinoDialog(
+        context: context,
+        builder: (context) {
+          return CupertinoAlertDialog(
+            title: const Text('오늘 이미 인증글을 작성했어요'),
+            content: const Text('작성한 인증글을 덮어쓰시겠어요?'),
+            actions: [
+              CupertinoDialogAction(
+                textStyle: const TextStyle(
+                  color: CustomColors.pointBlue,
+                ),
+                child: const Text('취소'),
+                onPressed: () {
+                  Navigator.pop(context);
+                  return;
+                },
+              ),
+              CupertinoDialogAction(
+                onPressed: () {
+                  Navigator.pop(context);
+                  callback();
+                },
+                isDefaultAction: true,
+                textStyle: const TextStyle(
+                  color: CustomColors.pointBlue,
+                ),
+                child: const Text('작성하기'),
+              ),
+            ],
+          );
+        },
+      );
+    } else {
+      callback();
+    }
   }
 }

--- a/lib/presentation/write_post/view/resolution_list_view_widget.dart
+++ b/lib/presentation/write_post/view/resolution_list_view_widget.dart
@@ -5,6 +5,7 @@ import 'package:wehavit/common/common.dart';
 import 'package:wehavit/dependency/presentation/viewmodel_dependency.dart';
 import 'package:wehavit/domain/entities/entities.dart';
 import 'package:wehavit/presentation/common_components/common_components.dart';
+import 'package:wehavit/presentation/state/resolution_list/resolution_list_provider.dart';
 import 'package:wehavit/presentation/write_post/write_post.dart';
 
 class ResolutionWritingMenuBottomSheet extends StatelessWidget {
@@ -68,7 +69,9 @@ class ResolutionWritingMenuBottomSheet extends StatelessWidget {
                   if (result == true) {
                     // ignore: use_build_context_synchronously
                     Navigator.of(context).pop(true);
-
+                    ref.invalidate(myWeeklyResolutionSummaryProvider);
+                    ref.invalidate(resolutionListNotifierProvider);
+                    ref.invalidate(weeklyResolutionInfoProvider);
                     showToastMessage(
                       // ignore: use_build_context_synchronously
                       context,
@@ -104,6 +107,9 @@ class ResolutionWritingMenuBottomSheet extends StatelessWidget {
                           ),
                         );
                         if (result == true) {
+                          ref.invalidate(myWeeklyResolutionSummaryProvider);
+                          ref.invalidate(resolutionListNotifierProvider);
+                          ref.invalidate(weeklyResolutionInfoProvider);
                           showToastMessage(
                             // ignore: use_build_context_synchronously
                             context,
@@ -132,6 +138,9 @@ class ResolutionWritingMenuBottomSheet extends StatelessWidget {
                                 entity: resolutionEntity,
                               )
                               .whenComplete(() {
+                            ref.invalidate(myWeeklyResolutionSummaryProvider);
+                            ref.invalidate(resolutionListNotifierProvider);
+                            ref.invalidate(weeklyResolutionInfoProvider);
                             Navigator.pop(context, true);
                             showToastMessage(
                               context,

--- a/lib/presentation/write_post/view/writing_confirm_post_view.dart
+++ b/lib/presentation/write_post/view/writing_confirm_post_view.dart
@@ -53,149 +53,152 @@ class _WritingConfirmPostViewState extends ConsumerState<WritingConfirmPostView>
               showShareTargetBottomSheet(context);
             },
           ),
-          body: Column(
-            children: [
-              Expanded(
-                child: SafeArea(
-                  minimum: const EdgeInsets.only(
-                    left: 16.0,
-                    right: 16.0,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            DateFormat('yyyy년 M월 d일').format(
-                              viewModel.todayDate.subtract(
-                                Duration(days: viewModel.isWritingYesterdayPost ? 1 : 0),
+          body: SafeArea(
+            child: Column(
+              children: [
+                Expanded(
+                  child: SafeArea(
+                    minimum: const EdgeInsets.only(
+                      left: 16.0,
+                      right: 16.0,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              DateFormat('yyyy년 M월 d일').format(
+                                viewModel.todayDate.subtract(
+                                  Duration(days: viewModel.isWritingYesterdayPost ? 1 : 0),
+                                ),
                               ),
+                              style: context.labelLarge,
                             ),
-                            style: context.labelLarge,
-                          ),
-                          TextButton.icon(
-                            onPressed: () {
-                              provider.toggleYesterdayOption();
-                            },
-                            icon: Icon(
-                              size: 20,
-                              viewModel.isWritingYesterdayPost ? Icons.check_box : Icons.check_box_outline_blank,
-                              color:
-                                  viewModel.isWritingYesterdayPost ? CustomColors.whYellow500 : CustomColors.whGrey900,
-                            ),
-                            label: Text(
-                              '전날 기록하기',
-                              style: context.labelLarge?.copyWith(
+                            TextButton.icon(
+                              onPressed: () {
+                                provider.toggleYesterdayOption();
+                              },
+                              icon: Icon(
+                                size: 20,
+                                viewModel.isWritingYesterdayPost ? Icons.check_box : Icons.check_box_outline_blank,
                                 color: viewModel.isWritingYesterdayPost
                                     ? CustomColors.whYellow500
                                     : CustomColors.whGrey900,
                               ),
+                              label: Text(
+                                '전날 기록하기',
+                                style: context.labelLarge?.copyWith(
+                                  color: viewModel.isWritingYesterdayPost
+                                      ? CustomColors.whYellow500
+                                      : CustomColors.whGrey900,
+                                ),
+                              ),
+                              style: TextButton.styleFrom(
+                                padding: const EdgeInsets.all(0),
+                                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                                alignment: Alignment.centerLeft,
+                              ),
                             ),
-                            style: TextButton.styleFrom(
-                              padding: const EdgeInsets.all(0),
-                              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                              alignment: Alignment.centerLeft,
-                            ),
-                          ),
-                        ],
-                      ),
-                      Text(
-                        widget.entity.goalStatement,
-                        style: context.titleSmall?.copyWith(
-                          color: CustomColors.pointColorList[widget.entity.colorIndex],
+                          ],
                         ),
-                      ),
-                      Text(
-                        widget.entity.actionStatement,
-                        style: context.bodyMedium,
-                      ),
-                      Expanded(
-                        child: TextFormField(
-                          focusNode: contentFieldFocusNode,
-                          maxLines: null,
+                        Text(
+                          widget.entity.goalStatement,
+                          style: context.titleSmall?.copyWith(
+                            color: CustomColors.pointColorList[widget.entity.colorIndex],
+                          ),
+                        ),
+                        Text(
+                          widget.entity.actionStatement,
                           style: context.bodyMedium,
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            hintText: '오늘의 발자국을 남겨주세요',
-                            hintStyle: context.bodyMedium?.copyWith(color: CustomColors.whGrey600),
-                          ),
-                          onChanged: (value) {
-                            viewModel.postContent = value;
-                          },
                         ),
-                      ),
-                      Visibility(
-                        visible: viewModel.imageMediaList.isNotEmpty,
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 4.0),
-                          child: Row(
-                            children: List<Widget>.generate(
-                              viewModel.imageMediaList.length,
-                              (index) => Padding(
-                                padding: const EdgeInsets.only(right: 8.0),
-                                child: UploadPhotoCell(
-                                  imageFile: File(viewModel.imageMediaList[index].imageFile.path),
-                                  state: viewModel.imageMediaList[index].status,
-                                  onCancel: () {
-                                    provider.cancelPhotoUpload(viewModel.imageMediaList[index]);
-                                  },
-                                  onRetry: () async {
-                                    provider.reuploadPhoto(viewModel.imageMediaList[index]);
-                                  },
+                        Expanded(
+                          child: TextFormField(
+                            focusNode: contentFieldFocusNode,
+                            maxLines: null,
+                            style: context.bodyMedium,
+                            decoration: InputDecoration(
+                              border: InputBorder.none,
+                              hintText: '오늘의 발자국을 남겨주세요',
+                              hintStyle: context.bodyMedium?.copyWith(color: CustomColors.whGrey600),
+                            ),
+                            onChanged: (value) {
+                              viewModel.postContent = value;
+                            },
+                          ),
+                        ),
+                        Visibility(
+                          visible: viewModel.imageMediaList.isNotEmpty,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 4.0),
+                            child: Row(
+                              children: List<Widget>.generate(
+                                viewModel.imageMediaList.length,
+                                (index) => Padding(
+                                  padding: const EdgeInsets.only(right: 8.0),
+                                  child: UploadPhotoCell(
+                                    imageFile: File(viewModel.imageMediaList[index].imageFile.path),
+                                    state: viewModel.imageMediaList[index].status,
+                                    onCancel: () {
+                                      provider.cancelPhotoUpload(viewModel.imageMediaList[index]);
+                                    },
+                                    onRetry: () async {
+                                      provider.reuploadPhoto(viewModel.imageMediaList[index]);
+                                    },
+                                  ),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              UploadPhotoBottomToolbar(
-                type: widget.hasRested ? UploadPhotoBottomToolbarType.regret : UploadPhotoBottomToolbarType.upload,
-                onIconPressed: () async {
-                  if (!widget.hasRested) {
-                    FocusScope.of(context).unfocus();
-                    provider.pickPhotos().whenComplete(
-                          () => setState(() {
-                            Future.delayed(
-                              const Duration(
-                                milliseconds: 100,
-                              ),
-                              () => contentFieldFocusNode.requestFocus(),
-                            );
-                          }),
-                        );
-                  }
-                },
-                onActionPressed: () async {
-                  // 넘길 수 있는지 확인
-                  if (!ref
-                      .read(writingConfirmPostViewModelProvider(widget.entity))
-                      .imageMediaList
-                      .every((entity) => entity.status == ImageUploadStatus.success)) {
-                    showToastMessage(context, text: '아직 업로드 중이거나 업로드에 실패한 사진이 있어요');
-                    return;
-                  }
-
-                  final myUserEntity = await ref.read(myUserDataProvider.future);
-
-                  await provider
-                      .uploadPost(
-                    hasRested: widget.hasRested,
-                    myUserEntity: myUserEntity,
-                  )
-                      .whenComplete(() {
-                    if (context.mounted) {
-                      Navigator.of(context).pop(true);
+                UploadPhotoBottomToolbar(
+                  type: widget.hasRested ? UploadPhotoBottomToolbarType.regret : UploadPhotoBottomToolbarType.upload,
+                  onIconPressed: () async {
+                    if (!widget.hasRested) {
+                      FocusScope.of(context).unfocus();
+                      provider.pickPhotos().whenComplete(
+                            () => setState(() {
+                              Future.delayed(
+                                const Duration(
+                                  milliseconds: 100,
+                                ),
+                                () => contentFieldFocusNode.requestFocus(),
+                              );
+                            }),
+                          );
                     }
-                  });
-                },
-              ),
-            ],
+                  },
+                  onActionPressed: () async {
+                    // 넘길 수 있는지 확인
+                    if (!ref
+                        .read(writingConfirmPostViewModelProvider(widget.entity))
+                        .imageMediaList
+                        .every((entity) => entity.status == ImageUploadStatus.success)) {
+                      showToastMessage(context, text: '아직 업로드 중이거나 업로드에 실패한 사진이 있어요');
+                      return;
+                    }
+
+                    final myUserEntity = await ref.read(myUserDataProvider.future);
+
+                    await provider
+                        .uploadPost(
+                      hasRested: widget.hasRested,
+                      myUserEntity: myUserEntity,
+                    )
+                        .whenComplete(() {
+                      if (context.mounted) {
+                        Navigator.of(context).pop(true);
+                      }
+                    });
+                  },
+                ),
+              ],
+            ),
           ),
         ),
       ],


### PR DESCRIPTION
# 설명
QA 에서 발견된 버그를 수정합니다.

Fixes #
Closes #377, #380, #383, #384
Resolves #

# 작업 내역
- 인증글 업로드 후에도 이번 주 인증글 현황이 업데이트되지 않는 문제 → 업로드 시 State invalidate 코드를 추가하여 해결
- 인증 남기기 iOS 화면에서 아래쪽 레이아웃이 SafeArea 적용되지 않았던 문제 해결
- 인증글 재작성 시 이미 작성된 글이 있다는 다이얼로그 추가
- 가로 스크롤 캘린더의 초기 날짜가 시간을 포함한 경우 (00:00:00이 아닌 경우) 해당 날짜를 미포함하는 문제 해결

## 작업 결과물
|다이얼로그 추가|레이아웃 수정|
|---|---|
|![Simulator Screenshot - iPhone 15 Pro - 2025-03-07 at 15 46 49](https://github.com/user-attachments/assets/d3692c14-af78-4613-aa97-969591caba51)|![Simulator Screenshot - iPhone 15 Pro - 2025-03-07 at 15 46 56](https://github.com/user-attachments/assets/a4857c9e-d868-4bee-ae0d-ff45a0c76589)|


## 참고 사항(선택)
작업을 진행하면서 참고한 사항이나 참고할 사항이 있다면 적어주세요.


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
