### PR TITLE
[#379] fix: 로그아웃, 친구 삭제, 퀵샷 삭제 수행 전 Dialog를 띄우기

### DIFF
--- a/lib/presentation/common_components/confirm_post_list_cell.dart
+++ b/lib/presentation/common_components/confirm_post_list_cell.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
@@ -520,25 +521,28 @@ class QuickshotPresetPalette extends StatelessWidget {
                     onQuickshotPresetPressed(filePath);
                   },
                   onLongPress: () async {
-                    showDialog(
+                    showCupertinoDialog(
                       context: context,
                       builder: (context) {
                         return Consumer(
-                          builder: (context, ref, child) {
-                            return AlertDialog(
-                              content: Text(
-                                '저장된 퀵샷을 지우시겠어요?',
-                                style: context.bodyMedium?.copyWith(color: CustomColors.whGrey100),
-                              ),
-                              actions: <Widget>[
-                                ElevatedButton(
+                          builder: (context, ref, _) {
+                            return CupertinoAlertDialog(
+                              title: const Text('저장된 퀵샷을 삭제하시겠어요?'),
+                              content: const Text('삭제된 퀵샷은 복구하지 못해요.'),
+                              actions: [
+                                CupertinoDialogAction(
+                                  textStyle: const TextStyle(
+                                    color: CustomColors.pointBlue,
+                                  ),
+                                  isDefaultAction: true,
+                                  child: const Text('취소'),
                                   onPressed: () {
-                                    Navigator.of(context).pop(); //창 닫기
+                                    Navigator.pop(context);
                                   },
-                                  child: const Text('아니요'),
                                 ),
-                                ElevatedButton(
-                                  onPressed: () {
+                                CupertinoDialogAction(
+                                  isDestructiveAction: true,
+                                  onPressed: () async {
                                     ref
                                         .read(removeQuickshotPresetUsecaseProvider)
                                         .call(quickshotEntity: entity)
@@ -548,7 +552,7 @@ class QuickshotPresetPalette extends StatelessWidget {
                                       if (context.mounted) Navigator.of(context).pop(); //창 닫기
                                     });
                                   },
-                                  child: const Text('네'),
+                                  child: const Text('삭제'),
                                 ),
                               ],
                             );

--- a/lib/presentation/common_components/my_profile_block.dart
+++ b/lib/presentation/common_components/my_profile_block.dart
@@ -1,4 +1,3 @@
-import 'package:awesome_extensions/awesome_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wehavit/common/common.dart';
@@ -35,6 +34,7 @@ class MyProfileBlock extends StatelessWidget {
                 return Row(
                   children: [
                     Expanded(child: UserProfileCell(myUserData.userId, type: UserProfileCellType.profile)),
+                    // TODO: 딥링크 통해 앱 공유 링크 생성 시 추가하기
                     // Column(
                     //   children: [
                     //     Image.asset(CustomIconImage.linkIcon, width: 20, height: 20),

--- a/lib/presentation/common_components/my_profile_block.dart
+++ b/lib/presentation/common_components/my_profile_block.dart
@@ -35,13 +35,13 @@ class MyProfileBlock extends StatelessWidget {
                 return Row(
                   children: [
                     Expanded(child: UserProfileCell(myUserData.userId, type: UserProfileCellType.profile)),
-                    Column(
-                      children: [
-                        Image.asset(CustomIconImage.linkIcon, width: 20, height: 20),
-                        const SizedBox(height: 4),
-                        Text('초대하기', style: context.labelMedium),
-                      ],
-                    ),
+                    // Column(
+                    //   children: [
+                    //     Image.asset(CustomIconImage.linkIcon, width: 20, height: 20),
+                    //     const SizedBox(height: 4),
+                    //     Text('초대하기', style: context.labelMedium),
+                    //   ],
+                    // ),
                   ],
                 );
               },

--- a/lib/presentation/friend_list/view/friend_list_view.dart
+++ b/lib/presentation/friend_list/view/friend_list_view.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:awesome_extensions/awesome_extensions.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
@@ -283,7 +284,40 @@ class FrinedListViewState extends ConsumerState<FriendListView> {
                         friendUidList[index],
                         type: isManagingMode ? UserProfileCellType.deleteMode : UserProfileCellType.normal,
                         onDelete: () async {
-                          ref.read(friendListViewModelProvider.notifier).removeFriend(targetUid: friendUidList[index]);
+                          showCupertinoDialog(
+                            context: context,
+                            builder: (context) {
+                              return CupertinoAlertDialog(
+                                title: const Text('정말 친구를 삭제하시겠어요?'),
+                                actions: [
+                                  CupertinoDialogAction(
+                                    textStyle: const TextStyle(
+                                      color: CustomColors.pointBlue,
+                                    ),
+                                    isDefaultAction: true,
+                                    child: const Text('취소'),
+                                    onPressed: () {
+                                      Navigator.pop(context);
+                                    },
+                                  ),
+                                  CupertinoDialogAction(
+                                    isDestructiveAction: true,
+                                    onPressed: () async {
+                                      await ref
+                                          .read(friendListViewModelProvider.notifier)
+                                          .removeFriend(targetUid: friendUidList[index])
+                                          .whenComplete(() {
+                                        if (mounted) {
+                                          Navigator.pop(context);
+                                        }
+                                      });
+                                    },
+                                    child: const Text('친구 삭제'),
+                                  ),
+                                ],
+                              );
+                            },
+                          );
                         },
                       ),
                     );

--- a/lib/presentation/my_page/view/my_page_view.dart
+++ b/lib/presentation/my_page/view/my_page_view.dart
@@ -202,13 +202,40 @@ class MyPageScreenState extends ConsumerState<MyPageView> with AutomaticKeepAliv
                 buttonTitle: '로그아웃',
                 iconString: WHIcons.logout,
                 onPressed: () async {
-                  await ref.read(logOutUseCaseProvider).call();
-                  ref.invalidate(getMyUserDataUsecaseProvider);
-                  if (mounted) {
-                    // ignore: use_build_context_synchronously
-                    Navigator.pushNamedAndRemoveUntil(context, '/', (_) => false);
-                    Navigator.pushNamed(context, '/entrance');
-                  }
+                  showCupertinoDialog(
+                    context: context,
+                    builder: (context) {
+                      return CupertinoAlertDialog(
+                        title: const Text('정말 로그아웃하시겠어요?'),
+                        actions: [
+                          CupertinoDialogAction(
+                            textStyle: const TextStyle(
+                              color: CustomColors.pointBlue,
+                            ),
+                            isDefaultAction: true,
+                            child: const Text('취소'),
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                          ),
+                          CupertinoDialogAction(
+                            isDestructiveAction: true,
+                            onPressed: () async {
+                              await ref.read(logOutUseCaseProvider).call();
+                              ref.invalidate(getMyUserDataUsecaseProvider);
+                              if (mounted) {
+                                // ignore: use_build_context_synchronously
+                                Navigator.pushNamedAndRemoveUntil(context, '/', (_) => false);
+                                // ignore: use_build_context_synchronously
+                                Navigator.pushNamed(context, '/entrance');
+                              }
+                            },
+                            child: const Text('로그아웃'),
+                          ),
+                        ],
+                      );
+                    },
+                  );
                 },
               ),
               const SizedBox(


### PR DESCRIPTION
# 설명
로그아웃, 친구 삭제, 퀵샷 삭제 로직과 같은 Destructive 액션의 로직을 수행하기 앞서, Dialog UI를 띄워 사용자에게 확인을 받도록 개선하였습니다.

Fixes #
Closes #379 
Resolves #

# 작업 내역
- 로그아웃 시 다이얼로그 띄우기
- 친구 삭제 시 다이얼로그 띄우기
- 퀵샷 삭제 시 다이얼로그 띄우기

## 작업 결과물
|로그아웃|친구삭제|퀵샷삭제|
|---|---|---|
|![Simulator Screenshot - iPhone 15 Pro - 2025-03-20 at 20 28 14](https://github.com/user-attachments/assets/a9b3b988-6c2c-495c-8340-7b6a66fb2a8d)|![Simulator Screenshot - iPhone 15 Pro - 2025-03-20 at 20 28 09](https://github.com/user-attachments/assets/8f8f4149-c326-4a90-8a06-e0340a5a8c10)|![Simulator Screenshot - iPhone 15 Pro - 2025-03-20 at 20 28 01](https://github.com/user-attachments/assets/a62ca0a9-4c6c-42c9-b4f9-f8675bbd44a9)|

## 참고 사항(선택)
Flutter의 기본 Dialog (Material Design) 의 느낌이 플랫한 디자인과 어울리지 않아, 
우선 쿠퍼티노 Dialog로 UI 디자인을 통일하여 적용하였음.
이후에 안드로이드 쪽에서 디자인이 어색하다면 Dialog 컴포넌트 분리 및 분기처리하여 개선해주기

# 체크 리스트
- [x] 이해하기 어려운 부분은 주석을 달았습니다.
- [x] 내 코드는 Lint를 통과했고 경고(warning)가 없습니다.
- [x] 내 코드에 불필요한 print 등이 없습니다.
