### PR TITLE
[#382] fix: 알림 전송 Usecase에서 나에게 알림 전송하지 않도록 수정

### DIFF
--- a/lib/domain/usecases/send_notification_to_shared_users_usecase.dart
+++ b/lib/domain/usecases/send_notification_to_shared_users_usecase.dart
@@ -35,6 +35,11 @@ class SendNotificationToSharedUsersUsecase {
 
     await Future.forEach(groupEntityList, (GroupEntity groupEntity) async {
       await Future.forEach(groupEntity.groupMemberUidList, (String uid) async {
+        // 스스로에게는 메시지를 보내지 않는다.
+        if (myUserEntity.userId == uid) {
+          return;
+        }
+
         final token = await _userModelRepository.getUserFCMMessageToken(uid: uid).then(
               (result) => result.fold(
                 (failure) => null,

--- a/lib/domain/usecases/send_notification_to_target_user_usecase.dart
+++ b/lib/domain/usecases/send_notification_to_target_user_usecase.dart
@@ -31,8 +31,11 @@ class SendNotificationToTargetUserUsecase {
       );
     }
 
-    if (myUserEntity.userId == targetUserEntity.userId)
-      List<String> sharingUserTokenList = [targetUserEntity.messageToken];
+    // 스스로에게는 메시지를 보내지 않는다.
+    if (myUserEntity.userId == targetUserEntity.userId) {
+      return left(const Failure('나에게는 메시지를 보낼 수 없어요'));
+    }
+    List<String> sharingUserTokenList = [targetUserEntity.messageToken];
 
     await _notificationRepository.sendNotification(
       title: messageTitleTemplate,

--- a/lib/domain/usecases/send_notification_to_target_user_usecase.dart
+++ b/lib/domain/usecases/send_notification_to_target_user_usecase.dart
@@ -31,7 +31,8 @@ class SendNotificationToTargetUserUsecase {
       );
     }
 
-    List<String> sharingUserTokenList = [targetUserEntity.messageToken];
+    if (myUserEntity.userId == targetUserEntity.userId)
+      List<String> sharingUserTokenList = [targetUserEntity.messageToken];
 
     await _notificationRepository.sendNotification(
       title: messageTitleTemplate,


### PR DESCRIPTION
# 설명
알림 로직에서 나를 타겟으로 알림을 전송하지 않도록 수정합니다. 

Fixes #
Closes #382 
Resolves #

# 작업 내역
- 리액션에 대한 알림 전송 Usecase 내에 타겟 필터링 추가
- 게시글에 대한 알림 전송 Usecase 내에 타겟 필터링 추가

## 작업 결과물
내가 포함된 그룹에 글을 작성하거나 나에게 스스로 리액션을 전송하더라도 내 게시글에 대한 알림을 받지 않습니다.


# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
